### PR TITLE
Document missing arguments in `sensitivitySpiderPlot`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@
   modifying the projectConfiguration object directly, the package will look for
   matching environment variables and build the paths accordingly. A message is
   shown to the user to make this transparent.
+- Complete `sensitivitySpiderPlot` documentation (\#799)
   
 
 

--- a/R/sensitivity-spider-plot.R
+++ b/R/sensitivity-spider-plot.R
@@ -21,13 +21,16 @@
 #' A separate plot will be generated for each output path. Each plot will
 #' contain a spider plot panel for each PK parameter, and the sensitivities
 #' for each parameter will be displayed as lines.
-#' @param yAxisType Character string, either "percent" (percentage change) or
-#' "absolute" (absolute values) for PK parameter values, for y-axis data normalization.
-#' Default is "percent".
 #' @param xAxisScale Character string, either "log" (logarithmic scale) or "lin"
 #' (linear scale), to set the x-axis scale. Default is "log".
 #' @param yAxisScale Character string, either "log" or "lin", sets the y-axis scale
 #' similarly to `xAxisScale`. Default is "lin".
+#' @param xAxisType Character string, either "percent" (percentage change) or
+#' "absolute" (absolute values) for PK parameter values, for x-axis data normalization.
+#' Default is "percent".
+#' @param yAxisType Character string, either "percent" (percentage change) or
+#' "absolute" (absolute values) for PK parameter values, for y-axis data normalization.
+#' Default is "percent".
 #' @param yAxisFacetScales Character string, either "fixed" or "free", determines
 #' the scaling across y-axes of different facets. Default is "fixed".
 #' If "fixed", all facetes within one plot will have the same range, which allows
@@ -107,9 +110,9 @@ sensitivitySpiderPlot <- function(sensitivityCalculation,
                                   pkParameters = NULL,
                                   xAxisScale = NULL,
                                   yAxisScale = NULL,
-                                  yAxisFacetScales = "fixed",
                                   xAxisType = "percent",
                                   yAxisType = "percent",
+                                  yAxisFacetScales = "fixed",
                                   defaultPlotConfiguration = NULL) {
   # Input validation -------------------------------------
 

--- a/R/utilities-population.R
+++ b/R/utilities-population.R
@@ -187,7 +187,7 @@ extendPopulationFromXLS <- function(population, XLSpath, sheet = NULL) {
   }
   extendPopulationByUserDefinedParams(
     population = population,
-    parameterPaths = paste(complete_data$`Container Path`, complete_data$`Parameter Name`, sep="|"),
+    parameterPaths = paste(complete_data$`Container Path`, complete_data$`Parameter Name`, sep = "|"),
     meanValues = complete_data$Mean,
     sdValues = complete_data$SD,
     distributions = complete_data$Distribution

--- a/man/sensitivitySpiderPlot.Rd
+++ b/man/sensitivitySpiderPlot.Rd
@@ -11,9 +11,9 @@ sensitivitySpiderPlot(
   pkParameters = NULL,
   xAxisScale = NULL,
   yAxisScale = NULL,
-  yAxisFacetScales = "fixed",
   xAxisType = "percent",
   yAxisType = "percent",
+  yAxisFacetScales = "fixed",
   defaultPlotConfiguration = NULL
 )
 }
@@ -36,16 +36,20 @@ for each parameter will be displayed as lines.}
 \item{yAxisScale}{Character string, either "log" or "lin", sets the y-axis scale
 similarly to \code{xAxisScale}. Default is "lin".}
 
+\item{xAxisType}{Character string, either "percent" (percentage change) or
+"absolute" (absolute values) for PK parameter values, for x-axis data normalization.
+Default is "percent".}
+
+\item{yAxisType}{Character string, either "percent" (percentage change) or
+"absolute" (absolute values) for PK parameter values, for y-axis data normalization.
+Default is "percent".}
+
 \item{yAxisFacetScales}{Character string, either "fixed" or "free", determines
 the scaling across y-axes of different facets. Default is "fixed".
 If "fixed", all facetes within one plot will have the same range, which allows
 for easier comparison between different PK parameters. If "free", each facet
 will have its own range, which allows for better visualization of the single
 PK parameters sensitivity.}
-
-\item{yAxisType}{Character string, either "percent" (percentage change) or
-"absolute" (absolute values) for PK parameter values, for y-axis data normalization.
-Default is "percent".}
 
 \item{defaultPlotConfiguration}{An object of class \code{DefaultPlotConfiguration}
 used to customize plot aesthetics. Plot-specific settings provided directly

--- a/tests/testthat/_snaps/scenario-configuration.md
+++ b/tests/testthat/_snaps/scenario-configuration.md
@@ -10,6 +10,12 @@
       mySC$removeParamSheets(NULL)
       mySC$addParamSheets(c("mySheet1", "mySheet2"))
       mySC$print(projectConfiguration = FALSE)
+    Condition
+      Warning:
+      ospsuite.utils::Printable was deprecated in ospsuite.utils 1.6.2.
+      i Please use ospsuite.utils::ospPrint*() instead.
+      i The deprecated feature was likely used in the ospsuite.utils package.
+        Please report the issue at <https://github.com/open-systems-pharmacology/OSPSuite.RUtils/issues>.
     Output
       ScenarioConfiguration: 
          Model file name: NULL 

--- a/tests/testthat/test-utilities-individual.R
+++ b/tests/testthat/test-utilities-individual.R
@@ -1,6 +1,4 @@
-skip_on_ci()
-
-XLSpath <- "../data/Individuals.xlsx"
+XLSpath <- getTestDataFilePath("Individuals.xlsx")
 
 test_that("It returns NULL if the specified individual Id cannot be found in
           the file and nullIfNotFound is TRUE", {

--- a/tests/testthat/test-utilities-population.R
+++ b/tests/testthat/test-utilities-population.R
@@ -115,8 +115,8 @@ test_that("extendPopulationFromXLS works", {
       .writeExcel(
         path = PopulationParameters,
         data = list("UserDefinedVariability" = data.frame(
-          `Container Path` = c("Organism|Kidney","Organism|Kidney"),
-          `Parameter Name` = c("GFR","eGFR"),
+          `Container Path` = c("Organism|Kidney", "Organism|Kidney"),
+          `Parameter Name` = c("GFR", "eGFR"),
           "Mean" = 0.12,
           "SD" = 0.001,
           "Distribution" = "Normal",
@@ -134,10 +134,12 @@ test_that("extendPopulationFromXLS works", {
       expect_snapshot(
         population$getParameterValuesForIndividual(4)
       )
-expect_equal(population$allParameterPaths, c("Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)",
-                                             "Organism|Muscle|Intracellular|Aciclovir|Concentration",
-                                             "Organism|Kidney|GFR",
-                                             "Organism|Kidney|eGFR"))
+      expect_equal(population$allParameterPaths, c(
+        "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)",
+        "Organism|Muscle|Intracellular|Aciclovir|Concentration",
+        "Organism|Kidney|GFR",
+        "Organism|Kidney|eGFR"
+      ))
     }
   )
 })


### PR DESCRIPTION
Fix warning missing arguments in `sensitivitySpiderPlot`

Closes #793 