### PR TITLE
Copilot/setup documentation for esqlabsr

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -51,4 +51,6 @@ _\.new\.png$
 ^[.]?air[.]toml$
 ^\.vscode$
 ^AGENTS\.md$
+^CLAUDE\.md$
+^\.claude/\.
 ^.cursor/.

--- a/.claude/skills/ospsuite-r-coding-standards.md
+++ b/.claude/skills/ospsuite-r-coding-standards.md
@@ -1,0 +1,281 @@
+---
+name: ospsuite-r-coding-standards
+description: >
+  Coding standards, best practices, and collaboration guidelines for the
+  esqlabsR package. Use when writing, reviewing, or refactoring R code in
+  esqlabsR. Covers OSPSuite-specific R conventions, R6 class design, naming,
+  documentation, and the pull-request workflow.
+---
+
+# OSPSuite R Coding Standards for esqlabsR
+
+Based on the [OSPSuite R coding standards](https://github.com/Open-Systems-Pharmacology/developer-docs/blob/main/ospsuite-r-specifics/CODING_STANDARDS_R.md) and [collaboration guide](https://github.com/Open-Systems-Pharmacology/developer-docs/blob/main/ospsuite-r-specifics/collaboration_guide.md).
+
+## Naming Conventions
+
+### Files
+
+Use **kebab-case** with `.R` extension for all source and test files:
+
+```r
+# Bad
+DataCombined.R
+test-DataCombined.R
+
+# Good
+data-combined.R
+test-data-combined.R
+```
+
+### Objects
+
+| Type | Convention | Example |
+|------|-----------|---------|
+| Variables & functions | `camelCase` | `performSimulation`, `parameterToDelete` |
+| R6 classes | PascalCase | `Scenario`, `ScenarioConfiguration` |
+| Constants | `ALL_CAPS` | `DEFAULT_PERCENTILE` |
+| Internal functions | prefix with `.` | `.runSingleSimulation` |
+
+**Do not** use Hungarian notation (no `b` for Boolean, `s` for string, etc.).
+
+## R6 Class Design
+
+Every R6 class in esqlabsR follows a consistent pattern:
+
+```r
+#' @title MyClass
+#' @docType class
+#' @description Brief description.
+#' @format NULL
+#' @export
+MyClass <- R6::R6Class(
+  "MyClass",
+  cloneable = FALSE,
+  active = list(
+    #' @field myProp Description. Read-only.
+    myProp = function(value) {
+      if (missing(value)) {
+        private$.myProp
+      } else {
+        stop(messages$errorPropertyReadOnly("myProp"))
+      }
+    }
+  ),
+  public = list(
+    #' @description Create a new `MyClass` object.
+    #' @param myArg Description of argument.
+    #' @return A new `MyClass` object.
+    initialize = function(myArg) {
+      private$.myProp <- myArg
+      invisible(self)
+    },
+
+    #' @description Print the object to the console.
+    #' @param ... Rest arguments.
+    print = function(...) {
+      ospsuite.utils::ospPrintClass(self)
+      ospsuite.utils::ospPrintItems(list(
+        "My property" = self$myProp
+      ))
+      invisible(self)
+    }
+  ),
+  private = list(
+    .myProp = NULL
+  )
+)
+```
+
+**Key rules:**
+- Set `cloneable = FALSE` by default
+- Read-only properties use active bindings + `stop(messages$errorPropertyReadOnly(...))`
+- Always implement a `print()` method
+- Private methods start with `.` (e.g., `.computeInternal()`)
+- Internal (non-exported) classes use `#' @keywords internal`
+- Utility functions for a class go in `utilities-{class-name}.R`
+
+## Code Style
+
+### Assignments
+
+```r
+# Good
+x <- 5
+
+# Bad
+x = 5
+```
+
+### Booleans
+
+```r
+# Good
+if (condition == TRUE) { ... }
+
+# Bad
+if (condition == T) { ... }
+```
+
+### Explicit Returns
+
+Prefer `return()` even when implicit return works:
+
+```r
+# Good
+myFunction <- function(x) {
+  result <- x * 2
+  return(result)
+}
+
+# Acceptable (for simple one-liners)
+myFunction <- function(x) x * 2
+```
+
+### Code Blocks
+
+```r
+# Good
+if (condition) {
+  doSomething()
+} else {
+  doOther()
+}
+
+# OK for simple side-effect-free statements
+y <- if (x < 20) "Too low" else "Too high"
+```
+
+### Pipes
+
+```r
+# Good — base pipe
+result <- data |> filter(x > 0) |> select(y)
+
+# Bad — magrittr pipe
+result <- data %>% filter(x > 0) %>% select(y)
+```
+
+## Documentation Standards
+
+### Functions
+
+```r
+#' Brief one-line title
+#'
+#' @description Optional longer description using **markdown**.
+#'
+#' @param x Description of `x`. Wrap at 80 characters.
+#' @param y Description of `y`.
+#'
+#' @returns Description of the return value.
+#'
+#' @examples
+#' myFunction(x = 1, y = 2)
+#'
+#' @export
+myFunction <- function(x, y) { ... }
+```
+
+### R6 Classes
+
+Document the class with one roxygen block before the `R6Class()` call.
+Use the `@field` tag for active bindings. Use the `@description` tag inside
+`initialize` and other methods. Reference properties with `$` prefix:
+
+> `$myProp` for properties, `$myMethod()` for methods.
+
+### Conventions in Text
+
+- Functions: `` `myFunction()` `` (with parentheses)
+- Variables/objects: `` `myVar` ``
+- Package names: `` `{dplyr}` ``
+- Programming languages: `` `R` ``, `` `C++` ``
+
+## Error and Warning Messages
+
+All messages are defined as functions on the `messages` enum in `R/messages.R`.
+Never inline message strings—always add them to `messages`:
+
+```r
+# Bad
+stop("The property is read-only.")
+
+# Good
+stop(messages$errorPropertyReadOnly("myProp"))
+```
+
+Use `{cli}` functions for user-facing output:
+
+```r
+cli::cli_abort("Something went wrong: {.val {value}}")
+cli::cli_warn("Deprecated: use {.fn newFunction} instead.")
+cli::cli_inform("Loading {.pkg ospsuite}...")
+```
+
+## Global Variables and Constants
+
+- Avoid global variables; if truly needed, discuss with the team first
+- No magic numbers or hardcoded strings — declare constants instead:
+
+```r
+# Bad
+if (percentile > 0.5) { ... }
+
+# Good
+DEFAULT_PERCENTILE <- 0.5
+if (percentile > DEFAULT_PERCENTILE) { ... }
+```
+
+## Cyclomatic Complexity
+
+Keep cyclomatic complexity ≤ 15 per function. Check with:
+
+```r
+cyclocomp::cyclocomp(myFunction)
+cyclocomp::cyclocomp_package("esqlabsR")
+```
+
+If complexity exceeds 15, break the function into smaller pieces.
+
+## Collaboration Workflow
+
+### Branch and PR Rules
+
+1. Every change relates to a GitHub issue
+2. Every change is made on a separate branch
+3. Every change is proposed via a pull request
+4. Every user-visible change is reflected in `NEWS.md`
+5. Every PR is reviewed by at least one other contributor
+6. `{styler}` or `air format .` must be run before opening a PR
+
+### Recommended Workflow
+
+```r
+# Start work
+usethis::pr_init("my-feature-branch")
+
+# ... make changes, commit ...
+
+# Open PR
+usethis::pr_push()
+
+# Pause and switch back to main
+usethis::pr_pause()
+
+# Resume work on an existing PR
+usethis::pr_fetch(123)   # PR number
+
+# Finish after merge
+usethis::pr_finish()
+```
+
+### PR Checklist
+
+Before marking a PR as "ready for review":
+
+- [ ] `air format .` run on all changed files
+- [ ] `devtools::document()` run if roxygen comments changed
+- [ ] `devtools::test()` passes
+- [ ] `NEWS.md` updated for user-visible changes
+- [ ] `_pkgdown.yml` updated if new exported functions added
+- [ ] No commented-out code or debug artifacts

--- a/.claude/skills/r-package-development.md
+++ b/.claude/skills/r-package-development.md
@@ -1,0 +1,74 @@
+---
+name: r-package-development
+description: >
+  R package development with devtools, testthat, and roxygen2. Use when the
+  user is working on an R package, running tests, writing documentation, or
+  building package infrastructure.
+---
+
+# R package development
+
+## Key commands
+
+```
+# Run code in the package
+Rscript -e "devtools::load_all(); code"
+
+# Run all tests
+Rscript -e "devtools::test()"
+
+# Run all tests for files starting with {name}
+Rscript -e "devtools::test(filter = '^{name}')"
+
+# Run all tests for R/{name}.R
+Rscript -e "devtools::test_active_file('R/{name}.R')"
+
+# Run a single test "blah" for R/{name}.R
+Rscript -e "devtools::test_active_file('R/{name}.R', desc = 'blah')"
+
+# Redocument the package
+Rscript -e "devtools::document()"
+
+# Check pkgdown documentation
+Rscript -e "pkgdown::check_pkgdown()"
+
+# Check the package with R CMD check
+Rscript -e "devtools::check()"
+
+# Format code
+air format .
+```
+
+## Coding
+
+* Always run `air format .` after generating code.
+* Use the base pipe operator (`|>`) not the magrittr pipe (`%>`).
+* Use `\() ...` for single-line anonymous functions. For all other cases, use `function() {...}`.
+* Use `<-` for assignment, never `=`.
+* Use `TRUE`/`FALSE`, never `T`/`F`.
+
+## Testing
+
+- Tests for `R/{name}.R` go in `tests/testthat/test-{name}.R`.
+- All new code should have an accompanying test.
+- If there are existing tests, place new tests next to similar existing tests.
+- Strive to keep tests minimal with few comments.
+- Avoid `expect_true()` and `expect_false()` in favour of a specific expectation which will give a better failure message.
+- When testing errors and warnings, don't use `expect_error()` or `expect_warning()`. Instead, use `expect_snapshot(error = TRUE)` for errors and `expect_snapshot()` for warnings because these allow the user to review the full text of the output.
+
+## Documentation
+
+- Every user-facing function should be exported and have roxygen2 documentation.
+- Wrap roxygen comments at 80 characters.
+- Internal functions should use the tag `#' @keywords internal`.
+- Whenever you add a new (non-internal) documentation topic, also add the topic to `_pkgdown.yml`.
+- Always re-document the package after changing a roxygen2 comment.
+- Use `pkgdown::check_pkgdown()` to check that all topics are included in the reference index.
+
+## `NEWS.md`
+
+- Every user-facing change should be given a bullet in `NEWS.md`. Do not add bullets for small documentation changes or internal refactorings.
+- Each bullet should briefly describe the change to the end user and mention the related issue in parentheses.
+- A bullet can consist of multiple sentences but should not contain any new lines (i.e. DO NOT line wrap).
+- If the change is related to a function, put the name of the function early in the bullet.
+- Order bullets alphabetically by function name. Put all bullets that don't mention function names at the beginning.

--- a/.claude/skills/testing-r-packages.md
+++ b/.claude/skills/testing-r-packages.md
@@ -1,0 +1,212 @@
+---
+name: testing-r-packages
+description: >
+  Best practices for writing R package tests using testthat version 3+. Use
+  when writing, organizing, or improving tests for esqlabsR. Covers test
+  structure, expectations, fixtures, snapshots, mocking, and modern testthat 3
+  patterns including self-sufficient tests, proper cleanup with withr, and
+  snapshot testing.
+---
+
+# Testing esqlabsR with testthat
+
+Modern best practices for R package testing using testthat 3+.
+
+## File Organization
+
+**Mirror package structure:**
+- Code in `R/foofy.R` → tests in `tests/testthat/test-foofy.R`
+- Use `usethis::use_r("foofy")` and `usethis::use_test("foofy")` to create paired files
+
+**Special files:**
+- `tests/testthat/setup.R` – Shared test setup (loaded before all tests)
+- `tests/testthat/helper-*.R` – Helper functions and custom expectations
+- `tests/testthat/fixtures/` – Static test data files accessed via `test_path()`
+
+## Test Structure
+
+```r
+test_that("descriptive behavior", {
+  result <- my_function(input)
+  expect_equal(result, expected_value)
+})
+```
+
+Test descriptions should read naturally and describe behavior, not implementation.
+
+## Running Tests
+
+```r
+# Run all tests
+devtools::test()
+
+# Run tests for a specific file
+devtools::test(filter = "^utilities$")
+
+# Run a single test
+devtools::test_active_file("R/utilities.R", desc = "my test name")
+
+# Review snapshot changes
+testthat::snapshot_review()
+
+# Accept snapshot changes
+testthat::snapshot_accept()
+```
+
+## Expectations
+
+### Errors and Warnings — Use Snapshots
+
+Do **not** use `expect_error()` or `expect_warning()` alone. Use snapshots to capture full output:
+
+```r
+# Good
+test_that("validation catches wrong type", {
+  expect_snapshot(error = TRUE, myFunction("wrong_type"))
+})
+
+test_that("function warns about deprecated usage", {
+  expect_snapshot(myFunction(old_arg = TRUE))
+})
+
+# Bad
+test_that("validation catches wrong type", {
+  expect_error(myFunction("wrong_type"))
+})
+```
+
+### Avoid `expect_true()` / `expect_false()`
+
+Prefer specific expectations for better failure messages:
+
+```r
+# Good
+expect_equal(result, 42)
+expect_null(result)
+expect_s3_class(result, "data.frame")
+expect_r6_class(result, "Scenario")
+
+# Bad
+expect_true(result == 42)
+expect_true(is.null(result))
+```
+
+### Common Expectations
+
+```r
+expect_equal(result, expected)          # numeric tolerance by default
+expect_identical(result, expected)      # exact match
+expect_null(result)
+expect_type(result, "list")
+expect_s3_class(result, "data.frame")
+expect_r6_class(result, "MyR6Class")
+expect_length(result, 3)
+expect_named(result, c("x", "y"))
+expect_contains(result, "item")
+expect_in("item", result)
+```
+
+## Design Principles
+
+### Self-Sufficient Tests
+
+Each test should contain all setup, execution, and teardown code:
+
+```r
+# Good: self-contained
+test_that("Scenario initialises correctly", {
+  config <- ScenarioConfiguration$new(...)
+  scenario <- Scenario$new(config)
+  expect_r6_class(scenario, "Scenario")
+})
+
+# Bad: relies on ambient state
+config <- ScenarioConfiguration$new(...)
+test_that("Scenario initialises correctly", {
+  scenario <- Scenario$new(config)  # Where did 'config' come from?
+  expect_r6_class(scenario, "Scenario")
+})
+```
+
+### Cleanup Side Effects with `withr`
+
+```r
+test_that("function respects options", {
+  withr::local_options(my_option = "test_value")
+  withr::local_tempfile()  # auto-cleaned up after test
+
+  result <- my_function()
+  expect_equal(result$setting, "test_value")
+})
+```
+
+**Common withr functions:**
+- `local_options()` – Temporarily set options
+- `local_envvar()` – Temporarily set environment variables
+- `local_tempfile()` / `local_tempdir()` – Temp files with automatic cleanup
+
+### Guard Tests that Require OSPSuite
+
+Tests that require a running OSPSuite environment should be guarded:
+
+```r
+test_that("simulation runs", {
+  skip_if_not(ospsuite:::.isOspsuiteAvailable(), "OSPSuite not available")
+  # ... test code
+})
+```
+
+## Snapshot Testing
+
+For complex output (error messages, print methods, plots), use snapshot tests:
+
+```r
+test_that("print method shows key fields", {
+  config <- ScenarioConfiguration$new(...)
+  expect_snapshot(print(config))
+})
+
+test_that("error message is informative", {
+  expect_snapshot(error = TRUE, Scenario$new(NULL))
+})
+```
+
+Snapshots are stored in `tests/testthat/_snaps/`.
+
+**Workflow:**
+```r
+devtools::test()                     # Creates new snapshots on first run
+testthat::snapshot_review("name")    # Review changes interactively
+testthat::snapshot_accept("name")    # Accept all changes
+```
+
+**Important:** Never accept new snapshots without manual review. If a CI build fails because of snapshot tests, review the new output before accepting.
+
+## Test Fixtures and Data
+
+```r
+# Constructor functions — create test data on-demand
+new_test_scenario_config <- function(...) {
+  ScenarioConfiguration$new(...)
+}
+
+# Temporary files
+test_that("reads Excel input", {
+  temp_file <- withr::local_tempfile(fileext = ".xlsx")
+  writexl::write_xlsx(list(Sheet1 = data.frame(x = 1)), temp_file)
+  result <- readExcelInput(temp_file)
+  expect_s3_class(result, "data.frame")
+})
+
+# Static fixtures — access via test_path()
+data <- readRDS(test_path("fixtures", "my_data.rds"))
+```
+
+## testthat 3 Modernizations
+
+When working with existing tests, prefer modern patterns:
+
+**Deprecated → Modern:**
+- `context()` → Remove (duplicates filename)
+- `expect_equivalent()` → `expect_equal(ignore_attr = TRUE)`
+- `with_mock()` → `local_mocked_bindings()`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,152 @@
+# esqlabsR — Claude Instructions
+
+## Project Overview
+
+`{esqlabsR}` is an R package that facilitates and standardizes the modeling and simulation of physiologically based kinetic (PBK) and quantitative systems pharmacology/toxicology (QSP/T) models implemented in the [Open Systems Pharmacology Software](https://www.open-systems-pharmacology.org/) (OSPS). It extends `{ospsuite}`, `{ospsuite.utils}`, and `{tlf}`.
+
+**Key dependencies:** `{ospsuite}`, `{ospsuite.utils}`, `{tlf}`, `{R6}`, `{ggplot2}`, `{cli}`, `{lifecycle}`
+
+## Development Commands
+
+```bash
+# Load the package for interactive use
+Rscript -e "devtools::load_all()"
+
+# Run all tests
+Rscript -e "devtools::test()"
+
+# Run tests for a specific file (e.g., R/utilities.R)
+Rscript -e "devtools::test(filter = '^utilities$')"
+
+# Re-generate documentation
+Rscript -e "devtools::document()"
+
+# Check the package (R CMD check)
+Rscript -e "devtools::check()"
+
+# Format all R code
+air format .
+
+# Check pkgdown documentation
+Rscript -e "pkgdown::check_pkgdown()"
+```
+
+## Coding Standards
+
+### Naming Conventions
+
+- **Files:** kebab-case with `.R` extension (`scenario-configuration.R`, `test-scenario-configuration.R`)
+- **Variables and functions:** `camelCase` (e.g., `performSimulation`, `parameterToDelete`)
+- **Classes (R6):** PascalCase (e.g., `Scenario`, `ScenarioConfiguration`)
+- **Constants:** `ALL_CAPS` (e.g., `DEFAULT_PERCENTILE`)
+- **Internal functions:** prefix with `.` (e.g., `.runSingleSimulation`)
+- Do **not** use Hungarian notation
+
+### Code Style
+
+- Use `<-` for assignment (never `=`)
+- Indentation: 2 spaces (no tabs)
+- Line length limit: 80 characters
+- Use `TRUE`/`FALSE`, never `T`/`F`
+- Prefer `return()` explicitly, even when optional
+- No trailing semicolons
+- Use `|>` (base pipe), not `%>%` (magrittr pipe)
+- Use `\() ...` for single-line anonymous functions; `function() {...}` for multi-line
+- Run `air format .` after writing any R code
+
+### R6 Classes
+
+- Classes use R6 with `cloneable = FALSE` by default
+- Active bindings enforce read-only properties via `stop(messages$errorPropertyReadOnly(...))`
+- Every class must implement a meaningful `print()` method
+- Private methods are prefixed with `.` (e.g., `$.myPrivateMethod()`)
+- Each class lives in its own file named after the R class in kebab-case
+
+```r
+# Example class structure
+MyClass <- R6::R6Class(
+  "MyClass",
+  cloneable = FALSE,
+  active = list(
+    myProp = function(value) {
+      if (missing(value)) {
+        private$.myProp
+      } else {
+        stop(messages$errorPropertyReadOnly("myProp"))
+      }
+    }
+  ),
+  public = list(
+    initialize = function(...) { ... },
+    print = function(...) {
+      ospsuite.utils::ospPrintClass(self)
+      invisible(self)
+    }
+  ),
+  private = list(
+    .myProp = NULL
+  )
+)
+```
+
+### Documentation
+
+- All exported functions and classes use roxygen2 (`#'`) documentation
+- Wrap roxygen comments at 80 characters
+- Internal-only functions use `#' @keywords internal`
+- Use markdown syntax in roxygen (`**bold**` not `\bold{}`)
+- Reference functions/methods with `()` (e.g., `myFunction()`)
+- Reference package names with `{}` (e.g., `{dplyr}`)
+- Reference variables/objects as inline code (e.g., `myVar`)
+- Add new exported topics to `_pkgdown.yml`
+- Always run `devtools::document()` after changing roxygen comments
+
+### Error Messages
+
+- Error, warning, and informational messages are defined in `R/messages.R` as an `enum`
+- Use `cli::cli_abort()`, `cli::cli_warn()`, and `cli::cli_inform()` for user-facing messages
+- Reference messages via the `messages` enum (e.g., `stop(messages$myError())`)
+
+### `NEWS.md`
+
+- Add a bullet for every user-facing change; skip small documentation fixes and internal refactoring
+- Format: brief description + issue reference in parentheses
+- Keep bullets to a single line (no wrapping)
+- Mention the function name early when relevant
+- Order bullets alphabetically by function name
+
+## Testing
+
+- Tests for `R/{name}.R` go in `tests/testthat/test-{name}.R`
+- All new exported functionality must have tests
+- Use `testthat` edition 3 (`Config/testthat/edition: 3`)
+- Use snapshot testing with `expect_snapshot(error = TRUE)` for errors and warnings
+- Avoid `expect_true()` and `expect_false()`; prefer specific expectations
+- Tests involving `{ospsuite}` simulations may require a running OSPSuite environment; use `testthat::skip_if_not()` guards when necessary
+- Use `withr` for side-effect cleanup (temp files, options, env vars)
+- Snapshot files live in `tests/testthat/_snaps/`
+- When visual output changes, review snapshots with `testthat::snapshot_review()` before accepting
+
+## File Structure
+
+```
+R/
+  {class-name}.R          # R6 class definitions
+  utilities-{topic}.R     # Utility functions for a topic
+  validation-{topic}.R    # Input validation functions
+  messages.R              # All user-facing messages
+  globals.R               # Global variable declarations
+  zzz.R                   # Package load/unload hooks
+tests/testthat/
+  test-{name}.R           # Tests mirroring R/{name}.R
+  setup.R                 # Shared test setup
+```
+
+## Collaboration Workflow
+
+1. Each change must be related to an issue on the repository
+2. Create a separate branch per change (`usethis::pr_init("branch-name")`)
+3. Apply `air format .` before committing
+4. Open a pull request with `usethis::pr_push()`
+5. Every user-visible change needs an entry in `NEWS.md`
+6. Every PR must be reviewed by at least one other contributor before merging


### PR DESCRIPTION
Here is a first test/draft using copilot to set up instructions and skills for Claude.
I used the Agent prompt below if helpful

```md
Setup Claude AI documentation, instructions and skills for esqlabsR repository that are relevant for developing, reviewing and documenting the esqlabsR R package. 
Use relevant skills from posit-dev/skills 
Open-Systems-Pharmacology/developer-docs/ospsuite-r-specifics includes all R best practices and coding standards for esqlabsR that can be used to tune the instructions and skills
```


Copilot PR content

- [x] Create `CLAUDE.md` at the repository root with esqlabsR-specific instructions for Claude AI
- [x] Create `.claude/skills/r-package-development.md` skill adapted from posit-dev/skills
- [x] Create `.claude/skills/testing-r-packages.md` skill adapted from posit-dev/skills
- [x] Create `.claude/skills/ospsuite-r-coding-standards.md` skill based on OSP developer docs
- [x] Add `CLAUDE.md` and `.claude/` to `.Rbuildignore` so they are excluded from the package build