### PR TITLE
`extendPopulationFromXLS()` now properly collapses paths using "|"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,8 @@ file are now exported to the subfolder `Figures\<Current Time Stamp>` of the `Re
  
 - Fix warning cannot be displayed when no individual model parameters are displayed.
 
+- Fix `extendPopulationFromXLS()` did not created correct parameter paths (\#769).
+
 # esqlabsR 5.3.0
 
 ## Breaking changes

--- a/R/utilities-population.R
+++ b/R/utilities-population.R
@@ -186,10 +186,9 @@ extendPopulationFromXLS <- function(population, XLSpath, sheet = NULL) {
     ))
   }
 
-
   extendPopulationByUserDefinedParams(
     population = population,
-    parameterPaths = paste(complete_data$`Container Path`, complete_data$`Parameter Name`),
+    parameterPaths = paste(complete_data$`Container Path`, complete_data$`Parameter Name`, collapse = "|"),
     meanValues = complete_data$Mean,
     sdValues = complete_data$SD,
     distributions = complete_data$Distribution

--- a/R/utilities-population.R
+++ b/R/utilities-population.R
@@ -185,10 +185,9 @@ extendPopulationFromXLS <- function(population, XLSpath, sheet = NULL) {
       "*" = "Please fill all the columns and try again."
     ))
   }
-
   extendPopulationByUserDefinedParams(
     population = population,
-    parameterPaths = paste(complete_data$`Container Path`, complete_data$`Parameter Name`, collapse = "|"),
+    parameterPaths = paste(complete_data$`Container Path`, complete_data$`Parameter Name`, sep="|"),
     meanValues = complete_data$Mean,
     sdValues = complete_data$SD,
     distributions = complete_data$Distribution

--- a/man/ProjectConfiguration.Rd
+++ b/man/ProjectConfiguration.Rd
@@ -7,9 +7,6 @@
 \description{
 An object storing configuration used project-wide
 }
-\section{Super class}{
-\code{\link[ospsuite.utils:Printable]{ospsuite.utils::Printable}} -> \code{ProjectConfiguration}
-}
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
 \describe{

--- a/tests/testthat/_snaps/utilities-population.md
+++ b/tests/testthat/_snaps/utilities-population.md
@@ -20,10 +20,11 @@
       $paths
       [1] "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)"
       [2] "Organism|Muscle|Intracellular|Aciclovir|Concentration"                    
-      [3] "Organism|Kidney GFR"                                                      
+      [3] "Organism|Kidney|GFR"                                                      
+      [4] "Organism|Kidney|eGFR"                                                     
       
       $values
-      [1] 0.0000000 0.0000000 0.1198664
+      [1] 0.0000000 0.0000000 0.1198664 0.1186738
       
 
 # extendPopulationFromXLS throws an error if specified sheet is empty or data is missing

--- a/tests/testthat/test-utilities-population.R
+++ b/tests/testthat/test-utilities-population.R
@@ -127,15 +127,16 @@ test_that("extendPopulationFromXLS works", {
       population <- ospsuite::loadPopulation(system.file("extdata", "SimResults_pop.csv", package = "ospsuite"))
 
       set.seed(42)
-
       extendPopulationFromXLS(population,
         PopulationParameters,
         sheet = "UserDefinedVariability"
       )
-
       expect_snapshot(
         population$getParameterValuesForIndividual(4)
       )
+expect_equal(population$allParameterPaths, c("Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)",
+                                             "Organism|Muscle|Intracellular|Aciclovir|Concentration",
+                                             "Organism|Kidney|GFR"))
     }
   )
 })

--- a/tests/testthat/test-utilities-population.R
+++ b/tests/testthat/test-utilities-population.R
@@ -115,8 +115,8 @@ test_that("extendPopulationFromXLS works", {
       .writeExcel(
         path = PopulationParameters,
         data = list("UserDefinedVariability" = data.frame(
-          `Container Path` = "Organism|Kidney",
-          `Parameter Name` = "GFR",
+          `Container Path` = c("Organism|Kidney","Organism|Kidney"),
+          `Parameter Name` = c("GFR","eGFR"),
           "Mean" = 0.12,
           "SD" = 0.001,
           "Distribution" = "Normal",
@@ -136,7 +136,8 @@ test_that("extendPopulationFromXLS works", {
       )
 expect_equal(population$allParameterPaths, c("Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)",
                                              "Organism|Muscle|Intracellular|Aciclovir|Concentration",
-                                             "Organism|Kidney|GFR"))
+                                             "Organism|Kidney|GFR",
+                                             "Organism|Kidney|eGFR"))
     }
   )
 })


### PR DESCRIPTION
Fixes #769