### PR TITLE
Update pkgdown.yaml

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -110,4 +110,4 @@ jobs:
         with:
           clean: false
           branch: gh-pages
-          folder: docs
+          folder: pkgdown


### PR DESCRIPTION
fixes https://github.com/esqLABS/esqlabsR/actions/runs/6785325756/job/18443740020

deployment action looked for `docs/` folder while everything is stored in `pkgdown/` folder:

![image](https://github.com/esqLABS/esqlabsR/assets/34234913/a3aaab70-657a-4e8e-b3e1-5ee78da024eb)

