### PR TITLE
Installation routines now install ParameterIdentification build from a private Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,7 +62,7 @@ build_script:
   - Rscript -e "install.packages(c('covr', 'clipr', 'shinytest2', 'vdiffr', 'withr'), repos = 'http://cran.us.r-project.org')"
   - Rscript -e "install.packages('https://ci.appveyor.com/api/projects/open-systems-pharmacology-ci/ospsuite-rutils/artifacts/ospsuite.utils.zip', repos = NULL, type = 'binary')"
   - Rscript -e "install.packages('https://ci.appveyor.com/api/projects/open-systems-pharmacology-ci/tlf-library/artifacts/tlf.zip', repos = NULL, type = 'binary')"
-  - Rscript -e "install.packages('https://ci.appveyor.com/api/projects/open-systems-pharmacology-ci/ospsuite-parameteridentification/artifacts/ospsuite.parameteridentification.zip', repos = NULL, type = 'binary')"
+  - Rscript -e "install.packages('https://ci.appveyor.com/api/projects/StephanSchaller/esqlabs-parameteridentification/artifacts/ospsuite.parameteridentification.zip', repos = NULL, type = 'binary', headers = c('Authorization' = 'Bearer v2.4n7xybvbbboj2ye9fmk5'))"
 
 test_script:
   - travis-tool.sh run_tests

--- a/inst/extdata/install-packages.R
+++ b/inst/extdata/install-packages.R
@@ -7,7 +7,7 @@
 .releaseHttpsHeaders <- list(ospsuite.utils = c(),
                              tlf = c(),
                              ospsuite = c(),
-                             ospsuite.parameteridentification = c("Authorization" = "Bearer v2.4n7xybvbbboj2ye9fmk5"),
+                             ospsuite.parameteridentification = c(),
                              esqlabsR = c())
 
 # Message strings used in the setup script
@@ -33,7 +33,7 @@ packageInstallationMessages <- list(
 .developPaths <- list(ospsuite.utils = "https://ci.appveyor.com/api/projects/open-systems-pharmacology-ci/ospsuite-rutils/artifacts/ospsuite.utils.zip",
                       tlf = "https://ci.appveyor.com/api/projects/open-systems-pharmacology-ci/tlf-library/artifacts/tlf.zip",
                       ospsuite = "https://ci.appveyor.com/api/projects/open-systems-pharmacology-ci/ospsuite-r/artifacts/ospsuite.zip",
-                      ospsuite.parameteridentification = "https://ci.appveyor.com/api/projects/open-systems-pharmacology-ci/ospsuite-parameteridentification/artifacts/ospsuite.parameteridentification.zip",
+                      ospsuite.parameteridentification = "https://ci.appveyor.com/api/projects/StephanSchaller/esqlabs-parameteridentification/artifacts/ospsuite.parameteridentification.zip",
                       esqlabsR = "https://ci.appveyor.com/api/projects/StephanSchaller/esqlabsr/artifacts/esqlabsR.zip")
 
 #' Test if installed packages can be loaded

--- a/inst/extdata/install-packages.R
+++ b/inst/extdata/install-packages.R
@@ -1,3 +1,15 @@
+# Tokens for accessing developer versions
+.developHttpsHeaders <- list(ospsuite.utils = c(),
+                             tlf = c(),
+                             ospsuite = c(),
+                             ospsuite.parameteridentification = c("Authorization" = "Bearer v2.4n7xybvbbboj2ye9fmk5"),
+                             esqlabsR = c())
+.releaseHttpsHeaders <- list(ospsuite.utils = c(),
+                             tlf = c(),
+                             ospsuite = c(),
+                             ospsuite.parameteridentification = c("Authorization" = "Bearer v2.4n7xybvbbboj2ye9fmk5"),
+                             esqlabsR = c())
+
 # Message strings used in the setup script
 packageInstallationMessages <- list(
   installRTools = "Install Rtools compatible with your R version, then run updateEnvironment() again.)",
@@ -55,6 +67,8 @@ cleanEnvironment <- function(){
   rm(packageInstallationMessages,
      .releasePaths,
      .developPaths,
+     .releaseHttpsHeaders,
+     .developHttpsHeaders,
      .cranPackages,
      testInstalledPackages,
      testPKSIMConnection,
@@ -156,20 +170,22 @@ installOSPPackages <- function(rclrVersion = "0.9.2",
   }
 
   packagePaths <- .releasePaths
+  httpsHeaders <- .releaseHttpsHeaders
   if (developerVersion) {
     packagePaths <- .developPaths
+    httpsHeaders <- .developHttpsHeaders
   }
 
   displayProgress("Installing ospsuite.utils", suppressOutput = suppressOutput)
-  install.packages(packagePaths$ospsuite.utils, repos = NULL, lib = lib)
+  install.packages(packagePaths$ospsuite.utils, repos = NULL, lib = lib, headers = httpsHeaders$ospsuite.utils)
   displayProgress("Installing tlf", suppressOutput = suppressOutput)
-  install.packages(packagePaths$tlf, repos = NULL, lib = lib)
+  install.packages(packagePaths$tlf, repos = NULL, lib = lib, headers = httpsHeaders$tlf)
   displayProgress("Installing ospsuite", suppressOutput = suppressOutput)
-  install.packages(packagePaths$ospsuite, repos = NULL, lib = lib)
+  install.packages(packagePaths$ospsuite, repos = NULL, lib = lib, headers = httpsHeaders$ospsuite)
   displayProgress("Installing ospsuite.PI", suppressOutput = suppressOutput)
-  install.packages(packagePaths$ospsuite.parameteridentification, repos = NULL, lib = lib)
+  install.packages(packagePaths$ospsuite.parameteridentification, repos = NULL, lib = lib, headers = httpsHeaders$ospsuite.parameteridentification)
   displayProgress("Installing esqlabsR", suppressOutput = suppressOutput)
-  install.packages(packagePaths$esqlabsR, repos = NULL, lib = lib)
+  install.packages(packagePaths$esqlabsR, repos = NULL, lib = lib, headers = httpsHeaders$esqlabsR)
 }
 
 #' Install osps packages and their dependencies into project library.


### PR DESCRIPTION
The code in `inst/extdata/install-packages.R` and `appveyor.yml` now sends HTTP requests with headers to the private Appveyor build of esqlabs.ParameterIdentification. This code might need a change in paths as soon as the artifact name changes in Appveyor (it's now still called `ospsuite.parameteridentification`). 

The tokens are available in plaintext, but we have discussed that this is acceptable, since Appveyor only gives binary package files.

I cannot reinitiate an Appveyor build to test these changes in `appveyor.yml`, but we can see how it goes after the merge.