### PR TITLE
ignore-rows-without-scenario-name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # esqlabsR (development version)
 
+## Minor improvements and bug fixes
+
+- `readScenarioConfigurationFromExcel()` ignores rows where `Scenario_name` is empty.
+
 # esqlabsR 5.4.0
 
 ## Breaking changes

--- a/R/utilities-scenario-configuration.R
+++ b/R/utilities-scenario-configuration.R
@@ -66,6 +66,9 @@ readScenarioConfigurationFromExcel <- function(scenarioNames = NULL, projectConf
 
   # Remove empty rows
   wholeData <- dplyr::filter(wholeData, !dplyr::if_all(dplyr::everything(), is.na))
+  # Remove all rows where the name of the scenario is not defined. This might happen when other columns
+  # have accidentially some entry, and then the whole row is read with scneario name = NA
+  wholeData <- dplyr::filter(wholeData, !is.na(Scenario_name))
 
   outputPathsDf <- readExcel(
     path = projectConfiguration$scenariosFile,


### PR DESCRIPTION
`readScenarioConfigurationFromExcel()` ignores rows where `Scenario…_name` is empty.