### PR TITLE
test: set expected warning patterns in expect_warning() calls

### DIFF
--- a/tests/testthat/test-create-plots-from-excel.R
+++ b/tests/testthat/test-create-plots-from-excel.R
@@ -1717,11 +1717,21 @@ test_that("It shows a warning when xAxisScale is log and xAxisLimits contain 0",
       )
 
       expect_warning(
-        createPlotsFromExcel(
-          simulatedScenarios = simulatedScenarios,
-          observedData = observedData,
-          projectConfiguration = projectConfigurationLocal,
-          stopIfNotFound = TRUE
+        withCallingHandlers(
+          createPlotsFromExcel(
+            simulatedScenarios = simulatedScenarios,
+            observedData = observedData,
+            projectConfiguration = projectConfigurationLocal,
+            stopIfNotFound = TRUE
+          ),
+          warning = function(w) {
+            if (grepl(
+              "log-10 transformation|Position guide is perpendicular",
+              conditionMessage(w)
+            )) {
+              invokeRestart("muffleWarning")
+            }
+          }
         ),
         regexp = messages$warningLogScaleWithZeroLimit(
           plotID = "P1",
@@ -1759,11 +1769,21 @@ test_that("It shows a warning when yAxisScale is log and yAxisLimits contain 0",
       )
 
       expect_warning(
-        createPlotsFromExcel(
-          simulatedScenarios = simulatedScenarios,
-          observedData = observedData,
-          projectConfiguration = projectConfigurationLocal,
-          stopIfNotFound = TRUE
+        withCallingHandlers(
+          createPlotsFromExcel(
+            simulatedScenarios = simulatedScenarios,
+            observedData = observedData,
+            projectConfiguration = projectConfigurationLocal,
+            stopIfNotFound = TRUE
+          ),
+          warning = function(w) {
+            if (grepl(
+              "log-10 transformation|Position guide is perpendicular",
+              conditionMessage(w)
+            )) {
+              invokeRestart("muffleWarning")
+            }
+          }
         ),
         regexp = messages$warningLogScaleWithZeroLimit(
           plotID = "P1",
@@ -1801,11 +1821,21 @@ test_that("It shows a warning when yAxisScale is log and yValuesLimits contain 0
       )
 
       expect_warning(
-        createPlotsFromExcel(
-          simulatedScenarios = simulatedScenarios,
-          observedData = observedData,
-          projectConfiguration = projectConfigurationLocal,
-          stopIfNotFound = TRUE
+        withCallingHandlers(
+          createPlotsFromExcel(
+            simulatedScenarios = simulatedScenarios,
+            observedData = observedData,
+            projectConfiguration = projectConfigurationLocal,
+            stopIfNotFound = TRUE
+          ),
+          warning = function(w) {
+            if (grepl(
+              "log-10 transformation|Position guide is perpendicular",
+              conditionMessage(w)
+            )) {
+              invokeRestart("muffleWarning")
+            }
+          }
         ),
         regexp = messages$warningLogScaleWithZeroLimit(
           plotID = "P1",

--- a/tests/testthat/test-project-configuration.R
+++ b/tests/testthat/test-project-configuration.R
@@ -6,24 +6,30 @@ test_that("`createProjectConfiguration()` works as expected with project templat
 test_that("A warning is (not) displayed if path/file does not exist", {
   myConfig <- testProjectConfiguration()
   expect_no_warning(myConfig$outputFolder <- "this/directory/does/not/exist")
-  expect_warning(myConfig$dataFolder <- "this/directory/does/not/exist")
+  expect_warning(
+    myConfig$dataFolder <- "this/directory/does/not/exist",
+    "File not found"
+  )
 })
 
 
 test_that("`createDefaultProjectConfiguration()` is deprecated", {
-  expect_warning(createDefaultProjectConfiguration(
-    path = exampleProjectConfigurationPath(),
-    ignoreVersionCheck = TRUE
-  ))
+  expect_warning(
+    createDefaultProjectConfiguration(
+      path = exampleProjectConfigurationPath(),
+      ignoreVersionCheck = TRUE
+    ),
+    "deprecated"
+  )
 })
 
 
 test_that("Project Configuration can be created from V5 project configuration file but raises an error", {
-  expect_error(createProjectConfiguration(test_path(
+  expect_error(suppressWarnings(createProjectConfiguration(test_path(
     "..",
     "data",
     "ProjectConfiguration-V5.xlsx"
-  )))
+  ))))
 })
 
 test_that("Project Configuration can be customized but throws warning if path are wrong", {
@@ -31,50 +37,86 @@ test_that("Project Configuration can be customized but throws warning if path ar
   temp_project <- with_temp_project()
   myConfig <- temp_project$config
 
-  expect_warning({
-    myConfig$configurationsFolder <- "Wrong/Folder"
-  })
+  expect_warning(
+    {
+      myConfig$configurationsFolder <- "Wrong/Folder"
+    },
+    "File not found"
+  )
 
   # Create a new temporary project for each test to avoid interference
   temp_project2 <- with_temp_project()
   myConfig <- temp_project2$config
-  expect_warning({
-    myConfig$dataFolder <- "folder/data/does/not/exist"
-  })
-  expect_warning({
-    myConfig$modelFolder <- "folder/model/does/not/exist"
-  })
-  expect_warning({
-    myConfig$populationsFolder <- "folder/populations/does/not/exist"
-  })
+  expect_warning(
+    {
+      myConfig$dataFolder <- "folder/data/does/not/exist"
+    },
+    "File not found"
+  )
+  expect_warning(
+    {
+      myConfig$modelFolder <- "folder/model/does/not/exist"
+    },
+    "File not found"
+  )
+  expect_warning(
+    {
+      myConfig$populationsFolder <- "folder/populations/does/not/exist"
+    },
+    "File not found"
+  )
 
   # Create a new temporary project for each test to avoid interference
   temp_project3 <- with_temp_project()
   myConfig <- temp_project3$config
-  expect_warning({
-    myConfig$modelParamsFile <- "modelparams_donotexist.xlsx"
-  })
-  expect_warning({
-    myConfig$individualsFile <- "individuals_donotexist.xlsx"
-  })
-  expect_warning({
-    myConfig$populationsFile <- "populations_donotexist.xlsx"
-  })
-  expect_warning({
-    myConfig$scenariosFile <- "scenarios_donotexist.xlsx"
-  })
-  expect_warning({
-    myConfig$applicationsFile <- "applications_donotexist.xlsx"
-  })
-  expect_warning({
-    myConfig$plotsFile <- "plots_donotexist.xlsx"
-  })
-  expect_warning({
-    myConfig$dataFile <- "data_donotexist.xlsx"
-  })
-  expect_warning({
-    myConfig$dataImporterConfigurationFile <- "importer_donotexist.xml"
-  })
+  expect_warning(
+    {
+      myConfig$modelParamsFile <- "modelparams_donotexist.xlsx"
+    },
+    "File not found"
+  )
+  expect_warning(
+    {
+      myConfig$individualsFile <- "individuals_donotexist.xlsx"
+    },
+    "File not found"
+  )
+  expect_warning(
+    {
+      myConfig$populationsFile <- "populations_donotexist.xlsx"
+    },
+    "File not found"
+  )
+  expect_warning(
+    {
+      myConfig$scenariosFile <- "scenarios_donotexist.xlsx"
+    },
+    "File not found"
+  )
+  expect_warning(
+    {
+      myConfig$applicationsFile <- "applications_donotexist.xlsx"
+    },
+    "File not found"
+  )
+  expect_warning(
+    {
+      myConfig$plotsFile <- "plots_donotexist.xlsx"
+    },
+    "File not found"
+  )
+  expect_warning(
+    {
+      myConfig$dataFile <- "data_donotexist.xlsx"
+    },
+    "File not found"
+  )
+  expect_warning(
+    {
+      myConfig$dataImporterConfigurationFile <- "importer_donotexist.xml"
+    },
+    "File not found"
+  )
 })
 
 

--- a/tests/testthat/test-sensitivity-calculation.R
+++ b/tests/testthat/test-sensitivity-calculation.R
@@ -695,7 +695,8 @@ test_that("sensitivityCalculation handles simulation failure", {
         variationRange = c(-1, 2, 10)
       ),
       "Simulation run failed"
-    )
+    ),
+    "with variation factor .* failed"
   )
 
   expect_true(isOfType(resultsSimFailure, "SensitivityCalculation"))
@@ -815,7 +816,8 @@ test_that("sensitivityCalculation handles simulation failure for multiple output
         variationRange = c(-1, 2, 10)
       ),
       "Simulation run failed"
-    )
+    ),
+    "with variation factor .* failed"
   )
 
   expect_identical(nrow(resultsMultipleSimFailure$pkData), 99L)

--- a/tests/testthat/test-utilities-config-json.R
+++ b/tests/testthat/test-utilities-config-json.R
@@ -706,8 +706,10 @@ test_that("modifying ProjectConfiguration after snapshotting affects status chec
 
   # Status check should now warn about modification
 
-  expect_warning(status2 <- projectConfigurationStatus(projectConfig, jsonPath))
-  # The warning is about the object being modified, not necessarily about sync status
+  expect_warning(
+    status2 <- projectConfigurationStatus(projectConfig, jsonPath),
+    "The ProjectConfiguration object has been modified"
+  )
   expect_true(status2$in_sync)
   expect_true(status2$unsaved_changes)
 })


### PR DESCRIPTION
## Summary
- Specify regex patterns for `expect_warning()` calls so unexpected warnings cannot slip through unnoticed.
- For sites where the call also emits unrelated `ggplot2` warnings, muffle those via `withCallingHandlers()` so the testthat assertion only matches the intended package warning.

Closes #545