### PR TITLE
sensitivityTimeProfiles y label dimension fix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@ were overwritten by the administration protocol (\#817)
 ## Minor improvements and bug fixes
 
 - `readScenarioConfigurationFromExcel()` ignores rows where `Scenario_name` is empty.
+- Fixed a bug when the dimension in the y-axis label of `sensitivityTimeProfiles()` 
+did not match the unit (\#823).
 
 # esqlabsR 5.4.0
 

--- a/R/sensivitity-time-profiles.R
+++ b/R/sensivitity-time-profiles.R
@@ -216,10 +216,12 @@ sensitivityTimeProfiles <- function(sensitivityCalculation,
       unique(data$xUnit), "]"
     )
   }
+  yUnitForPlot <- unique(data$yUnit)
+  yDimensionForPlot <- ospsuite::getDimensionForUnit(yUnitForPlot)
   if (is.null(plotConfiguration$yLabel)) {
     plotConfiguration$yLabel <- paste0(
-      unique(data$yDimension), " [",
-      unique(data$yUnit), "]"
+      yDimensionForPlot, " [",
+      yUnitForPlot, "]"
     )
   }
 


### PR DESCRIPTION
- Fixes #823 

Fixed a bug when the dimension in the y-axis label of `sensitivityimeProfiles()` did not match the unit