### PR TITLE
Fix Main build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,6 @@ environment:
   R_ARCH: x64
   KEEP_VIGNETTES: 'true'
   NOT_CRAN: 'true'
-  app_version: 5.0.0.9000
-version: $(app_version)
 before_build: rake "prepare_for_build[%APPVEYOR_BUILD_VERSION%]"
 cache: C:\RLibrary
 platform: x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,60 +1,55 @@
-# DO NOT CHANGE the "init" and "install" sections below
-
-# Download script file from GitHub
+image: Visual Studio 2019
 init:
-  ps: |
-        $ErrorActionPreference = "Stop"
-        Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
-        Import-Module '..\appveyor-tool.ps1'
-
+- ps: |
+    $ErrorActionPreference = "Stop"
+    Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
+    Import-Module '..\appveyor-tool.ps1'
 install:
-  ps: Bootstrap
-
-cache:
-  - C:\RLibrary
-
+- ps: Bootstrap
+- git submodule update --init --recursive
 environment:
-  # env vars that may need to be set, at least temporarily, from time to time
-  # see https://github.com/krlmlr/r-appveyor#readme for details
-  R_VERSION: 4.2.0
-  R_arch: x64
   USE_RTOOLS: 'true'
+  R_VERSION: 4.2.0
+  R_ARCH: x64
+  KEEP_VIGNETTES: 'true'
   NOT_CRAN: 'true'
-
-
-# Adapt as necessary starting from here
 before_build: rake "prepare_for_build[%APPVEYOR_BUILD_VERSION%]"
-
-build_script:
-  - travis-tool.sh install_deps
-
+cache: C:\RLibrary
+platform: x64
+skip_commits:
+  files: '*.md'
+skip_branch_with_pr: 'true'
+skip_tags: 'true'
+branches:
+  only:
+  - main
+  - develop
+pull_requests:
+  do_not_increment_build_number: 'true'
 before_test:
-  - cinst pandoc
-  - ps: $env:Path += ";C:\Program Files (x86)\Pandoc\"
-  - pandoc -v
-
-test_script:
-  - travis-tool.sh run_tests
-
+- cinst pandoc
+- ps: $env:Path += ";C:\Program Files (x86)\Pandoc\"
+- pandoc -v
+build_script:
+- travis-tool.sh install_deps
+- Rscript install_ext_deps.R
+test_script: travis-tool.sh run_tests
+on_success: Rscript -e "covr::codecov()"
+after_test:
+- ps: copy esqlabsR_*.zip esqlabsR.zip
 on_failure:
-  - 7z a failure.zip *.Rcheck\*
-  - appveyor PushArtifact failure.zip
-
+- 7z a failure.zip *.Rcheck\*
+- appveyor PushArtifact failure.zip
 artifacts:
-  - path: '*.Rcheck\**\*.log'
-    name: Logs
-
-  - path: '*.Rcheck\**\*.out'
-    name: Logs
-
-  - path: '*.Rcheck\**\*.fail'
-    name: Logs
-
-  - path: '*.Rcheck\**\*.Rout'
-    name: Logs
-
-  - path: '\*_*.tar.gz'
-    name: Bits
-
-  - path: '\*_*.zip'
-    name: Bits
+- path: '*.Rcheck\**\*.log'
+  name: Logs
+- path: '*.Rcheck\**\*.out'
+  name: Logs
+- path: '*.Rcheck\**\*.fail'
+  name: Logs
+- path: '*.Rcheck\**\*.Rout'
+  name: Logs
+- path: \*_*.tar.gz
+  name: Bits
+- path: esqlabsR*.zip
+  name: Bits

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,8 @@ environment:
   R_ARCH: x64
   KEEP_VIGNETTES: 'true'
   NOT_CRAN: 'true'
+  app_version: 5.0.0.9000
+version: $(app_version)
 before_build: rake "prepare_for_build[%APPVEYOR_BUILD_VERSION%]"
 cache: C:\RLibrary
 platform: x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,55 +1,60 @@
-image: Visual Studio 2019
+# DO NOT CHANGE the "init" and "install" sections below
+
+# Download script file from GitHub
 init:
-- ps: |
-    $ErrorActionPreference = "Stop"
-    Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
-    Import-Module '..\appveyor-tool.ps1'
+  ps: |
+        $ErrorActionPreference = "Stop"
+        Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
+        Import-Module '..\appveyor-tool.ps1'
+
 install:
-- ps: Bootstrap
-- git submodule update --init --recursive
+  ps: Bootstrap
+
+cache:
+  - C:\RLibrary
+
 environment:
-  USE_RTOOLS: 'true'
+  # env vars that may need to be set, at least temporarily, from time to time
+  # see https://github.com/krlmlr/r-appveyor#readme for details
   R_VERSION: 4.2.0
-  R_ARCH: x64
-  KEEP_VIGNETTES: 'true'
+  R_arch: x64
+  USE_RTOOLS: 'true'
   NOT_CRAN: 'true'
+
+
+# Adapt as necessary starting from here
 before_build: rake "prepare_for_build[%APPVEYOR_BUILD_VERSION%]"
-cache: C:\RLibrary
-platform: x64
-skip_commits:
-  files: '*.md'
-skip_branch_with_pr: 'true'
-skip_tags: 'true'
-branches:
-  only:
-  - main
-  - develop
-pull_requests:
-  do_not_increment_build_number: 'true'
-before_test:
-- cinst pandoc
-- ps: $env:Path += ";C:\Program Files (x86)\Pandoc\"
-- pandoc -v
+
 build_script:
-- travis-tool.sh install_deps
-- Rscript install_ext_deps.R
-test_script: travis-tool.sh run_tests
-on_success: Rscript -e "covr::codecov()"
-after_test:
-- ps: copy esqlabsR_*.zip esqlabsR.zip
+  - travis-tool.sh install_deps
+
+before_test:
+  - cinst pandoc
+  - ps: $env:Path += ";C:\Program Files (x86)\Pandoc\"
+  - pandoc -v
+
+test_script:
+  - travis-tool.sh run_tests
+
 on_failure:
-- 7z a failure.zip *.Rcheck\*
-- appveyor PushArtifact failure.zip
+  - 7z a failure.zip *.Rcheck\*
+  - appveyor PushArtifact failure.zip
+
 artifacts:
-- path: '*.Rcheck\**\*.log'
-  name: Logs
-- path: '*.Rcheck\**\*.out'
-  name: Logs
-- path: '*.Rcheck\**\*.fail'
-  name: Logs
-- path: '*.Rcheck\**\*.Rout'
-  name: Logs
-- path: \*_*.tar.gz
-  name: Bits
-- path: esqlabsR*.zip
-  name: Bits
+  - path: '*.Rcheck\**\*.log'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.out'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.fail'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.Rout'
+    name: Logs
+
+  - path: '\*_*.tar.gz'
+    name: Bits
+
+  - path: '\*_*.zip'
+    name: Bits

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ environment:
   KEEP_VIGNETTES: 'true'
   NOT_CRAN: 'true'
   app_version: 5.0.0.9000
-version: $(app_version)
+version: $(app_version)-{build}
 before_build: rake "prepare_for_build[%APPVEYOR_BUILD_VERSION%]"
 cache: C:\RLibrary
 platform: x64

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -10,7 +10,6 @@ OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE
 APPVEYOR_ACCOUNT_NAME = 'open-systems-pharmacology-ci'
 
 task :prepare_for_build, [:build_version] do |t, args|
-  update_package_version(args.build_version, description_file)
   install_pksim('develop')
 end
 

--- a/tests/testthat/_snaps/scenario-configuration.md
+++ b/tests/testthat/_snaps/scenario-configuration.md
@@ -12,14 +12,14 @@
       mySC$print(projectConfiguration = FALSE)
     Output
       ScenarioConfiguration: 
-         Model file name: 
-         Scenario name: 
+         Model file name: NULL 
+         Scenario name: NULL 
          Parameters sheets: mySheet1 mySheet2 
-         Individual Id: 
-         Population Id: 
+         Individual Id: NULL 
+         Population Id: NULL 
          Read population from csv file: FALSE 
-         Application protocol: 
-         Simulation time intervals: 
+         Application protocol: NULL 
+         Simulation time intervals: NULL 
            Interval: 1 
              Start: 0 
              End: 10 


### PR DESCRIPTION
The Appveyor's {version} variable was set to only the package version (e.g 5.0.0.9000) without build id because this was used somewhere in the process to overwrite the `DESCRIPTION` file.

Using the same `{version}` value led to duplicated build id which is not accepted by Appveyor.

Since version number is now automatically managed by the release script, I removed the part of the ruby code that overwrites the DESCRIPTION file and restored `{version}` to `[package version]-[build number]`