### PR TITLE
support a ^ b equations type

### DIFF
--- a/inst/FunctionVisualizer/R/extract_variables.R
+++ b/inst/FunctionVisualizer/R/extract_variables.R
@@ -11,16 +11,20 @@
 #' @return A character vector of variable names extracted from the equation.
 #'
 #' @examples
-#' extract_variable_names("a * (b + 5) / c - sqrt(d)")
+#' .extractVariableNames("a * (b + 5) / c - sqrt(d)")
 #' # Returns: "a" "b" "c" "d"
 #'
-#' extract_variable_names("x^2 + y - log(z)", c("exp", "log", "sin", "cos", "tan", "sqrt", "floor", "ceiling", "pi"))
+#' .extractVariableNames("x^2 + y - log(z)", c("exp", "log", "sin", "cos", "tan", "sqrt", "floor", "ceiling", "pi"))
 #' # Returns: "x" "y" "z"
-extract_variable_names <- function(equation,
-                                   mathexpressions = c("exp", "log", "sin", "cos", "tan", "sqrt", "floor", "ceiling", "pi")) {
+#' @keywords internal
+#' @noRd
+.extractVariableNames <- function(equation,
+                                  mathexpressions = c("exp", "log", "sin", "cos", "tan", "sqrt", "floor", "ceiling", "pi"),
+                                  operatorTokenRegex = "[-+*/^(){}]|(%%)|(%/%)"
+                                  ) {
   # Check input types
-  if (!is.character(equation) || !is.character(mathexpressions)) {
-    stop("Both 'equation' and 'mathexpressions' must be character vectors.")
+  if (!is.character(equation) || !is.character(mathexpressions) || !is.character(operatorTokenRegex)) {
+    stop("Both 'equation', 'mathexpressions' and 'operatorTokenRegex' must be character vectors.")
   }
 
   # Remove all blanks from the equation
@@ -29,8 +33,9 @@ extract_variable_names <- function(equation,
   # Split the equation string at arithmetic operators and parentheses
   split_eq <- unlist(strsplit(
     cleaned_eq,
-    "[-+*/^(){}]|(%%)|(%/%)"
+    operatorTokenRegex
   ))
+
 
   # Remove numeric values and predefined mathematical expressions to get variable names
   varnames <- setdiff(
@@ -40,10 +45,3 @@ extract_variable_names <- function(equation,
 
   return(varnames)
 }
-
-##' Tests
-# print(extract_variable_names("a * (b + 5) / c - sqrt(d)"))
-# # Expected output: "a" "b" "c" "d"
-#
-# print(extract_variable_names("x^2 + y - log(z)", c("exp", "log", "sin", "cos", "tan", "sqrt", "floor", "ceiling", "pi")))
-# # Expected output: "x" "y" "z"

--- a/inst/FunctionVisualizer/app.R
+++ b/inst/FunctionVisualizer/app.R
@@ -62,7 +62,7 @@ server <- function(input, output, session) {
     update = TRUE, varnames = NULL, equation = NULL,
     mins = NULL, maxs = NULL, current = NULL, x = NULL,
     y = NULL, snapshots = NULL, points_x = NULL, points_y = NULL,
-    observedData = data.frame()
+    observedData = data.frame(), operator_token_regex = "[-+*/^(){}]|(%%)|(%/%)"
   )
 
   observeEvent(input$updatevars, {
@@ -93,7 +93,11 @@ server <- function(input, output, session) {
 
     isolate({
       v$equation <- input$equation
-      v$varnames <- extract_variable_names(input$equation, mathexpressions)
+      v$varnames <- .extractVariableNames(
+                      equation = input$equation,
+                      mathexpressions = mathexpressions,
+                      operatorTokenRegex = v$operator_token_regex
+                    )
 
       # export variable names for testing
       exportTestValues(
@@ -182,7 +186,7 @@ server <- function(input, output, session) {
 
     x_values <- seq(x_min, x_max, stepsize)
     # insert space before and after arithmetic operators in equation string
-    eq <- paste0(gsub("([-+*/()^{}]|(%%)|(%/%))", " \\1 ", v$equation), " ")
+    eq <- paste0(gsub(paste0("(", v$operator_token_regex ,")"), " \\1 ", v$equation), " ")
 
     colname <<- ""
 

--- a/inst/FunctionVisualizer/tests/testthat.R
+++ b/inst/FunctionVisualizer/tests/testthat.R
@@ -1,1 +1,2 @@
 shinytest2::test_app()
+

--- a/inst/FunctionVisualizer/tests/testthat/test_extract_variable_names.R
+++ b/inst/FunctionVisualizer/tests/testthat/test_extract_variable_names.R
@@ -1,21 +1,42 @@
-library(shinytest2)
-library(testthat)
-
-# Load the Shiny app
-app <- AppDriver$new(
-  variant = platform_variant(),
-  name = "FunctionVisualizer",
-  height = 619,
-  width = 979
-)
-
-test_that("Variable names extraction works correctly", {
-  app$set_inputs(equation = "Vmax * C / (Km + C)")
-  expect_equal(
-    app$get_value(export = "varnames"),
-    c("Vmax", "C", "Km")
-  )
+test_that("extractVariableNames correctly identifies variables in a simple equation", {
+  equation <- "a * (b + 5) / c - sqrt(d)"
+  expected_output <- c("a", "b", "c", "d")
+  result <- .extractVariableNames(equation)
+  expect_equal(result, expected_output)
 })
 
-# Stop the Shiny app after tests
-app$stop()
+test_that("extractVariableNames handles mathematical expressions correctly", {
+  equation <- "x^2 + y - log(z)"
+  mathexpressions <- c("exp", "log", "sin", "cos", "tan", "sqrt", "floor", "ceiling", "pi")
+  expected_output <- c("x", "y", "z")
+  result <- .extractVariableNames(equation, mathexpressions)
+  expect_equal(result, expected_output)
+})
+
+test_that("extractVariableNames excludes predefined mathematical expressions", {
+  equation <- "exp(x) + sin(y) - cos(z)"
+  mathexpressions <- c("exp", "log", "sin", "cos", "tan", "sqrt", "floor", "ceiling", "pi")
+  expected_output <- c("x", "y", "z")
+  result <- .extractVariableNames(equation, mathexpressions)
+  expect_equal(result, expected_output)
+})
+
+test_that("extractVariableNames handles equations without variables", {
+  equation <- "2 + 3 * 4 - sqrt(16)"
+  expected_output <- character(0)
+  result <- .extractVariableNames(equation)
+  expect_equal(result, expected_output)
+})
+
+test_that("extractVariableNames handles custom operatorTokenRegex", {
+  equation <- "a %% b + c %/% d"
+  operatorTokenRegex <- "[-+*/^(){}]|(%%)|(%/%)"
+  expected_output <- c("a", "b", "c", "d")
+  result <- .extractVariableNames(equation, operatorTokenRegex = operatorTokenRegex)
+  expect_equal(result, expected_output)
+})
+
+test_that("extractVariableNames throws an error with incorrect input types", {
+  expect_error(.extractVariableNames(123), "Both 'equation', 'mathexpressions' and 'operatorTokenRegex' must be character vectors.")
+  expect_error(.extractVariableNames("a + b", mathexpressions = 123), "Both 'equation', 'mathexpressions' and 'operatorTokenRegex' must be character vectors.")
+})


### PR DESCRIPTION
Adding support for equations type `a ^ b` in the `esqlabsR::startFunctionVisualizer()`

Closes #697 