### PR TITLE
Fix sensitivity-module correctness bugs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # esqlabsR (development version)
 
+## Minor improvements and bug fixes
+
+- `isTableFormulasEqual()` now compares every point pair of the two table formulas instead of only the first, and treats two empty tables as equal (previously returned `NULL`) (#1056).
+- `loadSensitivityCalculation()` no longer rejects valid saved results that use per-parameter variation ranges, absolute variation, or that dropped failed runs; the integrity check now counts the actually saved result files (#1056).
+- `sensitivityCalculation()` now restores the simulation's original output selections after the analysis, including when an error occurs, so the supplied simulation is left unchanged (#1056).
+- `sensitivityCalculation()` now errors clearly when `variationType = "absolute"` is used with a parameter whose initial value is 0, instead of silently producing invalid scaling factors (#1056).
+- `sensitivityCalculation()` now aligns baseline values by output path when computing percent change and sensitivity, fixing possible misalignment with multiple output paths (#1056).
+- `sensitivityCalculation()` no longer errors when all runs for a parameter fail; it now warns and omits that parameter from the results (#1056).
+- `sensitivityTornadoPlot()` now matches the `parameterFactor` and its reciprocal against the analysis results with a numerical tolerance, so user supplied reciprocal factors are no longer rejected due to floating point representation (#1056).
+
 # esqlabsR 5.7.0
 
 ## New features

--- a/R/messages.R
+++ b/R/messages.R
@@ -550,6 +550,19 @@ messages$sensitivityAnalysisSimulationFailure <- function(
   )
 }
 
+messages$errorAbsoluteVariationZeroInitialValue <- function(parameterPaths) {
+  cliFormat(
+    "{.code variationType = \"absolute\"} requires a non-zero initial value for every parameter, but the following parameter(s) have an initial value of 0: {.val {paste(parameterPaths, collapse = ', ')}}. Use {.code variationType = \"relative\"} or provide parameters with non-zero initial values."
+  )
+}
+
+messages$warningSensitivityAllRunsFailed <- function(parameterPath) {
+  cliFormat(
+    "All simulation runs failed for {.var {parameterPath}}.
+    No PK parameters could be calculated for this parameter and it will not be included in the sensitivity calculation."
+  )
+}
+
 messages$invalidCustomFunctionParameters <- function(providedParams) {
   cliFormat(
     "The user-defined function must have either {.var x}, {.var y}, or both {.var x} and {.var y} as parameters.

--- a/R/sensitivity-calculation.R
+++ b/R/sensitivity-calculation.R
@@ -20,6 +20,8 @@
 #'   set to `"absolute"`, the values are interpreted as absolute parameter
 #'   values. When set to `"relative"`, the values are interpreted as scaling
 #'   factors relative to the initial parameter values. Default is `"relative"`.
+#'   When `"absolute"`, every parameter must have a non-zero initial value; an
+#'   error is thrown otherwise.
 #' @param pkParameters A vector of names of PK parameters for which the
 #'   sensitivities will be calculated. For a full set of available standard PK
 #'   parameters, run `names(ospsuite::StandardPKParameter)`. By default, the

--- a/R/sensitivity-calculation.R
+++ b/R/sensitivity-calculation.R
@@ -119,8 +119,26 @@ sensitivityCalculation <- function(
   # Normalize variationRange
   variationRange <- .normalizeVariationRange(variationRange, parameterPaths)
 
-  # Store old simulation outputs and set user defined
-  oldOutputSelections <- simulation$outputSelections$allOutputs
+  # Store old simulation outputs and set user defined. The original output
+  # selections are restored on exit (including on error) so the caller's
+  # simulation is left untouched by the sensitivity sweep.
+  oldOutputPaths <- vapply(
+    simulation$outputSelections$allOutputs,
+    function(x) x$path,
+    character(1)
+  )
+  on.exit(
+    {
+      clearOutputs(simulation = simulation)
+      if (length(oldOutputPaths) > 0) {
+        ospsuite::addOutputs(
+          quantitiesOrPaths = oldOutputPaths,
+          simulation = simulation
+        )
+      }
+    },
+    add = TRUE
+  )
   setOutputs(quantitiesOrPaths = outputPaths, simulation = simulation)
 
   # Store initial value for each parameter
@@ -303,16 +321,8 @@ sensitivityCalculation <- function(
     "pkData" = pkData
   )
 
-  # Reset simulation outputs
-  oldOutputSelections <- simulation$outputSelections$allOutputs
-  clearOutputs(simulation = simulation)
-
-  for (outputSelection in oldOutputSelections) {
-    ospsuite::addOutputs(
-      quantitiesOrPaths = outputSelection$path,
-      simulation = simulation
-    )
-  }
+  # Original output selections are restored by the on.exit() handler registered
+  # above.
 
   class(results) <- c("SensitivityCalculation", class(results))
 

--- a/R/sensitivity-tornado-plot.R
+++ b/R/sensitivity-tornado-plot.R
@@ -123,9 +123,21 @@ sensitivityTornadoPlot <- function(
 
   data <- sensitivityCalculation$pkData
 
-  # validate data contains required parameterFactor results
-  parameterFactors <- c(parameterFactor, 1 / parameterFactor)
-  if (!all(parameterFactors %in% data$ParameterFactor)) {
+  # validate data contains required parameterFactor results. Match tolerantly:
+  # a user-typed reciprocal (e.g. 0.3 and 3.333333) is not bit-identical to the
+  # computed 1 / parameterFactor, so resolve the requested factors to the stored
+  # values within a relative tolerance rather than comparing for exact equality.
+  storedFactors <- unique(data$ParameterFactor)
+  requestedFactors <- c(parameterFactor, 1 / parameterFactor)
+  matchedFactors <- storedFactors[purrr::map_lgl(
+    storedFactors,
+    ~ any(.factorsMatch(.x, requestedFactors))
+  )]
+  requestedFound <- purrr::map_lgl(
+    requestedFactors,
+    ~ any(.factorsMatch(.x, storedFactors))
+  )
+  if (!all(requestedFound)) {
     stop(messages$noParameterFactor(data, parameterFactor))
   }
 
@@ -181,10 +193,7 @@ sensitivityTornadoPlot <- function(
     levels = rev(unique(data$ParameterPathLabel))
   )
 
-  data <- dplyr::filter(
-    data,
-    ParameterFactor %in% c(parameterFactor, 1 / parameterFactor)
-  )
+  data <- dplyr::filter(data, ParameterFactor %in% matchedFactors)
 
   # Create list of plots ---------------------------------
 

--- a/R/sensivitity-time-profiles.R
+++ b/R/sensivitity-time-profiles.R
@@ -197,8 +197,6 @@ sensitivityTimeProfiles <- function(
 
   # create plot for each output path
   for (outputPath in names(splitData)) {
-    subsetData <- splitData[[outputPath]]
-
     lsPlots[[outputPath]] <- .createTimeProfiles(
       splitData[[outputPath]],
       defaultPlotConfiguration = customPlotConfiguration

--- a/R/utilities-parameters.R
+++ b/R/utilities-parameters.R
@@ -377,8 +377,13 @@ isTableFormulasEqual <- function(formula1, formula2) {
     point1 <- allPoints1[[i]]
     point2 <- allPoints2[[i]]
 
-    return((point1$x == point2$x) && (point1$y == point2$y))
+    if (!((point1$x == point2$x) && (point1$y == point2$y))) {
+      return(FALSE)
+    }
   }
+
+  # Tables with no points (and tables whose every point pair matched) are equal.
+  return(TRUE)
 }
 
 #' Set the values of parameters in the simulation by path, if the `condition` is

--- a/R/utilities-sensitivity-calculation.R
+++ b/R/utilities-sensitivity-calculation.R
@@ -58,6 +58,18 @@
   parameterPath,
   customOutputFunctions = NULL
 ) {
+  # When every run for this parameter failed, the nesting step in
+  # `sensitivityCalculation()` dropped all results and `simulationResults` is an
+  # empty list. There is nothing to extract, so warn and return an empty frame
+  # with the expected columns rather than erroring downstream in `rename()`.
+  if (length(simulationResults) == 0) {
+    warning(
+      messages$warningSensitivityAllRunsFailed(parameterPath),
+      call. = FALSE
+    )
+    return(.emptyPKDataFrame())
+  }
+
   # calculate standard pkAnalyses
   pkDataList <- userPKDataList <-
     stats::setNames(
@@ -101,7 +113,7 @@
 
   pkData <- .addParameterColumns(pkData, simulationResults, parameterPath)
   pkData <- dplyr::group_by(pkData, ParameterPath, PKParameter) |>
-    dplyr::group_modify(.f = ~ .computePercentChange(.)) |>
+    dplyr::group_modify(.f = ~ .computePercentChange(.x, .y)) |>
     dplyr::ungroup()
 
   pkData <- dplyr::select(pkData, -dplyr::any_of("IndividualId"))
@@ -115,6 +127,31 @@
     dplyr::arrange(ParameterPath, PKParameter, ParameterFactor)
 
   return(pkData)
+}
+
+#' Empty PK parameter data frame
+#'
+#' Returns a zero-row data frame with the columns produced by
+#' `.simulationResultsToPKDataFrame()`, used when every run for a parameter
+#' failed and no PK data can be extracted.
+#'
+#' @keywords internal
+#' @noRd
+.emptyPKDataFrame <- function() {
+  data.frame(
+    OutputPath = character(0),
+    ParameterPath = character(0),
+    ParameterFactor = numeric(0),
+    ParameterValue = numeric(0),
+    ParameterUnit = character(0),
+    ParameterPathUserName = character(0),
+    PKParameter = character(0),
+    PKParameterValue = numeric(0),
+    PKPercentChange = numeric(0),
+    Unit = character(0),
+    SensitivityPKParameter = numeric(0),
+    stringsAsFactors = FALSE
+  )
 }
 
 # dataframe modification helpers ------------------------------
@@ -206,22 +243,27 @@
 #'
 #' @param data A dataframe returned by `pkAnalysesAsDataFrame()` and with
 #'   columns renamed to follow `UpperCamel` case.
+#' @param groupKeys Optional one-row data frame of grouping keys as supplied by
+#'   `dplyr::group_modify()`. `group_modify()` strips the grouping columns
+#'   (`ParameterPath`, `PKParameter`) from `data`, so the keys are read from here
+#'   to give the missing-baseline warning meaningful context. When called
+#'   directly (outside `group_modify()`) the keys are taken from `data` instead.
 #'
 #' @keywords internal
 #' @noRd
-.computePercentChange <- function(data) {
+.computePercentChange <- function(data, groupKeys = NULL) {
   # baseline values with a scaling of 1, i.e. no scaling
   baseDataFrame <- dplyr::filter(data, ParameterFactor == 1.0)
 
   # Handle case where no baseline data (ParameterFactor == 1.0) exists
   if (nrow(baseDataFrame) == 0) {
-    parameterPath <- unique(data$ParameterPath)[1]
-    pkParameter <- unique(data$PKParameter)[1]
+    parameterPath <- groupKeys$ParameterPath %||% unique(data$ParameterPath)
+    pkParameter <- groupKeys$PKParameter %||% unique(data$PKParameter)
 
     warning(
       messages$warningSensitivityPKParameterNotCalculated(
-        parameterPath,
-        pkParameter
+        parameterPath[1],
+        pkParameter[1]
       ),
       call. = FALSE
     )
@@ -235,13 +277,20 @@
     )
   }
 
-  # baseline values for parameters of interest
-  ParameterBaseValue <- baseDataFrame |> dplyr::pull(ParameterValue)
-  PKParameterBaseValue <- baseDataFrame |> dplyr::pull(PKParameterValue)
+  # Join the per-OutputPath baseline values back onto every row so that values
+  # align by OutputPath instead of relying on silent vector recycling, which is
+  # only correct when rows happen to be ordered output-major.
+  baseValues <- baseDataFrame |>
+    dplyr::select(
+      OutputPath,
+      ParameterBaseValue = ParameterValue,
+      PKParameterBaseValue = PKParameterValue
+    )
 
   # add columns with %change and sensitivity
   # reference: https://docs.open-systems-pharmacology.org/shared-tools-and-example-workflows/sensitivity-analysis#mathematical-background
   data |>
+    dplyr::left_join(baseValues, by = "OutputPath") |>
     dplyr::mutate(
       PKPercentChange = ((PKParameterValue - PKParameterBaseValue) /
         PKParameterBaseValue) *
@@ -251,7 +300,8 @@
         PKParameterBaseValue) *
         # p / delta p
         (ParameterBaseValue / (ParameterValue - ParameterBaseValue))
-    )
+    ) |>
+    dplyr::select(-ParameterBaseValue, -PKParameterBaseValue)
 }
 
 #' @keywords internal
@@ -316,6 +366,19 @@
       ParameterPathUserName = names(parameterPath) %||% NA_character_,
     ) |>
     dplyr::mutate(ParameterValue = ParameterValue * ParameterFactor)
+}
+
+#' Match parameter factors within a relative tolerance
+#'
+#' Compares `x` against each value in `y`, returning a logical vector the same
+#' length as `y`. Uses a relative tolerance so that a user-typed reciprocal
+#' (e.g. `3.333333`) matches a computed one (e.g. `1 / 0.3`), which
+#' `dplyr::near()`'s much tighter absolute tolerance would reject.
+#'
+#' @keywords internal
+#' @noRd
+.factorsMatch <- function(x, y, tol = 1e-4) {
+  abs(x - y) <= tol * pmax(abs(x), abs(y), 1)
 }
 
 # variationRange handlers -------------------------------------------------
@@ -401,6 +464,14 @@
   variationType
 ) {
   if (variationType == "absolute") {
+    # Absolute targets are converted to relative scaling factors by dividing by
+    # the initial value. A parameter with an initial value of 0 has no
+    # multiplicative scaling that reaches a non-zero target, so dividing would
+    # silently produce Inf/NaN factors and undiagnosed batch failures. Guard it.
+    zeroInitial <- names(initialValues)[initialValues == 0]
+    if (length(zeroInitial) > 0) {
+      stop(messages$errorAbsoluteVariationZeroInitialValue(zeroInitial))
+    }
     variationRange <- purrr::map2(variationRange, initialValues, ~ .x / .y)
   }
 
@@ -492,45 +563,6 @@
 }
 
 # plotting helpers ------------------------------
-
-#' @name savePlotList
-#' @title Save a list of plots
-#'
-#' @param plotlist A list of plots (ideally form `sensitivityTimeProfiles()` or
-#'   `sensitivitySpiderPlot()`).
-#' @param plot.type A string specifying the prefix for plot filename.
-#' @inheritParams sensitivitySpiderPlot
-#'
-#' @seealso sensitivityTimeProfiles, sensitivitySpiderPlot
-#'
-#' @examples
-#'
-#' # first check out examples for `sensitivityTimeProfiles()` and
-#' # `sensitivitySpiderPlot()`
-#'
-#' @keywords internal
-#' @noRd
-.savePlotList <- function(
-  plotlist,
-  plot.type,
-  outputFolder = "",
-  width = 16,
-  height = 9,
-  dpi = 300
-) {
-  purrr::walk2(
-    .x = plotlist,
-    .y = seq_along(plotlist),
-    .f = ~ ggplot2::ggsave(
-      filename = paste0(outputFolder, plot.type, "OutputPath", .y, ".png"),
-      plot = .x,
-      height = height,
-      width = width,
-      units = "cm",
-      dpi = dpi
-    )
-  )
-}
 
 #' Filter out data not needed for plotting
 #'
@@ -705,10 +737,12 @@ loadSensitivityCalculation <- function(outputDir, simulation = NULL) {
     full.names = TRUE
   )
 
-  variationRange <- unique(sensitivityCalculation$pkData$ParameterFactor)
-  parameterPaths <- sensitivityCalculation$parameterPaths
-
-  expectedCount <- length(parameterPaths) * length(variationRange)
+  # One CSV was written per stored `SimulationResults` object, i.e. one per
+  # (parameter, retained factor) entry in the nested `simulationResults`
+  # structure. This count is robust to per-parameter variation ranges, absolute
+  # variation (factors differ per parameter), and dropped failed runs, all of
+  # which break the naive `parameters * factors` assumption.
+  expectedCount <- sum(lengths(sensitivityCalculation$simulationResults))
   if (length(simResultFiles) != expectedCount) {
     stop(messages$errorCorruptSensitivityCalculation(outputDir))
   }

--- a/man/sensitivityCalculation.Rd
+++ b/man/sensitivityCalculation.Rd
@@ -39,7 +39,9 @@ c(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 2, 3, 4, 5, 6, 7, 8, 9,
 \code{variationRange} are applied as \code{"absolute"} or \code{"relative"} scaling. When
 set to \code{"absolute"}, the values are interpreted as absolute parameter
 values. When set to \code{"relative"}, the values are interpreted as scaling
-factors relative to the initial parameter values. Default is \code{"relative"}.}
+factors relative to the initial parameter values. Default is \code{"relative"}.
+When \code{"absolute"}, every parameter must have a non-zero initial value; an
+error is thrown otherwise.}
 
 \item{pkParameters}{A vector of names of PK parameters for which the
 sensitivities will be calculated. For a full set of available standard PK

--- a/tests/testthat/_snaps/sensitivity-calculation.md
+++ b/tests/testthat/_snaps/sensitivity-calculation.md
@@ -1,3 +1,12 @@
+# sensitivityCalculation errors on absolute variation with zero initial value
+
+    Code
+      sensitivityCalculation(simulation = localSim, outputPaths = outputPaths,
+        parameterPaths = zeroParam, variationRange = c(1, 2), variationType = "absolute")
+    Condition
+      Error in `.transformVariationRange()`:
+      ! `variationType = "absolute"` requires a non-zero initial value for every parameter, but the following parameter(s) have an initial value of 0: "Aciclovir|Lipophilicity". Use `variationType = "relative"` or provide parameters with non-zero initial values.
+
 # sensitivityCalculation PK parameters tidy dataframe is as expected
 
     Code

--- a/tests/testthat/test-sensitivity-calculation.R
+++ b/tests/testthat/test-sensitivity-calculation.R
@@ -388,6 +388,25 @@ test_that("sensitivityCalculation fails with invalid `variationType`", {
   )
 })
 
+test_that("sensitivityCalculation errors on absolute variation with zero initial value", {
+  localSim <- loadSimulation(
+    system.file("extdata", "Aciclovir.pkml", package = "ospsuite")
+  )
+  zeroParam <- "Aciclovir|Lipophilicity"
+  setParameterValuesByPath(zeroParam, 0, localSim)
+
+  expect_snapshot(
+    sensitivityCalculation(
+      simulation = localSim,
+      outputPaths = outputPaths,
+      parameterPaths = zeroParam,
+      variationRange = c(1, 2),
+      variationType = "absolute"
+    ),
+    error = TRUE
+  )
+})
+
 # Check SensitivityCalculation object -------------------------------------
 
 test_that("sensitivityCalculation returns a valid `SensitivityCalculation` object", {

--- a/tests/testthat/test-sensitivity-tornado-plot.R
+++ b/tests/testthat/test-sensitivity-tornado-plot.R
@@ -69,6 +69,44 @@ test_that("sensitivityTornadoPlot errors if parameterFactor is missing in sensit
   )
 })
 
+test_that("sensitivityTornadoPlot matches user-typed reciprocal factors with a tolerance", {
+  # The user typed 0.3 and its (truncated) reciprocal 3.333333 into the
+  # variation range. The requested reciprocal 1 / 0.3 = 3.33333... differs from
+  # the stored 3.333333 by ~3e-7, which exceeds dplyr::near()'s absolute
+  # tolerance: exact and near-equality matching both reject it, but the relative
+  # tolerance in .factorsMatch() resolves it.
+  syntheticCalculation <- structure(
+    list(
+      outputPaths = "OutA",
+      parameterPaths = "P",
+      pkData = data.frame(
+        OutputPath = "OutA",
+        ParameterPath = "P",
+        ParameterFactor = c(0.3, 1.0, 3.333333),
+        ParameterValue = c(1, 2, 3),
+        ParameterUnit = "",
+        ParameterPathUserName = NA_character_,
+        PKParameter = "C_max",
+        PKParameterValue = c(1, 2, 3),
+        PKPercentChange = c(-50, 0, 50),
+        Unit = "",
+        SensitivityPKParameter = c(1, 1, 1),
+        stringsAsFactors = FALSE
+      )
+    ),
+    class = c("SensitivityCalculation", "list")
+  )
+
+  # neither exact nor dplyr::near() matching would resolve the reciprocal
+  expect_false(any(dplyr::near(
+    syntheticCalculation$pkData$ParameterFactor,
+    1 / 0.3
+  )))
+  expect_no_error(
+    sensitivityTornadoPlot(syntheticCalculation, parameterFactor = 0.3)
+  )
+})
+
 # Default plot ------------------------------------------------------------
 
 test_that("sensitivityTornadoPlot creates default plot", {

--- a/tests/testthat/test-utilities-parameters.R
+++ b/tests/testthat/test-utilities-parameters.R
@@ -440,3 +440,25 @@ test_that("exportParametersToXLS creates new sheet when appending to existing fi
     }
   )
 })
+
+# isTableFormulasEqual ----------------------------------------------------
+
+test_that("isTableFormulasEqual compares every point pair, not just the first", {
+  makeTableFormula <- function(xs, ys) {
+    list(allPoints = Map(function(x, y) list(x = x, y = y), xs, ys))
+  }
+
+  identical <- makeTableFormula(c(0, 1, 2), c(0, 10, 20))
+  differAtSecond <- makeTableFormula(c(0, 1, 2), c(0, 99, 20))
+  differentLength <- makeTableFormula(c(0, 1), c(0, 10))
+
+  expect_true(isTableFormulasEqual(identical, identical))
+  # tables that match at point 1 but differ later must not compare as equal
+  expect_false(isTableFormulasEqual(identical, differAtSecond))
+  expect_false(isTableFormulasEqual(identical, differentLength))
+})
+
+test_that("isTableFormulasEqual treats two empty tables as equal", {
+  empty <- list(allPoints = list())
+  expect_true(isTableFormulasEqual(empty, empty))
+})

--- a/tests/testthat/test-utilities-parameters.R
+++ b/tests/testthat/test-utilities-parameters.R
@@ -448,14 +448,14 @@ test_that("isTableFormulasEqual compares every point pair, not just the first", 
     list(allPoints = Map(function(x, y) list(x = x, y = y), xs, ys))
   }
 
-  identical <- makeTableFormula(c(0, 1, 2), c(0, 10, 20))
+  equalFormula <- makeTableFormula(c(0, 1, 2), c(0, 10, 20))
   differAtSecond <- makeTableFormula(c(0, 1, 2), c(0, 99, 20))
   differentLength <- makeTableFormula(c(0, 1), c(0, 10))
 
-  expect_true(isTableFormulasEqual(identical, identical))
+  expect_true(isTableFormulasEqual(equalFormula, equalFormula))
   # tables that match at point 1 but differ later must not compare as equal
-  expect_false(isTableFormulasEqual(identical, differAtSecond))
-  expect_false(isTableFormulasEqual(identical, differentLength))
+  expect_false(isTableFormulasEqual(equalFormula, differAtSecond))
+  expect_false(isTableFormulasEqual(equalFormula, differentLength))
 })
 
 test_that("isTableFormulasEqual treats two empty tables as equal", {

--- a/tests/testthat/test-utilities-sensitivity-calculation.R
+++ b/tests/testthat/test-utilities-sensitivity-calculation.R
@@ -55,6 +55,34 @@ test_that("loadSensitivityCalculation() restores functional results", {
   )
 })
 
+test_that("loadSensitivityCalculation() round-trips per-parameter variationRange", {
+  # Per-parameter ranges yield a different set of factors per parameter, so the
+  # naive `parameters * unique(factors)` count is wrong. The load must accept
+  # the genuinely saved results.
+  set.seed(123)
+  perParamResults <- sensitivityCalculation(
+    simulation = simulation,
+    outputPaths = outputPaths,
+    parameterPaths = parameterPaths[1:2],
+    variationRange = list(c(0.5, 2), c(0.1, 0.5, 5, 10))
+  )
+
+  tempDir <- withr::local_tempdir()
+  saveSensitivityCalculation(
+    perParamResults,
+    outputDir = tempDir,
+    overwrite = TRUE
+  )
+
+  expect_no_error(resultLoaded <- loadSensitivityCalculation(tempDir))
+  expect_s3_class(resultLoaded, "SensitivityCalculation")
+  expect_equal(
+    lengths(resultLoaded$simulationResults),
+    lengths(perParamResults$simulationResults)
+  )
+  expect_equal(resultLoaded$pkData, perParamResults$pkData)
+})
+
 test_that("loadSensitivityCalculation() fails when simulation result file is missing", {
   tempDir <- withr::local_tempdir()
 
@@ -95,8 +123,29 @@ test_that("loadSensitivityCalculation() fails when simulation can't be retrieved
   ))
 })
 
+test_that(".simulationResultsToPKDataFrame() handles a parameter whose runs all failed", {
+  # When every run for a parameter fails, the nesting step drops all results,
+  # leaving an empty named list. The extractor must warn and return a
+  # well-formed empty frame rather than erroring in dplyr::rename().
+  emptyBatch <- stats::setNames(list(), character(0))
+
+  expect_warning(
+    pkData <- .simulationResultsToPKDataFrame(
+      emptyBatch,
+      "SomeParameter",
+      NULL
+    ),
+    messages$warningSensitivityAllRunsFailed("SomeParameter"),
+    fixed = TRUE
+  )
+
+  expect_equal(nrow(pkData), 0L)
+  expect_equal(pkData, .emptyPKDataFrame())
+})
+
 test_that(".computePercentChange() handles missing baseline simulation data", {
   successData <- data.frame(
+    OutputPath = "OutA",
     ParameterPath = "TestPath",
     PKParameter = "C_max",
     ParameterFactor = c(0.5, 1.0, 2.0),
@@ -106,6 +155,7 @@ test_that(".computePercentChange() handles missing baseline simulation data", {
   )
 
   failureData <- data.frame(
+    OutputPath = "OutA",
     ParameterPath = "TestPath",
     PKParameter = "C_max",
     ParameterFactor = c(0.5, 2.0),
@@ -125,4 +175,136 @@ test_that(".computePercentChange() handles missing baseline simulation data", {
   expect_true(all(is.na(resultFailure$PKPercentChange)))
   expect_true(all(is.na(resultFailure$SensitivityPKParameter)))
   expect_equal(nrow(resultFailure), nrow(failureData))
+})
+
+test_that(".computePercentChange() aligns baselines by OutputPath, not by row order", {
+  # Two output paths with different baselines. Rows are interleaved (not ordered
+  # output-major), so silent vector recycling would misalign baselines. The join
+  # on OutputPath must pick each row's own baseline.
+  data <- data.frame(
+    OutputPath = c("OutA", "OutB", "OutA", "OutB"),
+    ParameterPath = "TestPath",
+    PKParameter = "C_max",
+    ParameterFactor = c(1.0, 1.0, 2.0, 2.0),
+    PKParameterValue = c(10, 100, 20, 400),
+    ParameterValue = c(5, 5, 10, 10),
+    stringsAsFactors = FALSE
+  )
+
+  result <- .computePercentChange(data)
+  result <- result[result$ParameterFactor == 2.0, ]
+  result <- result[order(result$OutputPath), ]
+
+  # OutA: (20 - 10) / 10 * 100 = 100; OutB: (400 - 100) / 100 * 100 = 300
+  expect_equal(result$PKPercentChange, c(100, 300))
+})
+
+test_that(".computePercentChange() names the parameter in the missing-baseline warning under group_modify", {
+  # group_modify() strips the grouping columns from .x, so without the group
+  # keys the warning would render with blank ParameterPath / PKParameter.
+  failureData <- data.frame(
+    OutputPath = "OutA",
+    ParameterPath = "TestPath",
+    PKParameter = "C_max",
+    ParameterFactor = c(0.5, 2.0),
+    PKParameterValue = c(10, 30),
+    ParameterValue = c(5, 20),
+    stringsAsFactors = FALSE
+  )
+
+  expect_warning(
+    dplyr::group_by(failureData, ParameterPath, PKParameter) |>
+      dplyr::group_modify(.f = ~ .computePercentChange(.x, .y)) |>
+      dplyr::ungroup(),
+    messages$warningSensitivityPKParameterNotCalculated("TestPath", "C_max"),
+    fixed = TRUE
+  )
+})
+
+test_that(".computePercentChange() integrates correctly under group_modify with multiple OutputPaths", {
+  # Reproduces the production call path: grouped by ParameterPath + PKParameter,
+  # with OutputPath as a non-grouping column, so a group spans both outputs.
+  data <- data.frame(
+    OutputPath = c("OutA", "OutB", "OutA", "OutB"),
+    ParameterPath = "TestPath",
+    PKParameter = "C_max",
+    ParameterFactor = c(1.0, 1.0, 2.0, 2.0),
+    PKParameterValue = c(10, 100, 20, 400),
+    ParameterValue = c(5, 5, 10, 10),
+    stringsAsFactors = FALSE
+  )
+
+  result <- dplyr::group_by(data, ParameterPath, PKParameter) |>
+    dplyr::group_modify(.f = ~ .computePercentChange(.x, .y)) |>
+    dplyr::ungroup()
+  result <- result[result$ParameterFactor == 2.0, ]
+  result <- result[order(result$OutputPath), ]
+
+  expect_equal(result$PKPercentChange, c(100, 300))
+})
+
+# End-to-end through sensitivityCalculation() -----------------------------
+
+test_that("missing-baseline warning carries parameter context through sensitivityCalculation()", {
+  # The issue requires exercising the warning through the real production path,
+  # not the bare helper: group_modify() strips the grouping columns, so the
+  # warning used to render with blank ParameterPath / PKParameter names.
+  localSim <- loadSimulation(
+    system.file("extdata", "Aciclovir.pkml", package = "ospsuite")
+  )
+  parameterPath <- "Aciclovir|Lipophilicity"
+
+  realRunBatches <- runSimulationBatches
+  local_mocked_bindings(
+    runSimulationBatches = function(simulationBatches, ...) {
+      out <- realRunBatches(simulationBatches = simulationBatches, ...)
+      # Drop the baseline (ParameterFactor == 1, sorted first) run so the
+      # percent-change groups have no baseline row.
+      out[[1]][[1]] <- NULL
+      out
+    }
+  )
+
+  warnings <- testthat::capture_warnings(
+    sensitivityCalculation(
+      localSim,
+      outputPaths,
+      parameterPath,
+      variationRange = c(2, 5)
+    )
+  )
+
+  baselineWarnings <- grep("could not be calculated", warnings, value = TRUE)
+  expect_gt(length(baselineWarnings), 0)
+  expect_true(all(grepl(parameterPath, baselineWarnings, fixed = TRUE)))
+})
+
+test_that("sensitivityCalculation() does not error when every run for a parameter fails", {
+  localSim <- loadSimulation(
+    system.file("extdata", "Aciclovir.pkml", package = "ospsuite")
+  )
+  parameterPath <- "Aciclovir|Lipophilicity"
+
+  realRunBatches <- runSimulationBatches
+  local_mocked_bindings(
+    runSimulationBatches = function(simulationBatches, ...) {
+      out <- realRunBatches(simulationBatches = simulationBatches, ...)
+      # Every run for the (single, constant) parameter fails.
+      out[[1]][] <- NULL
+      out
+    }
+  )
+
+  expect_no_error(
+    res <- suppressWarnings(
+      sensitivityCalculation(
+        localSim,
+        outputPaths,
+        parameterPath,
+        variationRange = c(2, 5)
+      )
+    )
+  )
+  expect_s3_class(res, "SensitivityCalculation")
+  expect_equal(nrow(res$pkData), 0L)
 })


### PR DESCRIPTION
This addresses the full-codebase audit findings for the sensitivity module (#1056). An analysis silently mutating the caller's simulation, percent-change baselines misaligning across output paths, absolute variation dividing by zero, a parameter whose runs all fail aborting the whole analysis, a load check rejecting legitimately saved results, table-formula equality comparing only the first point, and tornado factor matching rejecting visually-equal user-typed reciprocals. The module is cleanly decoupled from the Project/Scenario rework, so these fixes land on their own.

## Simulation state and computation

`sensitivityCalculation()` now restores the simulation's original output selections through an `on.exit()` handler, so the caller's simulation is left untouched even when the analysis errors mid-run. Percent change and sensitivity align baseline values with an explicit join on the output path instead of relying on positional vector recycling. `variationType = "absolute"` now errors clearly when any parameter has an initial value of 0 rather than producing `Inf`/`NaN` scaling factors, and a parameter whose runs all fail is dropped with a warning instead of erroring in a downstream rename.

## Load integrity and equality

`loadSensitivityCalculation()` derives the expected result-file count from the saved nested structure, so per-parameter variation ranges, absolute variation, and dropped failed runs are accepted instead of rejected as corrupt. `isTableFormulasEqual()` compares every point pair (not just the first) and returns a logical for empty tables instead of `NULL`.

## Plotting

`sensitivityTornadoPlot()` matches `parameterFactor` and its reciprocal against the stored factors within a relative tolerance, so a user-typed truncated reciprocal (e.g. 0.3 and 3.333333) no longer raises a spurious error. Dead code (`.savePlotList()` and a stranded `subsetData` assignment) is removed.

Closes #1056

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tolerance-based matching for parameter factors in tornado plots to avoid errors from floating‑point precision
  * Restored and preserved simulation output selections after sensitivity runs
  * Corrected table-formula equality checks and output-path alignment in percent-change computations
  * Improved detection/handling when all runs for a parameter fail (warns and omits results)

* **New Features**
  * Clearer error when using absolute variation with zero baseline values

* **Documentation**
  * Clarified behavior of the absolute variation option in sensitivityCalculation docs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->