### PR TITLE
No warnings for `strToNum()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,10 @@ the function `plotPopulationTimeProfile()`. Supported values are listed in `osps
 warning is shown with the name of the failed scenario. The returned `outputValues` 
 is `NULL`.
 
+### MINOR CHANGES
+- `stringToNum()` does not show a warning `NAs introduced by coercion` when a value 
+cannot be converted to a numeric any more. For such values, `NA` is silently returned.
+
 ### BUG FIXES
 - exportParametersToXLS - ignore parameters with NaN https://github.com/esqLABS/esqlabsR/issues/480
 - Show a meaningful error when no time unit is specified for a scenario https://github.com/esqLABS/esqlabsR/issues/483

--- a/R/utilities-data.R
+++ b/R/utilities-data.R
@@ -24,7 +24,7 @@ stringToNum <- function(string, lloqMode = LLOQMode$`LLOQ/2`, uloqMode = ULOQMod
   # Remove all whitespaces
   string <- gsub(" ", "", string, fixed = TRUE)
   # Attempt to convert all passed values to numeric
-  numVals <- as.numeric(string)
+  numVals <- suppressWarnings(as.numeric(string))
 
   # If any values could not be interpreted and were coerced to NA, decide what to do (e.g. LLOQ and ULOQ treatment)
   naVals <- is.na(numVals)
@@ -37,7 +37,7 @@ stringToNum <- function(string, lloqMode = LLOQMode$`LLOQ/2`, uloqMode = ULOQMod
       # CHECK FOR LLOQ
       if (substring(string[[idx]], first = 1, last = 1) == "<") {
         # Transform the value that follow the "<" character
-        value <- as.numeric(substring(string[[idx]], first = 2))
+        value <- suppressWarnings(as.numeric(substring(string[[idx]], first = 2)))
         # If value is NA (could not convert to numeric), continue, as the output
         # should be NA
         if (is.na(value)) {
@@ -58,7 +58,7 @@ stringToNum <- function(string, lloqMode = LLOQMode$`LLOQ/2`, uloqMode = ULOQMod
       # CHECK FOR ULOQ
       if (substring(string[[idx]], first = 1, last = 1) == ">") {
         # Transform the value that follow the "<" character
-        value <- as.numeric(substring(string[[idx]], first = 2))
+        value <- suppressWarnings(as.numeric(substring(string[[idx]], first = 2)))
         # If value is NA (could not convert to numeric), continue, as the output
         # should be NA
         if (is.na(value)) {


### PR DESCRIPTION
- `stringToNum()` does not show a warning `NAs introduced by coercion…` when a value
cannot be converted to a numeric any more.