### PR TITLE
Set and validate plot configuration

### DIFF
--- a/R/sensitivity-spider-plot.R
+++ b/R/sensitivity-spider-plot.R
@@ -193,7 +193,7 @@ sensitivitySpiderPlot <- function(sensitivityCalculation,
   )
 
   # print plots without producing warnings
-  suppressWarnings(purrr::map(lsPlots, ~ print(.x)))
+  suppressWarnings(purrr::walk(lsPlots, ~ print(.x)))
 }
 
 #' @keywords internal
@@ -369,7 +369,7 @@ sensitivitySpiderPlot <- function(sensitivityCalculation,
   plotPatchwork <- patchwork::wrap_plots(plotList) +
     patchwork::plot_annotation(
       title = plotConfiguration$title,
-      subtitle = defaultPlotConfiguration$subtitle,
+      subtitle = plotConfiguration$subtitle,
       theme = theme(
         plot.title = element_text(size = plotConfiguration$titleSize)
       )

--- a/R/sensitivity-spider-plot.R
+++ b/R/sensitivity-spider-plot.R
@@ -383,18 +383,23 @@ sensitivitySpiderPlot <- function(sensitivityCalculation,
   defaultValues <- createEsqlabsPlotConfiguration()
 
   for (name in names(plotOverrideConfig)) {
-    if (name %in% names(plotConfiguration)) {
-      if (is.null(defaultValues[[name]]) ||
-        all(plotConfiguration[[name]] == defaultValues[[name]])) {
+    if (!name %in% names(plotConfiguration)) {
+      warning(messages$UnknownPlotConfiguration(name))
+      next
+    }
+
+    if (is.null(defaultValues[[name]]) && is.null(plotConfiguration[[name]])) {
+      plotConfiguration[[name]] <- plotOverrideConfig[[name]]
+    } else if (!is.null(defaultValues[[name]]) && !is.null(plotConfiguration[[name]])) {
+      if (all(plotConfiguration[[name]] == defaultValues[[name]])) {
         plotConfiguration[[name]] <- plotOverrideConfig[[name]]
       }
-    } else {
-      warning(messages$UnknownPlotConfiguration(name))
     }
   }
 
   return(plotConfiguration)
 }
+
 
 #' @keywords internal
 #' @noRd

--- a/R/sensitivity-spider-plot.R
+++ b/R/sensitivity-spider-plot.R
@@ -35,9 +35,9 @@
 #' will have its own range, which allows for better visualization of the single
 #' PK parameters sensitivity.
 #' @param defaultPlotConfiguration An object of class `DefaultPlotConfiguration`
-#' used to customize plot aesthetics. Modifications in `defaultPlotConfiguration`,
-#' such as `xAxisScale`, will take precedence over any plot-specific settings
-#' provided directly to the function.
+#' used to customize plot aesthetics. Plot-specific settings provided directly
+#' to the function, such as `xAxisScale`, will take precedence over any
+#' modifications in `defaultPlotConfiguration`.
 #'
 #' Supported parameters include:
 #' - `legendPosition`: Position of the legend on the plot.
@@ -208,8 +208,7 @@ sensitivitySpiderPlot <- function(sensitivityCalculation,
     plotConfiguration,
     list(title = unique(data$OutputPath))
   )
-  print(plotConfiguration$xAxisScale)
-  print(plotConfiguration$yAxisScale)
+
   # select percent or absolute column for y-axis
   if (yAxisType == "percent") {
     yColumn <- sym("PercentChangePK")

--- a/R/utilities-figures.R
+++ b/R/utilities-figures.R
@@ -621,3 +621,84 @@ createPlotsFromExcel <- function(
 
   return(dfExportConfigurations)
 }
+
+#' Get valid plot configuration options
+#'
+#' Generates a list of valid configuration options for plotting.
+#' Each configuration option specifies constraints, including data type,
+#' allowable values, and value ranges, formatted to facilitate validation with
+#' `ospsuite::validateIsOption` function.
+#'
+#' @return A list of lists, each containing type specifications and constraints
+#'         for a plot configuration parameter.
+#' @keywords internal
+#' @noRd
+.getPlotConfigurationOptions <- function() {
+  plotConfigurationOptions <- list(
+    legendPosition = list(
+      type = "character",
+      allowedValues = c("left", "right", "bottom", "top", "none")
+    ),
+    legendTitle = list(
+      type = "character",
+      nullAllowed = TRUE
+    ),
+    linesAlpha = list(
+      type = "numeric",
+      valueRange = c(0, 1)
+    ),
+    linesSize = list(
+      type = "numeric",
+      valueRange = c(0.1, 10)
+    ),
+    pointsShape = list(
+      type = "integer",
+      valueRange = c(0L, 25L)
+    ),
+    pointsSize = list(
+      type = "numeric",
+      valueRange = c(0.1, 10)
+    ),
+    subtitle = list(
+      type = "character",
+      nullAllowed = TRUE
+    ),
+    title = list(
+      type = "character",
+      nullAllowed = TRUE
+    ),
+    titleSize = list(
+      type = "numeric"
+    ),
+    xAxisScale = list(
+      type = "character",
+      allowedValues = c("log", "lin")
+    ),
+    xLabel = list(
+      type = "character",
+      nullAllowed = TRUE
+    ),
+    yAxisFacetScales = list(
+      type = "character",
+      allowedValues = c("fixed", "free")
+    ),
+    yAxisScale = list(
+      type = "character",
+      allowedValues = c("log", "lin")
+    ),
+    yAxisTicks = list(
+      type = "integer",
+      valueRange = c(1L, 20L)
+    ),
+    yAxisType = list(
+      type = "character",
+      allowedValues = c("percent", "absolute")
+    ),
+    yLabel = list(
+      type = "character",
+      nullAllowed = TRUE
+    )
+  )
+
+  return(plotConfigurationOptions)
+}

--- a/man/sensitivitySpiderPlot.Rd
+++ b/man/sensitivitySpiderPlot.Rd
@@ -9,10 +9,10 @@ sensitivitySpiderPlot(
   outputPaths = NULL,
   parameterPaths = NULL,
   pkParameters = NULL,
-  yAxisType = "percent",
-  xAxisScale = "log",
-  yAxisScale = "lin",
+  xAxisScale = NULL,
+  yAxisScale = NULL,
   yAxisFacetScales = "fixed",
+  yAxisType = "percent",
   defaultPlotConfiguration = NULL
 )
 }
@@ -29,9 +29,6 @@ A separate plot will be generated for each output path. Each plot will
 contain a spider plot panel for each PK parameter, and the sensitivities
 for each parameter will be displayed as lines.}
 
-\item{yAxisType}{Character string, either "percent" (percentage change) or
-"absolute" (absolute values) for PK parameter values, for y-axis data normalization. Default is "percent".}
-
 \item{xAxisScale}{Character string, either "log" (logarithmic scale) or "lin"
 (linear scale), to set the x-axis scale. Default is "log".}
 
@@ -41,14 +38,18 @@ similarly to \code{xAxisScale}. Default is "lin".}
 \item{yAxisFacetScales}{Character string, either "fixed" or "free", determines
 the scaling across y-axes of different facets. Default is "fixed".
 If "fixed", all facetes within one plot will have the same range, which allows
-for easier comparison between different PK parameters. If "free", each facet will
-have its own range, which allows for better visualization of the single PK parameters
-sensitivity.}
+for easier comparison between different PK parameters. If "free", each facet
+will have its own range, which allows for better visualization of the single
+PK parameters sensitivity.}
+
+\item{yAxisType}{Character string, either "percent" (percentage change) or
+"absolute" (absolute values) for PK parameter values, for y-axis data normalization.
+Default is "percent".}
 
 \item{defaultPlotConfiguration}{An object of class \code{DefaultPlotConfiguration}
-used to customize plot aesthetics. Modifications in \code{defaultPlotConfiguration},
-such as \code{xAxisScale}, will take precedence over any plot-specific settings
-provided directly to the function.
+used to customize plot aesthetics. Plot-specific settings provided directly
+to the function, such as \code{xAxisScale}, will take precedence over any
+modifications in \code{defaultPlotConfiguration}.
 
 Supported parameters include:
 \itemize{

--- a/man/sensitivityTimeProfiles.Rd
+++ b/man/sensitivityTimeProfiles.Rd
@@ -28,27 +28,7 @@ sensitivity will be analyzed.}
 \item{parameterPaths}{A single or a vector of the parameter path(s) to be
 varied.}
 
-\item{xAxisLog, yAxisLog}{Logical that decides whether to display the axis on
-logarithmic scale.}
-
 \item{palette}{The name of the palette to be used. Run \code{hcl_palettes(type = "qualitative")} for available options.}
-
-\item{savePlots}{Logical that decides whether you wish to save created
-plot(s). They are not saved by default. Note that if there are multiple
-output paths in your model, there will be multiple plots that will be
-saved.}
-
-\item{outputFolder}{A character string describing path folder where plots
-need to be saved. The path must be relative to the current working
-directory. By default (\code{""}), the plots will be saved in the current
-working directory (which can be found using \code{getwd()} function). This
-parameter is relevant only if \code{savePlots} is set to \code{TRUE}.}
-
-\item{width, height}{Plot size in inches. If not supplied, uses the size of
-current graphics device.}
-
-\item{dpi}{Plot resolution. Also accepts a string input: "retina" (320),
-"print" (300), or "screen" (72). Applies only to raster output types.}
 }
 \value{
 A single \code{ggplot} object if a single output path is specified.

--- a/tests/testthat/test-sensitivity-spider-plot.R
+++ b/tests/testthat/test-sensitivity-spider-plot.R
@@ -93,6 +93,38 @@ test_that("sensitivitySpiderPlot correctly applies free scaling with absolute y-
   expect_snapshot(unlist(plotParams))
 })
 
+
+# plot configuration -----------------------------------------
+
+n <- "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)"
+
+test_that("sensitivitySpiderPlot uses defaultPlotConfiguration axis scales", {
+  myPlotConfiguration <- createEsqlabsPlotConfiguration()
+  myPlotConfiguration$xAxisScale <- "lin"
+  myPlotConfiguration$yAxisScale <- "log"
+
+  p <- sensitivitySpiderPlot(results, defaultPlotConfiguration = myPlotConfiguration)
+  pb <- ggplot2::ggplot_build(p[[n]][[1]])
+
+  expect_equal(pb$layout$panel_scales_x[[1]]$trans$name, "identity")
+  expect_equal(pb$layout$panel_scales_y[[1]]$trans$name, "log-10")
+})
+
+test_that("sensitivitySpiderPlot signature overrides defaultPlotConfiguration", {
+  myPlotConfiguration <- createEsqlabsPlotConfiguration()
+  myPlotConfiguration$xAxisScale <- "lin" # to be overridden
+  myPlotConfiguration$yAxisScale <- "log" # to be overridden
+
+  p <- sensitivitySpiderPlot(results,
+    defaultPlotConfiguration = myPlotConfiguration,
+    xAxisScale = "log", yAxisScale = "lin"
+  )
+  pb <- ggplot2::ggplot_build(p[[n]][[1]])
+
+  expect_equal(pb$layout$panel_scales_x[[1]]$trans$name, "log-10")
+  expect_equal(pb$layout$panel_scales_y[[1]]$trans$name, "identity")
+})
+
 # multiple output paths -------------------------------------
 
 simPath <- system.file("extdata", "Aciclovir.pkml", package = "ospsuite")


### PR DESCRIPTION
- Fix `.updatePlotConfiguration` function to ensure that settings from `defaultPlotConfiguration` are correctly applied and that parameters passed directly through the function signature take precedence (#642 #643 ). 
-  introduces validation of plot configuration settings against a predefined list of valid options to prevent configuration errors 