### PR TITLE
use `scan` instead of `strsplit` to split only values that are not wi…

### DIFF
--- a/R/utilities-figures.R
+++ b/R/utilities-figures.R
@@ -391,8 +391,9 @@ createPlotsFromExcel <- function(plotGridNames = NULL, simulatedScenarios, obser
       }
       # For fields that require multiple values (e.g., axis limits require the
       # upper and the lower limit value), values are separated by a ','.
-      # Split the input string first
-      value <- unlist(strsplit(as.character(value), split = ","))
+      # Alternatively, the values can be enclosed in "" in case the title should contain a ','.
+      # Split the input string by ',' but do not split within ""
+      value <- unlist(scan(text = as.character(value), what = "character", sep = ","))
 
       # Expected type of the field to cast the value to the
       # correct type. For fields that do not have a default value (NULL), we have

--- a/R/utilities-figures.R
+++ b/R/utilities-figures.R
@@ -393,7 +393,10 @@ createPlotsFromExcel <- function(plotGridNames = NULL, simulatedScenarios, obser
       # upper and the lower limit value), values are separated by a ','.
       # Alternatively, the values can be enclosed in "" in case the title should contain a ','.
       # Split the input string by ',' but do not split within ""
-      value <- unlist(scan(text = as.character(value), what = "character", sep = ","))
+      value <- unlist(trimws(scan(
+        text = as.character(value), what = "character", sep = ",",
+        quiet = TRUE
+      )))
 
       # Expected type of the field to cast the value to the
       # correct type. For fields that do not have a default value (NULL), we have


### PR DESCRIPTION
…thin '""'

This way, it is possible to define e.g. a title with a comma: "This is, comma".
Fixes #412