### PR TITLE
Fix `.validateCharVector()` to reject lists where characters are expected

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # esqlabsR (development version)
 
+## Breaking changes
+
+## Major changes
+
+## Minor improvements and bug fixes
+
+- Improved `.validateCharVector()` to enforce atomic character vectors (#881).
+
+
 # esqlabsR 5.5.0
 
 ## Breaking changes

--- a/R/sensitivity-calculation.R
+++ b/R/sensitivity-calculation.R
@@ -91,11 +91,11 @@ sensitivityCalculation <- function(
   # Input validation ------------------------------------------------------
 
   # Validate vector arguments of character type
-  .validateCharVectors(outputPaths)
-  .validateCharVectors(parameterPaths)
-  .validateCharVectors(names(parameterPaths), nullAllowed = TRUE)
-  .validateCharVectors(variationType)
-  .validateCharVectors(pkParameters, nullAllowed = TRUE)
+  .validateCharVector(outputPaths)
+  .validateCharVector(parameterPaths)
+  .validateCharVector(names(parameterPaths), nullAllowed = TRUE)
+  .validateCharVector(variationType)
+  .validateCharVector(pkParameters, nullAllowed = TRUE)
 
   # Check for non-standard PK parameters
   .validatePKParameters(pkParameters)

--- a/R/sensitivity-calculation.R
+++ b/R/sensitivity-calculation.R
@@ -83,7 +83,7 @@ sensitivityCalculation <- function(
     outputPaths,
     parameterPaths,
     variationRange = c(seq(0.1, 1, by = 0.1), seq(2, 10, by = 1)),
-    variationType = c("relative"),
+    variationType = c("relative", "absolute"),
     pkParameters = c("C_max", "t_max", "AUC_inf"),
     customOutputFunctions = NULL,
     saOutputFilePath = NULL,
@@ -96,6 +96,8 @@ sensitivityCalculation <- function(
   .validateCharVector(names(parameterPaths), nullAllowed = TRUE)
   .validateCharVector(variationType)
   .validateCharVector(pkParameters, nullAllowed = TRUE)
+
+  variationType <- match.arg(variationType)
 
   # Check for non-standard PK parameters
   .validatePKParameters(pkParameters)

--- a/R/sensitivity-spider-plot.R
+++ b/R/sensitivity-spider-plot.R
@@ -135,9 +135,9 @@ sensitivitySpiderPlot <- function(
 
   validateIsOfType(sensitivityCalculation, "SensitivityCalculation")
 
-  .validateCharVectors(outputPaths, nullAllowed = TRUE)
-  .validateCharVectors(parameterPaths, nullAllowed = TRUE)
-  .validateCharVectors(pkParameters, nullAllowed = TRUE)
+  .validateCharVector(outputPaths, nullAllowed = TRUE)
+  .validateCharVector(parameterPaths, nullAllowed = TRUE)
+  .validateCharVector(pkParameters, nullAllowed = TRUE)
 
   # Plot configuration setup -----------------------------
 

--- a/R/sensitivity-tornado-plot.R
+++ b/R/sensitivity-tornado-plot.R
@@ -113,9 +113,9 @@ sensitivityTornadoPlot <- function(
     .getPlotConfigurationOptions("parameterFactor")
   )
 
-  .validateCharVectors(outputPaths, nullAllowed = TRUE)
-  .validateCharVectors(parameterPaths, nullAllowed = TRUE)
-  .validateCharVectors(pkParameters, nullAllowed = TRUE)
+  .validateCharVector(outputPaths, nullAllowed = TRUE)
+  .validateCharVector(parameterPaths, nullAllowed = TRUE)
+  .validateCharVector(pkParameters, nullAllowed = TRUE)
   ospsuite.utils::validateIsNumeric(xAxisZoomRange, nullAllowed = TRUE)
   if (!is.null(xAxisZoomRange)) {
     ospsuite.utils::validateIsOfLength(xAxisZoomRange, 2)

--- a/R/sensivitity-time-profiles.R
+++ b/R/sensivitity-time-profiles.R
@@ -125,8 +125,8 @@ sensitivityTimeProfiles <- function(
     validateIsOfType(observedData, "DataSet")
   }
 
-  .validateCharVectors(outputPaths, nullAllowed = TRUE)
-  .validateCharVectors(parameterPaths, nullAllowed = TRUE)
+  .validateCharVector(outputPaths, nullAllowed = TRUE)
+  .validateCharVector(parameterPaths, nullAllowed = TRUE)
 
   # Plot configuration setup -----------------------------
 

--- a/R/utilities-sensitivity-calculation.R
+++ b/R/utilities-sensitivity-calculation.R
@@ -378,70 +378,42 @@
 
 # validation helpers ------------------------------
 
-#' Validate vector arguments of `character` type
+#' Validate a character vector
 #'
-#' @param argVector A vector of `character` type.
-#' @param nullAllowed Boolean flag if `NULL` is accepted for the object. Default
-#' is `FALSE`.
+#' @param object An object or a vector of type `character`.
+#' @param nullAllowed Boolean flag if `NULL` is accepted for the object.
+#' If `TRUE`, `NULL` always returns TRUE, otherwise `NULL` returns FALSE.
+#' Default is `FALSE`.
 #'
-#' @description
-#'
-#' If the parameter in your function accepts vectors of `character` type, this
-#' can help you validate the following aspects:
-#'
-#' - the elements are indeed of `character` type
-#' - none of the entries are duplicated
-#' - there are no empty strings (`""`)
-#'
-#' @returns Error if validation is unsuccessful; otherwise, `NULL`.
-#'
-#' @examples
-#'
-#' x <- c("a", "b", "a")
-#' # this will produce error
-#' # validateCharVectors(x)
-#'
-#' # this will return `NULL`
-#' y <- c("a", "b", "c")
-#' validateCharVectors(y)
+#' @return
+#' `NULL` if the entered object is a valid character vector, otherwise produces
+#' an error. Also accepts `NULL` as input if `nullAllowed` is set to `TRUE`.
 #'
 #' @keywords internal
 #' @noRd
-.validateCharVectors <- function(argVector, nullAllowed = FALSE) {
-  argName <- deparse(substitute(argVector))
+.validateCharVector <- function(object, nullAllowed = FALSE) {
+  objectName <- deparse(substitute(object))
+  objectType <- "character"
 
-  # Handle NULL cases based on nullAllowed
-  if (is.null(argVector) && !nullAllowed) {
-    cli::cli_abort("The argument `{argName}` cannot be NULL.")
-  }
-
-  # Skip further checks if NULL is allowed and the argument is NULL
-  if (is.null(argVector)) {
-    return()
+  # Handle NULL
+  if (is.null(object)) {
+    if (nullAllowed) return(invisible(NULL))
+    stop(messages$errorWrongType(objectName, class(object)[1], objectType))
   }
 
   # Check if the argument is of type character
-  if (!isOfType(argVector, "character")) {
-    cli::cli_abort(c(
-      "x" = "The argument `{argName}` must be of type {.val character}.",
-      "i" = "Ensure that the provided value is a character vector."
-    ))
+  if (!(is.atomic(object) && typeof(object) == objectType)) {
+    stop(messages$errorWrongType(objectName, class(object)[1], objectType))
   }
 
   # Ensure all values are distinct
-  if (!hasOnlyDistinctValues(argVector)) {
-    cli::cli_abort(c(
-      "x" = "The argument `{argName}` must contain only distinct values.",
-      "i" = "Remove any duplicate entries from the `{argName}`."
-    ))
+  if (!hasOnlyDistinctValues(object)) {
+    stop(messages$errorDuplicatedValues())
   }
 
   # Check for empty string values
-  if (any(nchar(argVector) == 0L)) {
-    cli::cli_abort(c(
-      "x" = "The argument `{argName}` contains empty strings.",
-      "i" = "Ensure that `{argName}` does not have any empty entries."
-    ))
+  if (any(!nzchar(object))) {
+    stop(messages$errorEmptyString(objectName))
   }
 }
 

--- a/tests/testthat/test-sensitivity-calculation.R
+++ b/tests/testthat/test-sensitivity-calculation.R
@@ -373,6 +373,20 @@ test_that("sensitivityCalculation fails with invalid `customOutputFunctions`", {
   )
 })
 
+# Validate variationType
+
+test_that("sensitivityCalculation fails with invalid `variationType`", {
+  expect_error(
+    sensitivityCalculation(
+      simulation = simulation,
+      outputPaths = outputPaths,
+      parameterPaths = parameterPaths,
+      variationType = "invalidType"
+    ),
+    'should be one of \\"relative\\", \\"absolute\\"'
+  )
+})
+
 # Check SensitivityCalculation object -------------------------------------
 
 test_that("sensitivityCalculation returns a valid `SensitivityCalculation` object", {

--- a/tests/testthat/test-sensitivity-calculation.R
+++ b/tests/testthat/test-sensitivity-calculation.R
@@ -37,27 +37,40 @@ test_that("sensitivityCalculation fails with invalid `outputPaths`", {
     sensitivityCalculation(
       simulation = simulation,
       outputPaths = NULL,
-      parameterPaths = parameterPath
+      parameterPaths = parameterPaths
     ),
-    "The argument `outputPaths` cannot be NULL"
+    messages$errorWrongType("outputPaths", class(NULL), "character"),
+    fixed = TRUE
   )
 
   expect_error(
     sensitivityCalculation(
       simulation = simulation,
       outputPaths = c(1, 2, 3),
-      parameterPaths = parameterPath
+      parameterPaths = parameterPaths
     ),
-    'The argument `outputPaths` must be of type "character"'
+    messages$errorWrongType("outputPaths", "numeric", "character"),
+    fixed = TRUE
+  )
+
+  expect_error(
+    sensitivityCalculation(
+      simulation = simulation,
+      outputPaths = list("pathNameA" = "pathA"),
+      parameterPaths = parameterPaths
+    ),
+    messages$errorWrongType("outputPaths", "list", "character"),
+    fixed = TRUE
   )
 
   expect_error(
     sensitivityCalculation(
       simulation = simulation,
       outputPaths = "",
-      parameterPaths = parameterPath
+      parameterPaths = parameterPaths
     ),
-    "The argument `outputPaths` contains empty strings"
+    messages$errorEmptyString("outputPaths"),
+    fixed = TRUE
   )
 
   expect_error(
@@ -69,7 +82,8 @@ test_that("sensitivityCalculation fails with invalid `outputPaths`", {
       ),
       parameterPaths = parameterPath
     ),
-    "The argument `outputPaths` contains empty strings"
+    messages$errorEmptyString("outputPaths"),
+    fixed = TRUE
   )
 
   expect_error(
@@ -81,7 +95,8 @@ test_that("sensitivityCalculation fails with invalid `outputPaths`", {
       ),
       parameterPaths = parameterPath
     ),
-    "The argument `outputPaths` must contain only distinct values"
+    messages$errorDuplicatedValues(),
+    fixed = TRUE
   )
 })
 
@@ -94,7 +109,8 @@ test_that("sensitivityCalculation fails with invalid `parameterPaths`", {
       outputPaths = "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)",
       parameterPaths = NULL
     ),
-    "The argument `parameterPaths` cannot be NULL"
+    messages$errorWrongType("parameterPaths", class(NULL), "character"),
+    fixed = TRUE
   )
 
   expect_error(
@@ -103,7 +119,8 @@ test_that("sensitivityCalculation fails with invalid `parameterPaths`", {
       outputPaths = "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)",
       parameterPaths = c(1, 2, 3)
     ),
-    'The argument `parameterPaths` must be of type "character"'
+    messages$errorWrongType("parameterPaths", "numeric", "character"),
+    fixed = TRUE
   )
 
   expect_error(
@@ -112,7 +129,8 @@ test_that("sensitivityCalculation fails with invalid `parameterPaths`", {
       outputPaths = "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)",
       parameterPaths = ""
     ),
-    "The argument `parameterPaths` contains empty strings"
+    messages$errorEmptyString("parameterPaths"),
+    fixed = TRUE
   )
 
   expect_error(
@@ -125,7 +143,8 @@ test_that("sensitivityCalculation fails with invalid `parameterPaths`", {
         "Neighborhoods|Kidney_pls_Kidney_ur|Aciclovir|Glomerular Filtration-GFR|GFR fraction"
       )
     ),
-    "The argument `parameterPaths` contains empty strings"
+    messages$errorEmptyString("parameterPaths"),
+    fixed = TRUE
   )
 
   expect_error(
@@ -134,7 +153,8 @@ test_that("sensitivityCalculation fails with invalid `parameterPaths`", {
       outputPaths = "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)",
       parameterPaths = c(parameterPaths, parameterPaths[1])
     ),
-    "The argument `parameterPaths` must contain only distinct values"
+    messages$errorDuplicatedValues(),
+    fixed = TRUE
   )
 })
 
@@ -148,7 +168,8 @@ test_that("sensitivityCalculation fails with invalid `pkParameters`", {
       outputPaths = outputPaths,
       parameterPaths = parameterPaths
     ),
-    'The argument `pkParameters` must be of type "character"'
+    messages$errorWrongType("pkParameters", "numeric", "character"),
+    fixed = TRUE
   )
 
   expect_error(
@@ -158,7 +179,8 @@ test_that("sensitivityCalculation fails with invalid `pkParameters`", {
       outputPaths = outputPaths,
       parameterPaths = parameterPaths
     ),
-    "The argument `pkParameters` contains empty strings"
+    messages$errorEmptyString("pkParameters"),
+    fixed = TRUE
   )
 
   expect_error(
@@ -168,7 +190,8 @@ test_that("sensitivityCalculation fails with invalid `pkParameters`", {
       outputPaths = outputPaths,
       parameterPaths = parameterPaths
     ),
-    "The argument `pkParameters` contains empty strings"
+    messages$errorEmptyString("pkParameters"),
+    fixed = TRUE
   )
 
   expect_error(
@@ -178,7 +201,8 @@ test_that("sensitivityCalculation fails with invalid `pkParameters`", {
       outputPaths = "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)",
       parameterPaths = parameterPaths
     ),
-    "The argument `pkParameters` must contain only distinct values"
+    messages$errorDuplicatedValues(),
+    fixed = TRUE
   )
 
   expect_message(


### PR DESCRIPTION
- Improves `.validateCharVector()` by enforcing atomic character vectors.
- Fixes an issue where a list could be passed (e.g., `parameterPaths = list("label" = "fullPathName"`)) and slipping validation, later causing problems when validating parameter path names.
Closes #879 