### PR TITLE
use testhat::test_path() instead of working directory

### DIFF
--- a/tests/testthat/helper-for-tests.R
+++ b/tests/testthat/helper-for-tests.R
@@ -1,6 +1,5 @@
-getTestDataFilePath <- function(fileName) {
-  dataPath <- file.path(getwd(), "..", "data", fsep = .Platform$file.sep)
-  file.path(dataPath, fileName, fsep = .Platform$file.sep)
+getTestDataFilePath <- function(fileName = "") {
+  testthat::test_path("../data", fileName)
 }
 
 getSimulationFilePath <- function(simulationName) {


### PR DESCRIPTION
No need to change wd to run tests manually now