### PR TITLE
800-wrong-data-combined-name

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: esqlabsR
 Title: esqLABS utilities package
-Version: 5.3.0.9022
+Version: 5.3.0.9023
 Authors@R: c(
     person("esqLABS GmbH", role = c("cph", "fnd")),
     person("Pavel", "Balazki", , "pavel.balazki@esqlabs.com", role = c("cre", "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,8 @@
 - Classes do not inherit from the deprecated `Printable` class from the `{ospsuite.utils}` package.
 - Print methods for all classes are now implemented using the `ospPrint\*` functions 
 introduced in version 1.7.0. of the `{ospsuite.utils}` package.
+- Fix when `createPlotsFromExcel` or `createDataCombinedFromExcel` would return 
+wrong names of DataCombined for which the output path for a simulation scenario is not defined (\#800).
   
 
 ## Minor improvements and bug fixes

--- a/R/utilities-data-combined.R
+++ b/R/utilities-data-combined.R
@@ -163,13 +163,13 @@ createDataCombinedFromExcel <- function(
   # dataType == simulated, but no path defined - throw error
   missingLabel <- is.na(dfDataCombined[dfDataCombined$dataType == "simulated", ]$path)
   if (sum(missingLabel) > 0) {
-    stop(messages$stopNoPathProvided(dfDataCombined[missingLabel & dfDataCombined$dataType == "simulated", ]$DataCombinedName))
+    stop(messages$stopNoPathProvided(dfDataCombined[dfDataCombined$dataType == "simulated", ]$DataCombinedName[missingLabel]))
   }
 
   # dataType == observed, but no data set defined - throw error
   missingLabel <- is.na(dfDataCombined[dfDataCombined$dataType == "observed", ]$dataSet)
   if (sum(missingLabel) > 0) {
-    stop(messages$stopNoDataSetProvided(dfDataCombined[dfDataCombined$dataType == "observed", ]$DataCombinedName[which(missingLabel)]))
+    stop(messages$stopNoDataSetProvided(dfDataCombined[dfDataCombined$dataType == "observed", ]$DataCombinedName[missingLabel]))
   }
 
   # Store the names of all DataCombined before filtering. This is required

--- a/tests/testthat/test-create-plots-from-excel.R
+++ b/tests/testthat/test-create-plots-from-excel.R
@@ -22,8 +22,6 @@ simulatedScenarios <- runScenarios(
   scenarios = scenarios
 )
 
-# For compatibility with projects created with esqlabsR <5.0.1, use old data set
-# naming pattern.
 importerConfiguration <- ospsuite::loadDataImporterConfiguration(
   configurationFilePath = projectConfiguration$dataImporterConfigurationFile
 )

--- a/tests/testthat/test-utilities-data-combined.R
+++ b/tests/testthat/test-utilities-data-combined.R
@@ -1,0 +1,55 @@
+projectConfiguration <- testProjectConfiguration()
+
+# Define which scenarios to run
+scenarioNames <- c("TestScenario", "PopulationScenario")
+outputPaths <- "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)"
+
+# # Create `ScenarioConfiguration` objects from excel files
+# scenarioConfigurations <- readScenarioConfigurationFromExcel(
+#   scenarioNames = scenarioNames,
+#   projectConfiguration = projectConfiguration
+# )
+#
+# # Set output paths for each scenario
+# for (scenarioConfiguration in scenarioConfigurations) {
+#   scenarioConfiguration$outputPaths <- outputPaths
+# }
+#
+# # Run scenarios
+# scenarios <- createScenarios(scenarioConfigurations = scenarioConfigurations)
+#
+# simulatedScenarios <- runScenarios(
+#   scenarios = scenarios
+# )
+
+importerConfiguration <- ospsuite::loadDataImporterConfiguration(
+  configurationFilePath = projectConfiguration$dataImporterConfigurationFile
+)
+
+# Load observed data
+dataSheets <- "Laskin 1982.Group A"
+observedData <- esqlabsR::loadObservedData(
+  projectConfiguration = projectConfiguration,
+  sheets = dataSheets,
+  importerConfiguration = importerConfiguration
+)
+
+dataCombinedDf <- data.frame(list(
+  "DataCombinedName" = c("AciclovirPVB", "AciclovirPVB", "DC_missingPath", "DC_missingPath"),
+  "dataType" = c("simulated", "observed", "simulated", "observed"),
+  "label" = c("Aciclovir simulated", "Aciclovir observed", "Aciclovir simulated", "Aciclovir observed"),
+  "scenario" = c(scenarioNames[1], NA, scenarioNames[1], NA),
+  "path" = c(outputPaths, NA, NA, NA),
+  "dataSet" = c(NA, names(observedData), NA, names(observedData)),
+  "group" = c("Aciclovir PVB", "Aciclovir PVB"),
+  "xOffsets" = c(NA, NA),
+  "xOffsetsUnits" = c(NA, NA),
+  "yOffsets" = c(NA, NA),
+  "yOffsetsUnits" = c(NA, NA),
+  "xScaleFactors" = c(NA, NA),
+  "yScaleFactors" = c(NA, NA)
+))
+
+test_that("It returns correct names of data combined when a path is not specified for one simulated scenario", {
+  expect_error(.validateDataCombinedFromExcel(dataCombinedDf, observedData), regexp = messages$stopNoPathProvided("DC_missingPath"))
+})


### PR DESCRIPTION
Fixes #800

Fix when createPlotsFromExcel or createDataCombinedFromExcel would return
wrong names of DataCombined for which the output path for a simulation scenario is not defined