### PR TITLE
778-figure-export-destination

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: esqlabsR
 Title: esqLABS utilities package
-Version: 5.3.0.9007
+Version: 5.3.0.9009
 Authors@R: c(
     person("esqLABS GmbH", role = c("cph", "fnd")),
     person("Pavel", "Balazki", , "pavel.balazki@esqlabs.com", role = c("cre", "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 - Fix warnings related to NSE evaluation (\#762)
 
+- Figures defined for the export in the `exportConfiguration` sheet of the `Plots.xlsx` 
+file are now exported to the subfolder `Figures\<Current Time Stamp>` of the `Results` folder
+ defined in the `ProjectConfiguration` (\#778).
+
 # esqlabsR 5.3.0
 
 ## Breaking changes

--- a/R/utilities-figures.R
+++ b/R/utilities-figures.R
@@ -449,7 +449,12 @@ createPlotsFromExcel <- function(
   dfExportConfigurations <- .validateExportConfigurationsFromExcel(dfExportConfigurations, plotGrids)
   if (nrow(dfExportConfigurations) > 0) {
     # create a list of ExportConfiguration objects from dfExportConfigurations
-    outputFolder <- outputFolder %||% projectConfiguration$outputFolder
+    outputFolder <- outputFolder %||% file.path(
+      projectConfiguration$outputFolder,
+      "Figures",
+      format(Sys.time(), "%F %H-%M")
+    )
+
     defaultExportConfiguration <- createEsqlabsExportConfiguration(outputFolder)
     exportConfigurations <- apply(dfExportConfigurations, 1, \(row){
       exportConfiguration <- .createConfigurationFromRow(

--- a/tests/testthat/test-create-plots-from-excel.R
+++ b/tests/testthat/test-create-plots-from-excel.R
@@ -74,6 +74,12 @@ plotGridsDf <- data.frame(list(
 
 exportConfigurationDf <- data.frame(list("plotGridName" = character(0), "outputName" = character(0)))
 
+# Helper function to get the most recently created/modified directory
+.getLatestDirectory <- function(baseDir) {
+  allDirs <- list.dirs(baseDir, full.names = TRUE, recursive = FALSE)
+  allDirs[which.max(file.info(allDirs)$mtime)]
+}
+
 # Validation DataCombined
 test_that("It trows an error if mandatory field dataType is not filled out", {
   tempDir <- tempdir()
@@ -724,11 +730,10 @@ test_that("It exports plot grids as defined in sheet `exportConfiguration`", {
         projectConfiguration = projectConfigurationLocal,
         stopIfNotFound = TRUE
       )
-      # Get the name of the created folder (if successfull)
-      # Using tail in case there are multiple folders, so we just need the latest one
-      subFolderName <- tail(list.files(file.path(tempDir, "Figures")), n = 1)
-      expect_true(file.exists(file.path(tempDir, "Figures", subFolderName, "Aciclovir1.png")))
-      expect_true(file.exists(file.path(tempDir, "Figures", subFolderName, "Aciclovir2.png")))
+      # Get the most recently created/modified folder in the Figures directory
+      latestDir <- .getLatestDirectory(file.path(tempDir, "Figures"))
+      expect_true(file.exists(file.path(latestDir, "Aciclovir1.png")))
+      expect_true(file.exists(file.path(latestDir, "Aciclovir2.png")))
     }
   )
 })
@@ -765,8 +770,10 @@ test_that("It exports plot grids with specified output folder", {
         stopIfNotFound = TRUE,
         outputFolder = tempDir
       )
-      expect_true(file.exists(file.path(tempDir, "Aciclovir1.png")))
-      expect_true(file.exists(file.path(tempDir, "Aciclovir2.png")))
+      # Get the most recently created/modified folder in the Figures directory
+      latestDir <- .getLatestDirectory(file.path(tempDir, "Figures"))
+      expect_true(file.exists(file.path(latestDir, "Aciclovir1.png")))
+      expect_true(file.exists(file.path(latestDir, "Aciclovir2.png")))
     }
   )
 })
@@ -838,8 +845,13 @@ test_that("It correctly treats names with underscores", {
         projectConfiguration = projectConfigurationLocal,
         stopIfNotFound = TRUE
       )
-      expect_true(file.exists(file.path(tempDir, "Aciclovir1.png")))
-      expect_true(file.exists(file.path(tempDir, "Aciclovir2.png")))
+      
+      # Get the most recently created/modified folder in the Figures directory
+      figuresPath <- file.path(tempDir, "Figures")
+      latestDir <- .getLatestDirectory(figuresPath)
+      
+      expect_true(file.exists(file.path(latestDir, "Aciclovir1.png")))
+      expect_true(file.exists(file.path(latestDir, "Aciclovir2.png")))
     }
   )
 })

--- a/tests/testthat/test-create-plots-from-excel.R
+++ b/tests/testthat/test-create-plots-from-excel.R
@@ -724,6 +724,47 @@ test_that("It exports plot grids as defined in sheet `exportConfiguration`", {
         projectConfiguration = projectConfigurationLocal,
         stopIfNotFound = TRUE
       )
+      # Get the name of the created folder (if successfull)
+      # Using tail in case there are multiple folders, so we just need the latest one
+      subFolderName <- tail(list.files(file.path(tempDir, "Figures")), n = 1)
+      expect_true(file.exists(file.path(tempDir, "Figures", subFolderName, "Aciclovir1.png")))
+      expect_true(file.exists(file.path(tempDir, "Figures", subFolderName, "Aciclovir2.png")))
+    }
+  )
+})
+
+test_that("It exports plot grids with specified output folder", {
+  tempDir <- tempdir()
+  projectConfigurationLocal <- projectConfiguration$clone()
+  projectConfigurationLocal$configurationsFolder <- tempDir
+  projectConfigurationLocal$outputFolder <- tempDir
+  withr::with_tempfile(
+    new = "Plots.xlsx",
+    tmpdir = tempDir,
+    code = {
+      dataCombinedDfLocal <- dataCombinedDf
+      plotConfigurationDfLocal <- plotConfigurationDf
+      plotGridsDfLocal <- plotGridsDf
+      exportConfigurationDfLocal <- data.frame(
+        plotGridName = rep("Aciclovir", 2),
+        outputName = c("Aciclovir1", "Aciclovir2"),
+        height = c(10, NA)
+      )
+      .writeExcel(data = list(
+        "DataCombined" = dataCombinedDfLocal,
+        "plotConfiguration" = plotConfigurationDfLocal,
+        "plotGrids" = plotGridsDfLocal,
+        "exportConfiguration" = exportConfigurationDfLocal
+      ), path = file.path(tempDir, "Plots.xlsx"), )
+
+
+      createPlotsFromExcel(
+        simulatedScenarios = simulatedScenarios,
+        observedData = observedData,
+        projectConfiguration = projectConfigurationLocal,
+        stopIfNotFound = TRUE,
+        outputFolder = tempDir
+      )
       expect_true(file.exists(file.path(tempDir, "Aciclovir1.png")))
       expect_true(file.exists(file.path(tempDir, "Aciclovir2.png")))
     }


### PR DESCRIPTION
Fixes #778

Figures defined for the export in the `exportConfiguration` sheet of the `Plots.xlsx` 
file are now exported to the subfolder `Figures\<Current Time Stamp>` of the `Results` folder
 defined in the `ProjectConfiguration`

- Added test for expoft with specified output path