### PR TITLE
`sensitivityCalculation()` now supports non-default PK parameters

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: esqlabsR
 Title: esqLABS utilities package
-Version: 5.3.0.9016
+Version: 5.3.0.9017
 Authors@R: c(
     person("esqLABS GmbH", role = c("cph", "fnd")),
     person("Pavel", "Balazki", , "pavel.balazki@esqlabs.com", role = c("cre", "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,9 @@ file are now exported to the subfolder `Figures\<Current Time Stamp>` of the `Re
  
 - Fix warning cannot be displayed when no individual model parameters are displayed.
 
+- `sensitivityCalculation()` now supports non-default PK parameters, e.g., user-defined PK-Parameters 
+(see https://www.open-systems-pharmacology.org/OSPSuite-R/articles/pk-analysis.html#user-defined-pk-parameters 
+for how to create user-defined PK parameters). (\#788)
 # esqlabsR 5.3.0
 
 ## Breaking changes

--- a/R/project-configuration.R
+++ b/R/project-configuration.R
@@ -186,8 +186,8 @@ ProjectConfiguration <- R6::R6Class(
           value
       }
       private$.clean_path(private$.projectConfigurationData$outputFolder$value,
-                          self$projectConfigurationDirPath,
-                          must_work = FALSE
+        self$projectConfigurationDirPath,
+        must_work = FALSE
       )
     }
   ),
@@ -272,14 +272,13 @@ ProjectConfiguration <- R6::R6Class(
         self[[property]] <- private$.projectConfigurationData[[property]]$value
       }
     },
-
     .clean_path = function(path, parent = NULL, must_work = TRUE, replace_env_vars = TRUE) {
       # In case project configuration is initialized empty
       if (is.null(path) || is.na(path)) {
         return(NULL)
       }
 
-      if(replace_env_vars) {
+      if (replace_env_vars) {
         path <- private$.replace_env_var(path)
       }
 
@@ -356,10 +355,12 @@ ProjectConfiguration <- R6::R6Class(
       cli::cli_li("Data File: {.file {as.character(self$dataFile)}}")
       cli::cli_li("Data Importer Configuration File: {.file {as.character(self$dataImporterConfigurationFile)}}")
 
-      if(!isEmpty(private$.replaced_env_vars)) {
+      if (!isEmpty(private$.replaced_env_vars)) {
         cli::cli_h2("Environment Variables")
         cli::cli_inform("Environment variables were detected and replaced in paths:")
-        purrr::iwalk(private$.replaced_env_vars, \(x, idx){cli::cli_li("{idx} to {x}")})
+        purrr::iwalk(private$.replaced_env_vars, \(x, idx){
+          cli::cli_li("{idx} to {x}")
+        })
       }
       invisible(self)
     },

--- a/R/sensitivity-calculation.R
+++ b/R/sensitivity-calculation.R
@@ -19,10 +19,9 @@
 #' values. Default is `"relative"`.
 #' @param pkParameters A vector of names of PK parameters for which the
 #' sensitivities will be calculated. For a full set of available standard PK
-#' parameters, run `names(ospsuite::StandardPKParameter)`. By default, only
-#' the following parameters will be considered: `"C_max"`, `"t_max"`, `"AUC_inf"`.
-#' If `NULL`, all available PK-parameters will be calculated. You can also
-#' specify custom PK parameters.
+#' parameters, run `names(ospsuite::StandardPKParameter)`. By default, the
+#' following parameters are considered: `"C_max"`, `"t_max"`, `"AUC_inf"`.
+#' If `NULL`, all available PK-parameters (including the user-defined) will be calculated.
 #' @param customOutputFunctions A named list with
 #' custom function(s) for output calculations. User-defined functions should
 #' have either 'x', 'y', or both 'x' and 'y' as parameters which correspond to
@@ -269,7 +268,7 @@ sensitivityCalculation <- function(simulation,
     } else {
       # Convert tidy data to wide format
       pkParameterNames <- c(
-        names(ospsuite::StandardPKParameter),
+        names(ospsuite::allPKParameterNames()),
         names(customOutputFunctions)
       )
       pkDataWide <- .convertToWide(pkData, pkParameterNames)

--- a/R/sensitivity-calculation.R
+++ b/R/sensitivity-calculation.R
@@ -268,7 +268,7 @@ sensitivityCalculation <- function(simulation,
     } else {
       # Convert tidy data to wide format
       pkParameterNames <- c(
-        names(ospsuite::allPKParameterNames()),
+        ospsuite::allPKParameterNames(),
         names(customOutputFunctions)
       )
       pkDataWide <- .convertToWide(pkData, pkParameterNames)

--- a/R/utilities-sensitivity-calculation.R
+++ b/R/utilities-sensitivity-calculation.R
@@ -431,11 +431,11 @@
 #' @keywords internal
 #' @noRd
 .validatePKParameters <- function(pkParameters) {
-  if (!is.null(pkParameters) && !isIncluded(pkParameters, names(ospsuite::StandardPKParameter))) {
-    nsPKNames <- pkParameters[!pkParameters %in% names(ospsuite::StandardPKParameter)]
+  if (!is.null(pkParameters) && !isIncluded(pkParameters, ospsuite::allPKParameterNames())) {
+    nsPKNames <- pkParameters[!pkParameters %in% ospsuite::allPKParameterNames()]
 
     message(
-      "Following non-standard PK parameters will not be calculated:\n",
+      "Following PK parameters are specified but were not calculated:\n",
       paste0(nsPKNames, collapse = "\n")
     )
   }

--- a/man/ProjectConfiguration.Rd
+++ b/man/ProjectConfiguration.Rd
@@ -7,9 +7,6 @@
 \description{
 An object storing configuration used project-wide
 }
-\section{Super class}{
-\code{\link[ospsuite.utils:Printable]{ospsuite.utils::Printable}} -> \code{ProjectConfiguration}
-}
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
 \describe{

--- a/man/sensitivityCalculation.Rd
+++ b/man/sensitivityCalculation.Rd
@@ -40,10 +40,9 @@ values. Default is \code{"relative"}.}
 
 \item{pkParameters}{A vector of names of PK parameters for which the
 sensitivities will be calculated. For a full set of available standard PK
-parameters, run \code{names(ospsuite::StandardPKParameter)}. By default, only
-the following parameters will be considered: \code{"C_max"}, \code{"t_max"}, \code{"AUC_inf"}.
-If \code{NULL}, all available PK-parameters will be calculated. You can also
-specify custom PK parameters.}
+parameters, run \code{names(ospsuite::StandardPKParameter)}. By default, the
+following parameters are considered: \code{"C_max"}, \code{"t_max"}, \code{"AUC_inf"}.
+If \code{NULL}, all available PK-parameters (including the user-defined) will be calculated.}
 
 \item{customOutputFunctions}{A named list with
 custom function(s) for output calculations. User-defined functions should

--- a/tests/testthat/test-project-configuration.R
+++ b/tests/testthat/test-project-configuration.R
@@ -100,4 +100,3 @@ test_that("Project Configuration supports environment variable", {
     }
   )
 })
-

--- a/tests/testthat/test-sensitivity-calculation.R
+++ b/tests/testthat/test-sensitivity-calculation.R
@@ -187,6 +187,25 @@ test_that("sensitivityCalculation fails with invalid `pkParameters`", {
   )
 })
 
+test_that("sensitivityCalculation works with user-defined `pkParameters`", {
+  # Create a new parameter based on the standard AUC parameter
+  myAUC <- addUserDefinedPKParameter(
+    name = "MyAUC",
+    standardPKParameter = StandardPKParameter$AUC_tEnd
+  )
+
+  results <- sensitivityCalculation(
+    simulation = simulation,
+    outputPaths = outputPaths,
+    parameterPaths = parameterPaths,
+    variationRange = variationRange,
+    pkParameters = c("C_max", "MyAUC")
+  )
+
+  expect_true(isOfType(results, "SensitivityCalculation"))
+  expect_equal(unique(results$pkData$PKParameter), c("C_max", "MyAUC"))
+})
+
 # Validate variationRange -------------------------------------------------
 
 test_that("sensitivityCalculation fails with invalid `variationRange`", {

--- a/tests/testthat/test-sensitivity-calculation.R
+++ b/tests/testthat/test-sensitivity-calculation.R
@@ -182,7 +182,7 @@ test_that("sensitivityCalculation fails with invalid `pkParameters`", {
       outputPaths = "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)",
       parameterPaths = parameterPaths
     ),
-    "Following non-standard PK parameters will not be calculated:\nabc\nxyz\n",
+    "Following PK parameters are specified but were not calculated:\nabc\nxyz\n",
     fixed = TRUE
   )
 })


### PR DESCRIPTION
Fixes #788

- `sensitivityCalculation()` now supports non-default PK parameters, e.g., user-defined PK-Parameters
(see https://www.open-systems-pharmacology.org/OSPSuite-R/articles/pk-analysis.html#user-defined-pk-parameters for how to create user-defined PK parameters). (\#788)