### PR TITLE
780-create-plots-return-data-combined

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: esqlabsR
 Title: esqLABS utilities package
-Version: 5.3.0.9007
+Version: 5.3.0.9010
 Authors@R: c(
     person("esqLABS GmbH", role = c("cph", "fnd")),
     person("Pavel", "Balazki", , "pavel.balazki@esqlabs.com", role = c("cre", "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # esqlabsR (development version)
 
+## Major Changes
+
+- `createPlotsFromExcel` now returns a list with the items `plots` and `dataCombined`. 
+`plots` contains `ggplot2` objects and `dataCombined` the list of `DataCombined` 
+objects used for the creation of the plots (\#780).
+
 ## Minor improvements and bug fixes
 
 - Fix warnings related to NSE evaluation (\#762)

--- a/R/utilities-figures.R
+++ b/R/utilities-figures.R
@@ -272,7 +272,9 @@ createEsqlabsExportConfiguration <- function(outputFolder) { # nolint: object_le
 #' stored. If `NULL` (default), `projectConfiguration$outputFolder` is used. Only
 #' relevant for plots specified for export in the `exportConfiguration` sheet.
 #'
-#' @return A list of `ggplot` objects
+#' @return A list named list with `plots` being the list of `ggplot` objects
+#' and `dataCombined` being the list of `DataCombined` objects used for the creation
+#' of the plots.
 #'
 #' @import tidyr
 #'

--- a/R/utilities-figures.R
+++ b/R/utilities-figures.R
@@ -469,7 +469,7 @@ createPlotsFromExcel <- function(
     })
   }
 
-  return(plotGrids)
+  return(list("plots" = plotGrids, "dataCombined" = dataCombinedList))
 }
 
 #' Create a plotConfiguration or exportConfiguration objects from a row of sheet

--- a/inst/extdata/examples/TestProject/Code/Scenarios/defaultScenario.R
+++ b/inst/extdata/examples/TestProject/Code/Scenarios/defaultScenario.R
@@ -62,7 +62,8 @@ defaultScenario <- function(projectConfiguration, loadPreSimulatedResults = FALS
   # file for figure specification
   # sort(names(observedData))
   ########## Create figures########
-  plots <- createPlotsFromExcel(
+  # The function return the figures as `ggplot2` objects and the data combined objects
+  plotsAndDC <- createPlotsFromExcel(
     plotGridNames = c("Aciclovir",
                       "Aciclovir2"),
     simulatedScenarios = simulatedScenariosResults,
@@ -73,5 +74,5 @@ defaultScenario <- function(projectConfiguration, loadPreSimulatedResults = FALS
   )
 
   # Return a list with simulated scenarios and created plots
-  return(list(simulatedScenariosResults = simulatedScenariosResults, plots = plots))
+  return(list(simulatedScenariosResults = simulatedScenariosResults, plotsAndDC = plotsAndDC))
 }

--- a/man/createPlotsFromExcel.Rd
+++ b/man/createPlotsFromExcel.Rd
@@ -37,7 +37,9 @@ relevant for plots specified for export in the \code{exportConfiguration} sheet.
 simulated results or observed data are not found. If FALSE a warning is printed.}
 }
 \value{
-A list of \code{ggplot} objects
+A list named list with \code{plots} being the list of \code{ggplot} objects
+and \code{dataCombined} being the list of \code{DataCombined} objects used for the creation
+of the plots.
 }
 \description{
 Generate plots as defined in excel file \code{projectConfiguration$plotsFile}

--- a/tests/testthat/test-create-plots-from-excel.R
+++ b/tests/testthat/test-create-plots-from-excel.R
@@ -524,7 +524,9 @@ test_that("It creates plots for all plot grids when plotGridNames is NULL", {
     projectConfiguration = projectConfiguration,
     stopIfNotFound = TRUE
   )
-  expect_equal(names(plots), c("Aciclovir", "Aciclovir2", "Aciclovir3"))
+  expect_equal(names(plots$plots), c("Aciclovir", "Aciclovir2", "Aciclovir3"))
+  expect_equal(names(plots$dataCombined), c("AciclovirPVB", "AciclovirPop"))
+  expect_true(isOfType(plots$dataCombined, "DataCombined"))
 })
 
 test_that("It creates plots only for specified plotGrids", {

--- a/tests/testthat/test-create-plots-from-excel.R
+++ b/tests/testthat/test-create-plots-from-excel.R
@@ -537,7 +537,7 @@ test_that("It creates plots only for specified plotGrids", {
     projectConfiguration = projectConfiguration,
     stopIfNotFound = TRUE
   )
-  expect_equal(names(plots), c("Aciclovir"))
+  expect_equal(names(plots$plots), c("Aciclovir"))
 })
 
 test_that("It trows an error when specified plot grid names are not defined in the sheet", {

--- a/vignettes/esqlabsR-plot-results.Rmd
+++ b/vignettes/esqlabsR-plot-results.Rmd
@@ -185,23 +185,34 @@ plots <- createPlotsFromExcel(
 )
 ```
 
-The function returns a named list of `ggplot2` objects, with names being
-the names of the plot grids:
+The function returns a list with the two entries `plots` and `dataCombined`. `plots`
+is a named list of `ggplot2` objects, with names being the names of the plot grids,
+and `dataCombined` is a list of `DataCombined` objects, with the names being the names of the 
+`DataCombined` used for creation of the specified plots:
 
 ```{r}
-names(plots)
+print("The following plots were generated:")
+names(plots$plots)
+
+print("The following DataCombined objects were used:")
+names(plots$dataCombined)
 ```
 
 
 ```{r}
-plots$Aciclovir
+plots$plots$Aciclovir
 ```
 
 ```{r}
-plots$Aciclovir2
+plots$plots$Aciclovir2
 ```
 
-Also, calling this function will export the plots as image files if the 
+The returned `DataCombined` objects can be used e.g. to calculate the residuals
+between simulation results and observed data mapped in the `DataCombined`. For
+more information on how to use the `DataCombined` objects, please refer to the
+[documentation of the `{ospsuite}` package](https://www.open-systems-pharmacology.org/OSPSuite-R/reference/calculateResiduals.html).
+
+Calling `createPlotsFromExcel()` will export the plots as image files if the 
 exportConfiguration sheet is setup correctly.
 
 By default, the function will try to create all plots defined in the


### PR DESCRIPTION
Fixes #780

- `createPlotsFromExcel` now returns a list with the items `plots` and `dataCombined`.