### PR TITLE
Require ospsuite >= 12.4.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ License: GPL-2
 URL: https://github.com/esqLABS/esqlabsR, https://esqlabs.github.io/esqlabsR/
 BugReports: https://github.com/esqLABS/esqlabsR/issues
 Depends:
-    ospsuite (>= 12.2.0),
+    ospsuite (>= 12.4.2),
     R (>= 4.4)
 Imports:
     colorspace,

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,10 +4,13 @@
 
 - Added Excel-based parameter identification (PI) workflow: `readPITaskConfigurationFromExcel()`, `createPITasks()`, and `runPI()` enable defining and running PI tasks from `ParameterIdentification.xlsx`. Supports multi-scenario fitting, parameter grouping, residual scaling, and optional confidence interval estimation. See `vignette("pi-workflow")` (\#928).
 
+## Breaking changes
+
+- Bumped minimum required `ospsuite` version to 12.4.2; earlier versions fail to load data correctly (#1000).
+
 ## Minor improvements and bug fixes
 
 - `snapshotProjectConfiguration()` and `projectConfigurationStatus()` no longer fail on projects that have no PI configuration (i.e. `parameterIdentificationFile` is not set) (#1007).
-- Bumped minimum required `ospsuite` version to 12.4.2; earlier versions fail to load data correctly (#1000).
 
 # esqlabsR 5.6.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 ## Minor improvements and bug fixes
 
 - `snapshotProjectConfiguration()` and `projectConfigurationStatus()` no longer fail on projects that have no PI configuration (i.e. `parameterIdentificationFile` is not set) (#1007).
+- Bumped minimum required `ospsuite` version to 12.4.2; earlier versions fail to load data correctly (#1000).
 
 # esqlabsR 5.6.0
 


### PR DESCRIPTION
## Summary
- Bumps minimum required `ospsuite` from 12.2.0 to 12.4.2 in `DESCRIPTION`. Earlier versions fail to load data correctly (`loadData` does not work).
- Adds a NEWS.md entry under the development version.

Closes #1000

## Test plan
- [ ] CI passes (R CMD check resolves the new minimum)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Raised the minimum required ospsuite dependency to 12.4.2 to ensure proper data loading.

* **Breaking changes**
  * Earlier ospsuite versions may fail to load data correctly; upgrade to 12.4.2 or later.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->