### PR TITLE
Chapter 2: typed ScenarioData class for parsed Project$scenarios

### DIFF
--- a/R/project-parse.R
+++ b/R/project-parse.R
@@ -48,14 +48,17 @@
   jsonPath <- normalizePath(path, winslash = "/", mustWork = FALSE)
   projectDirPath <- dirname(jsonPath)
 
+  outputPaths <- raw$outputPaths %||% list()
+  scenarios <- .parseScenarios(raw$scenarios, outputPaths)
+
   Project$new(
     schemaVersion = schemaVersion,
     esqlabsRVersion = raw$esqlabsRVersion,
     jsonPath = jsonPath,
     projectDirPath = projectDirPath,
     filePaths = raw$filePaths %||% list(),
-    outputPaths = raw$outputPaths %||% list(),
-    scenarios = raw$scenarios %||% list(),
+    outputPaths = outputPaths,
+    scenarios = scenarios,
     modelParameterSets = raw$modelParameterSets %||% list(),
     individualParameterSets = raw$individualParameterSets %||% list(),
     applicationParameterSets = raw$applicationParameterSets %||% list(),
@@ -65,4 +68,94 @@
     observedData = raw$observedData %||% list(),
     plots = raw$plots
   )
+}
+
+# Internal: parse the JSON `scenarios` array into a named list of
+# `ScenarioData` objects, keyed by scenario name.
+#
+# `scenariosData` is the raw `simplifyVector = FALSE` shape produced by
+# `jsonlite::fromJSON()`: a list of plain named lists. `outputPaths` is
+# the project-level lookup table (named list or named character vector
+# of `id -> literal path`); used to resolve `outputPathIds`.
+#
+# This helper handles only what's needed at parse time: field copies,
+# `simulationType` derivation from `populationId` presence,
+# `simulationTime` string parsing, `steadyStateTime` unit conversion,
+# `outputPathIds` -> literal `outputPaths` resolution. Validation
+# beyond a couple of must-have parse errors is deferred to Chapter 4.
+#
+# @keywords internal
+# @noRd
+.parseScenarios <- function(scenariosData, outputPaths) {
+  if (is.null(scenariosData)) {
+    return(list())
+  }
+
+  result <- list()
+  for (entry in scenariosData) {
+    sc <- ScenarioData$new()
+    sc$scenarioName <- entry$name
+    sc$modelFile <- entry$modelFile
+    sc$applicationProtocol <- entry$applicationProtocol %||% NA
+    sc$individualId <- entry$individualId
+
+    if (!is.null(entry$populationId)) {
+      sc$populationId <- entry$populationId
+      sc$simulationType <- "Population"
+    }
+    if (!is.null(entry$readPopulationFromCSV)) {
+      sc$readPopulationFromCSV <- entry$readPopulationFromCSV
+    }
+    if (!is.null(entry$modelParameterSets)) {
+      sc$modelParameterSets <- unlist(entry$modelParameterSets)
+    }
+    if (!is.null(entry$simulationTime)) {
+      sc$simulationTime <- .parseSimulationTimeIntervals(
+        entry$simulationTime
+      )
+      sc$simulationTimeUnit <- entry$simulationTimeUnit
+    }
+    if (isTRUE(entry$steadyState)) {
+      sc$simulateSteadyState <- TRUE
+    }
+    if (!is.null(entry$steadyStateTime)) {
+      if (is.null(entry$steadyStateTimeUnit)) {
+        stop(
+          "Scenario '",
+          entry$name,
+          "' has 'steadyStateTime' set but ",
+          "'steadyStateTimeUnit' is null. Please specify a unit ",
+          "(e.g. \"min\").",
+          call. = FALSE
+        )
+      }
+      sc$steadyStateTime <- ospsuite::toBaseUnit(
+        quantityOrDimension = ospDimensions$Time,
+        values = entry$steadyStateTime,
+        unit = entry$steadyStateTimeUnit
+      )
+      sc$steadyStateTimeUnit <- entry$steadyStateTimeUnit
+    }
+    if (!is.null(entry$overwriteFormulasInSS)) {
+      sc$overwriteFormulasInSS <- entry$overwriteFormulasInSS
+    }
+
+    if (!is.null(entry$outputPathIds)) {
+      pathIds <- unlist(entry$outputPathIds)
+      unknown <- setdiff(pathIds, names(outputPaths))
+      if (length(unknown) > 0) {
+        stop(
+          "Scenario '",
+          entry$name,
+          "' references unknown outputPathIds: ",
+          paste(unknown, collapse = ", "),
+          call. = FALSE
+        )
+      }
+      sc$outputPaths <- unlist(outputPaths[pathIds], use.names = FALSE)
+    }
+
+    result[[entry$name]] <- sc
+  }
+  result
 }

--- a/R/project-to-json.R
+++ b/R/project-to-json.R
@@ -105,12 +105,106 @@
   .asJsonObject(project$outputPaths)
 }
 
-# JSON array of scenario objects. Will eventually rewrite the scenario's
-# literal `outputPaths` back to `outputPathIds` referencing
-# `project$outputPaths`, and convert `steadyStateTime` back to its declared
-# unit.
+# JSON array of scenario objects. Reverses the parse-time
+# transformations: literal `outputPaths` rebuilt as `outputPathIds`
+# against the project lookup, parsed `simulationTime` rejoined to
+# `"a, b, c; d, e, f"`, base-unit `steadyStateTime` converted back to
+# its declared unit. Field order matches the example fixture so
+# round-trip diffs stay zero-noise.
 .scenariosToJson <- function(project) {
-  project$scenarios
+  scenarios <- project$scenarios
+  if (is.null(scenarios) || length(scenarios) == 0L) {
+    return(list())
+  }
+
+  outputPathsLookup <- unlist(project$outputPaths, use.names = TRUE)
+
+  unname(lapply(scenarios, function(sc) {
+    # Default to `list()` so the JSON output is `[]` when the scenario
+    # has no resolved paths (whether the JSON had `outputPathIds: []`,
+    # omitted the key, or `sc$outputPaths` was set to `NULL`
+    # programmatically). Round-trip preserves array-shape symmetry with
+    # the parser, which collapses absent and empty-array to `NULL`.
+    outputPathIds <- list()
+    if (!is.null(sc$outputPaths)) {
+      idx <- match(sc$outputPaths, outputPathsLookup)
+      if (anyNA(idx)) {
+        unknown <- sc$outputPaths[is.na(idx)]
+        stop(
+          "Scenario '",
+          sc$scenarioName,
+          "' has outputPaths not declared in project$outputPaths: ",
+          paste(unknown, collapse = ", "),
+          call. = FALSE
+        )
+      }
+      outputPathIds <- as.list(names(outputPathsLookup)[idx])
+    }
+
+    simTimeStr <- NULL
+    if (!is.null(sc$simulationTime)) {
+      intervals <- vapply(
+        sc$simulationTime,
+        function(int) paste(int, collapse = ", "),
+        character(1)
+      )
+      simTimeStr <- paste(intervals, collapse = "; ")
+    }
+
+    if (sc$simulateSteadyState && is.null(sc$steadyStateTimeUnit)) {
+      stop(
+        "Scenario '",
+        sc$scenarioName,
+        "' has simulateSteadyState=TRUE but steadyStateTimeUnit is NULL. ",
+        "Set steadyStateTimeUnit (e.g. \"min\") so the value can round-trip.",
+        call. = FALSE
+      )
+    }
+
+    list(
+      name = sc$scenarioName,
+      individualId = sc$individualId,
+      populationId = if (sc$simulationType == "Population") {
+        sc$populationId
+      } else {
+        NULL
+      },
+      readPopulationFromCSV = sc$readPopulationFromCSV,
+      # `as.list(NULL)` -> `list()`; this collapses both "key absent" and
+      # "empty array" in the parsed scenario to JSON `[]`. Matches the
+      # end-state serializer in `json-as-primary-input-v2`.
+      modelParameterSets = as.list(sc$modelParameterSets),
+      applicationProtocol = if (
+        is.null(sc$applicationProtocol) || is.na(sc$applicationProtocol)
+      ) {
+        NULL
+      } else {
+        sc$applicationProtocol
+      },
+      simulationTime = simTimeStr,
+      simulationTimeUnit = sc$simulationTimeUnit,
+      steadyState = sc$simulateSteadyState,
+      steadyStateTime = if (
+        sc$simulateSteadyState && !is.null(sc$steadyStateTimeUnit)
+      ) {
+        ospsuite::toUnit(
+          quantityOrDimension = ospDimensions$Time,
+          values = sc$steadyStateTime,
+          targetUnit = sc$steadyStateTimeUnit
+        )
+      } else {
+        NULL
+      },
+      steadyStateTimeUnit = if (sc$simulateSteadyState) {
+        sc$steadyStateTimeUnit
+      } else {
+        NULL
+      },
+      overwriteFormulasInSS = sc$overwriteFormulasInSS,
+      modelFile = sc$modelFile,
+      outputPathIds = outputPathIds
+    )
+  }))
 }
 
 # JSON object (map of parameter-set name → array of parameter entries).

--- a/R/project.R
+++ b/R/project.R
@@ -75,8 +75,10 @@ Project <- R6::R6Class(
       private$.outputPaths
     },
 
-    #' @field scenarios List of scenario entries. Each entry is a plain named
-    #'   list mirroring the JSON object shape.
+    #' @field scenarios Named list of `ScenarioData` objects, indexed
+    #'   by scenario name. Built by `.parseScenarios()` from the
+    #'   raw JSON `scenarios` array; round-trips back through
+    #'   `.scenariosToJson()`.
     scenarios = function(value) {
       if (!missing(value)) cli::cli_abort("{.field scenarios} is read-only.")
       private$.scenarios
@@ -154,7 +156,8 @@ Project <- R6::R6Class(
     #' @param projectDirPath Absolute path of the source directory, or `NULL`.
     #' @param filePaths Named list of file paths.
     #' @param outputPaths Named list of output-path IDs to paths.
-    #' @param scenarios List of scenario entries.
+    #' @param scenarios Named list of `ScenarioData` objects (typically
+    #'   produced by `.parseScenarios()`), indexed by scenario name.
     #' @param modelParameterSets Named list of model parameter sets.
     #' @param individualParameterSets Named list of individual parameter sets.
     #' @param applicationParameterSets Named list of application parameter sets.

--- a/R/scenario-data.R
+++ b/R/scenario-data.R
@@ -1,0 +1,138 @@
+# ScenarioData (internal, work-in-progress) ----
+#
+# Plain-data scenario class produced by `.parseScenarios()` in
+# `R/project-parse.R`. Holds the typed shape of a JSON scenario entry
+# without any runtime side effects: no Simulation construction, no
+# Population loading, no parameter merging. Construction is by direct
+# field assignment.
+#
+# Transitional name: this class will be renamed to `Scenario` and
+# exported in Chapter 3 (`runscenarios-from-project`), at which point
+# the legacy R6 `Scenario` in `R/scenario.R` is retired. The two
+# coexist briefly because the legacy class is still load-bearing for
+# `runScenarios()` / `createScenarios()` on this branch.
+#
+# This file is intentionally a sibling of `R/scenario.R` rather than
+# replacing it: the legacy file's diff stays at zero in this chapter.
+
+#' @title ScenarioData (internal, transitional)
+#' @docType class
+#' @description Plain-data class holding scenario configuration fields
+#'   parsed from a v2.0 `Project.json`. Does not create or hold ospsuite
+#'   runtime objects.
+#' @format NULL
+#' @keywords internal
+#' @noRd
+ScenarioData <- R6::R6Class(
+  "ScenarioData",
+  cloneable = TRUE,
+  active = list(
+    #' @field asList Returns the current scenario as a plain list of its
+    #'   field values. Read-only. Useful for programmatic inspection and
+    #'   for snapshot-testing the full object shape in one assertion.
+    asList = function(value) {
+      if (!missing(value)) {
+        cli::cli_abort("{.field asList} is read-only")
+      }
+      fieldNames <- setdiff(ls(self), "asList")
+      fieldNames <- fieldNames[
+        !vapply(
+          fieldNames,
+          function(n) is.function(self[[n]]),
+          logical(1)
+        )
+      ]
+      stats::setNames(lapply(fieldNames, function(n) self[[n]]), fieldNames)
+    }
+  ),
+  public = list(
+    #' @field scenarioName Character. Name of the scenario.
+    scenarioName = NULL,
+    #' @field modelFile Character. Name of the `.pkml` model file
+    #'   (relative to the model folder).
+    modelFile = NULL,
+    #' @field applicationProtocol Character or `NA`. Name of the
+    #'   application protocol; `NA` when absent in JSON.
+    applicationProtocol = NULL,
+    #' @field individualId Character. ID referencing
+    #'   `project$individuals`.
+    individualId = NULL,
+    #' @field populationId Character or `NULL`. ID referencing
+    #'   `project$populations`.
+    populationId = NULL,
+    #' @field outputPaths Character vector of literal output paths,
+    #'   resolved at parse time from `outputPathIds`.
+    outputPaths = NULL,
+    #' @field simulationType Character. `"Individual"` or
+    #'   `"Population"`; derived from `populationId` presence.
+    simulationType = "Individual",
+    #' @field readPopulationFromCSV Logical. If `TRUE`, load population
+    #'   from CSV.
+    readPopulationFromCSV = FALSE,
+    #' @field simulateSteadyState Logical. If `TRUE`, run steady-state
+    #'   before the main simulation.
+    simulateSteadyState = FALSE,
+    #' @field simulationTime List of length-3 numeric vectors
+    #'   `c(start, end, resolution)`, parsed from the JSON string.
+    simulationTime = NULL,
+    #' @field simulationTimeUnit Character. Time unit for
+    #'   `simulationTime`, preserved as declared in JSON.
+    simulationTimeUnit = NULL,
+    #' @field steadyStateTime Numeric. Steady-state time **in base
+    #'   unit (minutes)**; converted from the JSON value at parse time.
+    steadyStateTime = 1000,
+    #' @field steadyStateTimeUnit Character. Original unit for
+    #'   `steadyStateTime`, preserved for round-trip serialization.
+    steadyStateTimeUnit = NULL,
+    #' @field overwriteFormulasInSS Logical. Overwrite formula
+    #'   parameters during steady-state.
+    overwriteFormulasInSS = FALSE,
+    #' @field modelParameterSets Character vector. Names of model
+    #'   parameter sets referencing `project$modelParameterSets`,
+    #'   applied in listed order.
+    modelParameterSets = NULL,
+
+    #' @description Create a new ScenarioData. All fields default;
+    #'   the parser populates them by direct assignment.
+    initialize = function() {
+    },
+
+    #' @description Print a one-line-per-field summary.
+    #' @param ... Unused; present for S3 method consistency.
+    print = function(...) {
+      cat("<ScenarioData>", "\n")
+      cat("  Name:           ", self$scenarioName %||% "(none)", "\n")
+      cat("  Model:          ", self$modelFile %||% "(none)", "\n")
+      cat("  Type:           ", self$simulationType, "\n")
+      cat("  Individual:     ", self$individualId %||% "(none)", "\n")
+      if (self$simulationType == "Population") {
+        cat("  Population:     ", self$populationId %||% "(none)", "\n")
+        cat("  CSV Population: ", self$readPopulationFromCSV, "\n")
+      }
+      if (
+        !is.null(self$applicationProtocol) &&
+          !is.na(self$applicationProtocol)
+      ) {
+        cat("  Protocol:       ", self$applicationProtocol, "\n")
+      }
+      if (!is.null(self$modelParameterSets)) {
+        cat(
+          "  Param sets:     ",
+          paste(self$modelParameterSets, collapse = ", "),
+          "\n"
+        )
+      }
+      if (!is.null(self$outputPaths)) {
+        cat("  Output paths:   ", length(self$outputPaths), "path(s)\n")
+      }
+      if (self$simulateSteadyState) {
+        cat(
+          "  Steady state:    TRUE (time=",
+          self$steadyStateTime,
+          "min)\n"
+        )
+      }
+      invisible(self)
+    }
+  )
+)

--- a/inst/extdata/projects/Example/Project.json
+++ b/inst/extdata/projects/Example/Project.json
@@ -58,6 +58,22 @@
       "overwriteFormulasInSS": false,
       "modelFile": "Aciclovir.pkml",
       "outputPathIds": ["Aciclovir_PVB"]
+    },
+    {
+      "name": "Aciclovir_iv_steadystate",
+      "individualId": "Adult_male",
+      "populationId": null,
+      "readPopulationFromCSV": false,
+      "modelParameterSets": ["Global", "Aciclovir"],
+      "applicationProtocol": "Aciclovir_iv_250mg",
+      "simulationTime": "0, 24, 60",
+      "simulationTimeUnit": "h",
+      "steadyState": true,
+      "steadyStateTime": 1,
+      "steadyStateTimeUnit": "h",
+      "overwriteFormulasInSS": false,
+      "modelFile": "Aciclovir.pkml",
+      "outputPathIds": ["Aciclovir_fat_cell", "Aciclovir_PVB"]
     }
   ],
   "modelParameterSets": {

--- a/tests/testthat/_snaps/scenario-data.md
+++ b/tests/testthat/_snaps/scenario-data.md
@@ -1,0 +1,18 @@
+# ScenarioData has the documented field defaults
+
+    list(applicationProtocol = NULL, individualId = NULL, modelFile = NULL, 
+        modelParameterSets = NULL, outputPaths = NULL, overwriteFormulasInSS = FALSE, 
+        populationId = NULL, readPopulationFromCSV = FALSE, scenarioName = NULL, 
+        simulateSteadyState = FALSE, simulationTime = NULL, simulationTimeUnit = NULL, 
+        simulationType = "Individual", steadyStateTime = 1000, steadyStateTimeUnit = NULL)
+
+# .parseScenarios copies basic fields for an individual scenario
+
+    list(applicationProtocol = "Aciclovir_iv_250mg", individualId = "Adult_male", 
+        modelFile = "Aciclovir.pkml", modelParameterSets = c("Global", 
+        "Aciclovir"), outputPaths = "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)", 
+        overwriteFormulasInSS = FALSE, populationId = NULL, readPopulationFromCSV = FALSE, 
+        scenarioName = "Aciclovir_iv", simulateSteadyState = FALSE, 
+        simulationTime = list(c(0, 24, 60)), simulationTimeUnit = "h", 
+        simulationType = "Individual", steadyStateTime = 1000, steadyStateTimeUnit = NULL)
+

--- a/tests/testthat/test-project-parse.R
+++ b/tests/testthat/test-project-parse.R
@@ -47,18 +47,22 @@ test_that(".loadProjectJson() preserves outputPaths as a named list", {
   )
 })
 
-test_that(".loadProjectJson() preserves scenarios as a list of named lists", {
+test_that(".loadProjectJson() parses scenarios into ScenarioData objects keyed by name", {
   project <- esqlabsR:::.loadProjectJson(example_project_json_path())
 
   expect_type(project$scenarios, "list")
-  expect_length(project$scenarios, 2L)
+  expect_length(project$scenarios, 3L)
+  expect_named(
+    project$scenarios,
+    c("Aciclovir_iv", "Aciclovir_iv_population", "Aciclovir_iv_steadystate")
+  )
 
-  first <- project$scenarios[[1L]]
-  expect_identical(first$name, "Aciclovir_iv")
+  first <- project$scenarios[["Aciclovir_iv"]]
+  expect_s3_class(first, "ScenarioData")
+  expect_identical(first$scenarioName, "Aciclovir_iv")
   expect_identical(first$individualId, "Adult_male")
   expect_null(first$populationId)
-  expect_identical(first$modelParameterSets, list("Global", "Aciclovir"))
-  expect_identical(first$outputPathIds, list("Aciclovir_PVB"))
+  expect_identical(first$modelParameterSets, c("Global", "Aciclovir"))
 })
 
 test_that(".loadProjectJson() preserves modelParameterSets as a named list of sets", {
@@ -241,7 +245,7 @@ test_that("Project$print() summarises section counts", {
 
   expect_output(print(project), "<Project>")
   expect_output(print(project), "schema 2.0")
-  expect_output(print(project), "scenarios:\\s+2")
+  expect_output(print(project), "scenarios:\\s+3")
   expect_output(print(project), "individuals:\\s+1")
   expect_output(print(project), "populations:\\s+1")
 })

--- a/tests/testthat/test-project-to-json.R
+++ b/tests/testthat/test-project-to-json.R
@@ -87,7 +87,6 @@ test_that("round-trip is structurally identical for the bundled example", {
   expect_identical(reloaded$esqlabsRVersion, project$esqlabsRVersion)
   expect_identical(reloaded$filePaths, project$filePaths)
   expect_identical(reloaded$outputPaths, project$outputPaths)
-  expect_identical(reloaded$scenarios, project$scenarios)
   expect_identical(
     reloaded$modelParameterSets,
     project$modelParameterSets
@@ -105,17 +104,24 @@ test_that("round-trip is structurally identical for the bundled example", {
   expect_identical(reloaded$applications, project$applications)
   expect_identical(reloaded$observedData, project$observedData)
   expect_identical(reloaded$plots, project$plots)
+
+  # Scenarios are R6 objects; compare via the JSON projection so that
+  # parse(serialize(parse(x))) == parse(x) at the wire-shape level.
+  expect_identical(
+    esqlabsR:::.projectToJson(reloaded)$scenarios,
+    esqlabsR:::.projectToJson(project)$scenarios
+  )
 })
 
 test_that("round-trip preserves length-1 arrays as arrays, not scalars", {
   project <- esqlabsR:::.loadProjectJson(example_project_json_path())
   out <- withr::local_tempfile(fileext = ".json")
   esqlabsR:::.saveProjectJson(project, out)
-  reloaded <- esqlabsR:::.loadProjectJson(out)
 
-  # outputPathIds in the bundled example has one entry; auto_unbox must
+  raw <- jsonlite::fromJSON(out, simplifyVector = FALSE)
+  # outputPathIds for Aciclovir_iv has one entry; auto_unbox must
   # not collapse it to a scalar string.
-  ids <- reloaded$scenarios[[1L]]$outputPathIds
+  ids <- raw$scenarios[[1L]]$outputPathIds
   expect_type(ids, "list")
   expect_length(ids, 1L)
   expect_identical(ids[[1L]], "Aciclovir_PVB")
@@ -125,13 +131,13 @@ test_that("round-trip preserves NULL fields", {
   project <- esqlabsR:::.loadProjectJson(example_project_json_path())
   out <- withr::local_tempfile(fileext = ".json")
   esqlabsR:::.saveProjectJson(project, out)
-  reloaded <- esqlabsR:::.loadProjectJson(out)
 
+  raw <- jsonlite::fromJSON(out, simplifyVector = FALSE)
   # The first scenario has populationId: null and steadyStateTime: null.
   # Without `null = "null"`, jsonlite would drop them; the field would be
   # absent on reload, breaking equality.
-  expect_null(reloaded$scenarios[[1L]]$populationId)
-  expect_null(reloaded$scenarios[[1L]]$steadyStateTime)
+  expect_null(raw$scenarios[[1L]]$populationId)
+  expect_null(raw$scenarios[[1L]]$steadyStateTime)
 })
 
 test_that("empty map sections serialize as JSON objects, not arrays", {
@@ -209,4 +215,103 @@ test_that("empty map sections survive a round-trip as empty named lists", {
     reloaded2$applicationParameterSets,
     reloaded$applicationParameterSets
   )
+})
+
+test_that("round-trip preserves a steady-state scenario including unit conversion", {
+  project <- esqlabsR:::.loadProjectJson(example_project_json_path())
+  out <- withr::local_tempfile(fileext = ".json")
+  esqlabsR:::.saveProjectJson(project, out)
+
+  raw <- jsonlite::fromJSON(out, simplifyVector = FALSE)
+  ss <- Filter(
+    function(s) s$name == "Aciclovir_iv_steadystate",
+    raw$scenarios
+  )[[1L]]
+
+  expect_true(ss$steadyState)
+  # The numeric value must be in the *declared* unit (h), not the base
+  # unit (min); 1 h survives the round-trip exactly.
+  # jsonlite::fromJSON reads whole-number JSON numerics as integer.
+  expect_identical(ss$steadyStateTime, 1L)
+  expect_identical(ss$steadyStateTimeUnit, "h")
+})
+
+test_that("round-trip preserves outputPathIds order", {
+  project <- esqlabsR:::.loadProjectJson(example_project_json_path())
+  out <- withr::local_tempfile(fileext = ".json")
+  esqlabsR:::.saveProjectJson(project, out)
+
+  raw <- jsonlite::fromJSON(out, simplifyVector = FALSE)
+  ss <- Filter(
+    function(s) s$name == "Aciclovir_iv_steadystate",
+    raw$scenarios
+  )[[1L]]
+
+  # JSON declared fat_cell, PVB (non-alphabetical). The order must be
+  # preserved through parse -> serialize.
+  expect_identical(
+    ss$outputPathIds,
+    list("Aciclovir_fat_cell", "Aciclovir_PVB")
+  )
+})
+
+test_that(".scenariosToJson errors when scenario outputPaths are not in project lookup", {
+  project <- esqlabsR:::.loadProjectJson(example_project_json_path())
+  # Mutate the first scenario to have a literal path that the project
+  # does not declare. (Parser would have rejected this, but a Chapter
+  # 7+ programmatic mutation could land us here.)
+  # ScenarioData is R6: grab the reference and mutate the public field
+  # in place so we don't trigger the read-only `scenarios` setter on Project.
+  sc <- project$scenarios[[1L]]
+  sc$outputPaths <- c(sc$outputPaths, "Organism|NotDeclared|Path")
+
+  expect_error(
+    esqlabsR:::.projectToJson(project),
+    "outputPaths not declared.*Organism\\|NotDeclared\\|Path"
+  )
+})
+
+test_that(".scenariosToJson errors when simulateSteadyState is TRUE without a unit", {
+  project <- esqlabsR:::.loadProjectJson(example_project_json_path())
+  # Aciclovir_iv has simulateSteadyState=FALSE and no unit.
+  # Flip the flag without setting the unit — the round-trip cannot
+  # carry the steady-state time, so the serializer must reject it.
+  sc <- project$scenarios[["Aciclovir_iv"]]
+  sc$simulateSteadyState <- TRUE
+
+  expect_error(
+    esqlabsR:::.projectToJson(project),
+    "Aciclovir_iv.*simulateSteadyState=TRUE.*steadyStateTimeUnit"
+  )
+})
+
+test_that("round-trip preserves empty modelParameterSets as a JSON array", {
+  project <- esqlabsR:::.loadProjectJson(example_project_json_path())
+  sc <- project$scenarios[["Aciclovir_iv"]]
+  sc$modelParameterSets <- character(0)
+
+  out <- withr::local_tempfile(fileext = ".json")
+  esqlabsR:::.saveProjectJson(project, out)
+  raw <- jsonlite::fromJSON(out, simplifyVector = FALSE)
+
+  # Empty modelParameterSets must serialise as `[]`, not `null`, so the
+  # JSON shape stays an array.
+  mp <- raw$scenarios[[1L]]$modelParameterSets
+  expect_type(mp, "list")
+  expect_length(mp, 0L)
+})
+
+test_that("round-trip preserves empty outputPathIds as a JSON array", {
+  project <- esqlabsR:::.loadProjectJson(example_project_json_path())
+  sc <- project$scenarios[["Aciclovir_iv"]]
+  sc$outputPaths <- NULL
+
+  out <- withr::local_tempfile(fileext = ".json")
+  esqlabsR:::.saveProjectJson(project, out)
+  raw <- jsonlite::fromJSON(out, simplifyVector = FALSE)
+
+  # Absent / empty outputPaths must serialise as `[]`, not `null`.
+  ids <- raw$scenarios[[1L]]$outputPathIds
+  expect_type(ids, "list")
+  expect_length(ids, 0L)
 })

--- a/tests/testthat/test-scenario-data.R
+++ b/tests/testthat/test-scenario-data.R
@@ -1,0 +1,165 @@
+# Tests for the internal ScenarioData class and the .parseScenarios helper.
+# ScenarioData is the transitional internal name for the plain-data scenario
+# class that Chapter 3 will rename to `Scenario` and export. Both symbols
+# (and the parser) are intentionally unexported, hence `:::`.
+
+example_project_json_path <- function() {
+  system.file(
+    "extdata",
+    "projects",
+    "Example",
+    "Project.json",
+    package = "esqlabsR",
+    mustWork = TRUE
+  )
+}
+
+test_that("ScenarioData has the documented field defaults", {
+  sc <- esqlabsR:::ScenarioData$new()
+
+  expect_s3_class(sc, "ScenarioData")
+  expect_s3_class(sc, "R6")
+  expect_snapshot_value(sc$asList, style = "deparse")
+})
+
+test_that(".parseScenarios returns list() for NULL input", {
+  expect_identical(
+    esqlabsR:::.parseScenarios(NULL, list()),
+    list()
+  )
+})
+
+test_that(".parseScenarios copies basic fields for an individual scenario", {
+  project <- esqlabsR:::.loadProjectJson(example_project_json_path())
+  sc <- project$scenarios[["Aciclovir_iv"]]
+
+  expect_s3_class(sc, "ScenarioData")
+  expect_snapshot_value(sc$asList, style = "deparse")
+})
+
+test_that(".parseScenarios sets simulationType=Population when populationId present", {
+  project <- esqlabsR:::.loadProjectJson(example_project_json_path())
+  sc <- project$scenarios[["Aciclovir_iv_population"]]
+
+  expect_identical(sc$populationId, "European_adults")
+  expect_identical(sc$simulationType, "Population")
+})
+
+test_that(".parseScenarios defaults applicationProtocol to NA when JSON has null", {
+  raw <- list(
+    list(
+      name = "X",
+      individualId = "i",
+      modelFile = "m.pkml",
+      applicationProtocol = NULL
+    )
+  )
+  result <- esqlabsR:::.parseScenarios(raw, list())
+
+  expect_length(result, 1L)
+  expect_true(is.na(result[["X"]]$applicationProtocol))
+})
+
+test_that(".parseScenarios converts steadyStateTime to base units (minutes)", {
+  project <- esqlabsR:::.loadProjectJson(example_project_json_path())
+  sc <- project$scenarios[["Aciclovir_iv_steadystate"]]
+
+  expect_true(sc$simulateSteadyState)
+  # 1 hour -> 60 minutes
+  expect_equal(sc$steadyStateTime, 60)
+  expect_identical(sc$steadyStateTimeUnit, "h")
+})
+
+test_that(".parseScenarios leaves simulateSteadyState=FALSE when JSON omits/sets false", {
+  project <- esqlabsR:::.loadProjectJson(example_project_json_path())
+  sc <- project$scenarios[["Aciclovir_iv"]]
+
+  expect_false(sc$simulateSteadyState)
+  expect_null(sc$steadyStateTimeUnit)
+  # The class default of 1000 stays put when JSON's steadyStateTime is null.
+  expect_identical(sc$steadyStateTime, 1000)
+})
+
+test_that(".parseScenarios errors when steadyStateTime set without unit", {
+  raw <- list(
+    list(
+      name = "BadSS",
+      individualId = "i",
+      modelFile = "m.pkml",
+      steadyStateTime = 5,
+      steadyStateTimeUnit = NULL
+    )
+  )
+  expect_error(
+    esqlabsR:::.parseScenarios(raw, list()),
+    "BadSS.*steadyStateTime.*steadyStateTimeUnit"
+  )
+})
+
+test_that(".parseScenarios parses simulationTime to a list of length-3 numerics", {
+  project <- esqlabsR:::.loadProjectJson(example_project_json_path())
+  sc <- project$scenarios[["Aciclovir_iv"]]
+
+  expect_type(sc$simulationTime, "list")
+  expect_length(sc$simulationTime, 1L)
+  expect_identical(sc$simulationTime[[1L]], c(0, 24, 60))
+  expect_identical(sc$simulationTimeUnit, "h")
+})
+
+test_that(".parseScenarios resolves outputPathIds to literal outputPaths in declared order", {
+  project <- esqlabsR:::.loadProjectJson(example_project_json_path())
+  sc <- project$scenarios[["Aciclovir_iv_steadystate"]]
+
+  expect_type(sc$outputPaths, "character")
+  expect_length(sc$outputPaths, 2L)
+  # Order in JSON is fat_cell, PVB; the literal paths must follow that order.
+  expect_identical(
+    sc$outputPaths,
+    c(
+      "Organism|Fat|Intracellular|Aciclovir|Concentration in container",
+      "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)"
+    )
+  )
+})
+
+test_that(".parseScenarios single outputPathId resolves to a length-1 character vector", {
+  project <- esqlabsR:::.loadProjectJson(example_project_json_path())
+  sc <- project$scenarios[["Aciclovir_iv"]]
+
+  expect_type(sc$outputPaths, "character")
+  expect_length(sc$outputPaths, 1L)
+  expect_identical(
+    sc$outputPaths,
+    "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)"
+  )
+})
+
+test_that(".parseScenarios errors on unknown outputPathIds with the scenario name", {
+  raw <- list(
+    list(
+      name = "BadRefs",
+      individualId = "i",
+      modelFile = "m.pkml",
+      outputPathIds = list("Aciclovir_PVB", "Nope", "AlsoNope")
+    )
+  )
+  outputPaths <- list(Aciclovir_PVB = "Organism|PVB|...")
+
+  expect_error(
+    esqlabsR:::.parseScenarios(raw, outputPaths),
+    "BadRefs.*Nope.*AlsoNope"
+  )
+})
+
+test_that(".parseScenarios leaves outputPaths NULL when JSON omits outputPathIds", {
+  raw <- list(
+    list(
+      name = "NoOutputs",
+      individualId = "i",
+      modelFile = "m.pkml"
+    )
+  )
+  result <- esqlabsR:::.parseScenarios(raw, list())
+
+  expect_null(result[["NoOutputs"]]$outputPaths)
+})


### PR DESCRIPTION
## Summary

Chapter 2 of the JSON-based-project rework. 
Replaces the raw-list-per-scenario shape that Chapter 1's parser produces with a typed plain-data class, wired end-to-end through parse → serialize with round-trip integrity.

- `R/scenario-data.R` — new internal R6 class `ScenarioData` (un-exported). Plain-data only: public mutable fields, no init logic, just a `print()` method. Field list mirrors the end-state `Scenario` exactly (15 fields, including `steadyStateTime` stored in base unit / `steadyStateTimeUnit` preserved for round-trip).
- `R/project-parse.R` — new private helper `.parseScenarios(scenariosData, outputPaths)`. Resolves `outputPathIds` to literal `outputPaths` against the project lookup. Converts `steadyStateTime` to base units via `ospsuite::toBaseUnit(ospDimensions$Time, ...)`. Parses `simulationTime` to a list of length-3 numerics via the existing `.parseSimulationTimeIntervals()`. Errors with the scenario name on missing `steadyStateTimeUnit` or unknown `outputPathIds`. Wired into `.loadProjectJson()`.
- `R/project-to-json.R` — `.scenariosToJson()` becomes a real serializer that reverses every parse-time transformation. Errors symmetrically on (a) literal `outputPaths` not in the project lookup and (b) `simulateSteadyState=TRUE` with `NULL` unit — both are strengthenings over the end-state, which silently drops / silently resets to a 1000-min default on reload. These error paths are unreachable on this branch (parser never produces such states); they guard programmatic mutation paths landing in Chapter 6.
- `R/project.R` — roxygen update on `Project$scenarios` field/param to reflect the new contract. No signature change.
- `inst/extdata/projects/Example/Project.json` — gains a third scenario exercising steady-state with a non-minute unit (`"h"`) and a deliberately non-alphabetical multi-element `outputPathIds` so round-trip tests have something to verify.

## Transitional name

`ScenarioData` is the transitional internal name. Chapter 3 (`runscenarios-from-project`) renames it to `Scenario` and exports it, retiring the legacy R6 `Scenario` in `R/scenario.R`. The two coexist on this branch because the legacy class is still load-bearing for `runScenarios()` / `createScenarios()` until Chapter 3 rewrites them.

