### PR TITLE
Save the results last

### DIFF
--- a/R/utilities-scenarios.R
+++ b/R/utilities-scenarios.R
@@ -204,8 +204,6 @@ saveScenarioResults <- function(
         if (!dir.exists(paths = outputFolder)) {
           dir.create(path = outputFolder, recursive = TRUE)
         }
-        # Save results
-        ospsuite::exportResultsToCSV(results = results, filePath = outputPath)
         # Save simulations
         if (saveSimulationsToPKML) {
           outputPathSim <- file.path(outputFolder, paste0(scenarioName, ".pkml"))
@@ -220,6 +218,8 @@ saveScenarioResults <- function(
             filePath = file.path(outputFolder, paste0(scenarioName, "_population.csv"))
           )
         }
+        # Save results
+        ospsuite::exportResultsToCSV(results = results, filePath = outputPath)
       },
       error = function(cond) {
         warning(paste0("Cannot save to path '", outputFolder, "'"))


### PR DESCRIPTION
If the simulation fails, the results are `NULL` and the try-catch-block fails. By trying to save the results last, at least the simulation can be saved to pkml and the user can debug in MoBi what it is failing.