### PR TITLE
- Reverted usage of grepl instead of isCharInString

### DIFF
--- a/R/DataMapping.R
+++ b/R/DataMapping.R
@@ -86,7 +86,7 @@ DataMapping <- R6::R6Class(
           }))
           # If logarithmic scaling of the y axis is selected, the minimal value should be greater than zero
           yMin <- min(sapply(self$xySeries, function(x) {
-            if (grepl("y", self$log)) {
+            if (isCharInString("y", self$log)) {
               toUnit(
                 quantityOrDimension = self$yDimension,
                 values = x$yMinPositive(),

--- a/R/utilities-data-mapping.R
+++ b/R/utilities-data-mapping.R
@@ -195,7 +195,7 @@ plotTimeValues <- function(dataMapping, aggregated, ...) {
 
   # If logarithmic scaling of y-axis has been selected and manually provided y-lim
   # is non-positive, use the automatically calculated values
-  if (grepl("y", dataMapping$log) && !all(dataMapping$yLim > 0)) {
+  if (isCharInString("y", dataMapping$log) && !all(dataMapping$yLim > 0)) {
     dataMapping$yLim <- NULL
   }
 
@@ -409,7 +409,7 @@ plotPredictedVsObserved <- function(dataMapping, foldDistance = 2, timeDiffThres
 
   # If logarithmic scaling of y-axis has been selected and manually provided y-lim
   # is non-positive, use the automatically calculated values
-  if (grepl("y", dataMapping$log) && !all(dataMapping$yLim > 0)) {
+  if (isCharInString("y", dataMapping$log) && !all(dataMapping$yLim > 0)) {
     dataMapping$yLim <- NULL
   }
 
@@ -419,7 +419,7 @@ plotPredictedVsObserved <- function(dataMapping, foldDistance = 2, timeDiffThres
     ylim = dataMapping$yLim + abs(dataMapping$yLim) * c(-0.1, 0.1),
     xlab = "Observed values",
     ylab = "Simulated values",
-    log = if (grepl("y", dataMapping$log)) {
+    log = if (isCharInString("y", dataMapping$log)) {
       "xy"
     } else {
       ""

--- a/R/utilities-data.R
+++ b/R/utilities-data.R
@@ -72,8 +72,9 @@ readOSPSTimeValues <- function(dataConfiguration) {
       timeValues$setMetaData(name = "Molecule", value = group$Molecule[[1]])
 
       # If a molecule is specified, retrieve its molecular weight
-      if (!is.null(timeValues$getAllMetaData()$Molecule)) {
-        compoundProperties <- openxlsx::read.xlsx(xlsxFile = file.path(dataConfiguration$dataFolder, dataConfiguration$compoundPropertiesFile), sheet = timeValues$getAllMetaData()$Molecule)
+      moleculeName <- timeValues$getAllMetaData()$Molecule
+      if (!is.null(moleculeName) && !is.na(moleculeName)) {
+        compoundProperties <- openxlsx::read.xlsx(xlsxFile = file.path(dataConfiguration$dataFolder, dataConfiguration$compoundPropertiesFile), sheet = moleculeName)
         mwIdx <- which(compoundProperties$`Parameter,.[AdditionalParameter]` == "MW")
         mw <- compoundProperties$`Value.[1,1]`[[mwIdx]]
         unit <- compoundProperties$`Unit.[1,1]`[[mwIdx]]

--- a/R/utilities-figures.R
+++ b/R/utilities-figures.R
@@ -272,7 +272,7 @@ closeOutputDevice <- function(plotConfiguration) {
 #'
 #' @keywords internal
 .isPoint <- function(type) {
-  grepl("p", type) || (type == "b")
+  isCharInString("p", type) || (type == "b")
 }
 
 #' Does the plot type contain line?
@@ -283,5 +283,5 @@ closeOutputDevice <- function(plotConfiguration) {
 #'
 #' @keywords internal
 .isLine <- function(type) {
-  grepl("l", type) || (type == "b")
+  isCharInString("l", type) || (type == "b")
 }

--- a/R/utilities-steady-state.R
+++ b/R/utilities-steady-state.R
@@ -66,7 +66,7 @@ getSteadyState <- function(quantitiesPaths = NULL,
   }
 
   # Run simulations concurrently
-  simulationResults <- ospsuite::runSimulationsConcurrently(simulations = simulations)
+  simulationResults <- ospsuite::runSimulations(simulations = simulations)
   # Container task is required for checking the "isFormula" property
   task <- ospsuite:::getContainerTask()
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -168,3 +168,17 @@ compareWithNA <- function(v1, v2) {
   same[is.na(same)] <- FALSE
   return(same)
 }
+
+#' Is a character part of string?
+#'
+#' @param char Character to find in the string
+#' @param string String that should contain the character
+#'
+#' @return TRUE if the \code{character} is a substring if \code{string}, FALSE otherwise
+#' @export
+#'
+#' @examples
+#' isCharInString("a", "bsdalk")
+isCharInString <- function(char, string) {
+  any(unlist(strsplit(string, ""), use.names = FALSE) == char)
+}


### PR DESCRIPTION
- Check for molecule name being NA in addition to NULL when reading molecular weight in readOSPSTimeValues
- Using runSimulations instead of (missing) runSimulationsConcurrently