### PR TITLE
Trim dead validationResult data payload and rename summary keys

### DIFF
--- a/R/validation.R
+++ b/R/validation.R
@@ -22,9 +22,6 @@
 validationResult <- R6::R6Class(
   "validationResult",
   public = list(
-    #' @field data Successfully validated/processed data
-    data = NULL,
-
     #' @field critical_errors List of critical errors (blocking issues)
     critical_errors = list(),
 
@@ -35,7 +32,6 @@ validationResult <- R6::R6Class(
     initialize = function() {
       self$critical_errors <- list()
       self$warnings <- list()
-      self$data <- NULL
     },
 
     #' @description Add a critical error
@@ -66,12 +62,6 @@ validationResult <- R6::R6Class(
       self$warnings <- append(self$warnings, list(warning_entry))
     },
 
-    #' @description Set validated data
-    #' @param data The validated/processed data to store
-    set_data = function(data) {
-      self$data <- data
-    },
-
     #' @description Check if validation passed (no critical errors)
     is_valid = function() {
       length(self$critical_errors) == 0
@@ -99,8 +89,7 @@ validationResult <- R6::R6Class(
       list(
         has_critical_errors = self$has_critical_errors(),
         critical_error_count = length(self$critical_errors),
-        warning_count = length(self$warnings),
-        has_data = !is.null(self$data)
+        warning_count = length(self$warnings)
       )
     }
   )
@@ -826,8 +815,8 @@ validationSummary <- function(validationResults) {
   summary <- list(
     total_critical_errors = 0,
     total_warnings = 0,
-    files_with_errors = character(),
-    files_with_warnings = character()
+    sections_with_errors = character(),
+    sections_with_warnings = character()
   )
 
   for (name in names(validationResults)) {
@@ -836,12 +825,15 @@ validationSummary <- function(validationResults) {
       if (result$has_critical_errors()) {
         summary$total_critical_errors <- summary$total_critical_errors +
           length(result$critical_errors)
-        summary$files_with_errors <- c(summary$files_with_errors, name)
+        summary$sections_with_errors <- c(summary$sections_with_errors, name)
       }
       if (length(result$warnings) > 0) {
         summary$total_warnings <- summary$total_warnings +
           length(result$warnings)
-        summary$files_with_warnings <- c(summary$files_with_warnings, name)
+        summary$sections_with_warnings <- c(
+          summary$sections_with_warnings,
+          name
+        )
       }
     }
   }

--- a/man/validationResult.Rd
+++ b/man/validationResult.Rd
@@ -9,8 +9,6 @@ R6 class for storing validation results
 \section{Public fields}{
   \if{html}{\out{<div class="r6-fields">}}
   \describe{
-    \item{\code{data}}{Successfully validated/processed data}
-
     \item{\code{critical_errors}}{List of critical errors (blocking issues)}
 
     \item{\code{warnings}}{List of warnings (non-blocking issues)}
@@ -23,7 +21,6 @@ R6 class for storing validation results
     \item \href{#method-validationResult-initialize}{\code{validationResult$new()}}
     \item \href{#method-validationResult-add_critical_error}{\code{validationResult$add_critical_error()}}
     \item \href{#method-validationResult-add_warning}{\code{validationResult$add_warning()}}
-    \item \href{#method-validationResult-set_data}{\code{validationResult$set_data()}}
     \item \href{#method-validationResult-is_valid}{\code{validationResult$is_valid()}}
     \item \href{#method-validationResult-has_critical_errors}{\code{validationResult$has_critical_errors()}}
     \item \href{#method-validationResult-get_formatted_messages}{\code{validationResult$get_formatted_messages()}}
@@ -80,25 +77,6 @@ R6 class for storing validation results
       \item{\code{category}}{Warning category (e.g., "Data", "Structure")}
       \item{\code{message}}{Warning message}
       \item{\code{details}}{Optional list with additional details (sheet, row, column)}
-    }
-    \if{html}{\out{</div>}}
-  }
-}
-
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-validationResult-set_data"></a>}}
-\if{latex}{\out{\hypertarget{method-validationResult-set_data}{}}}
-\subsection{\code{validationResult$set_data()}}{
-  Set validated data
-  \subsection{Usage}{
-    \if{html}{\out{<div class="r">}}
-    \preformatted{validationResult$set_data(data)}
-    \if{html}{\out{</div>}}
-  }
-  \subsection{Arguments}{
-    \if{html}{\out{<div class="arguments">}}
-    \describe{
-      \item{\code{data}}{The validated/processed data to store}
     }
     \if{html}{\out{</div>}}
   }

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -12,8 +12,23 @@ test_that("validationResult class works correctly", {
   expect_equal(length(result$warnings), 1)
 
   summary <- result$get_summary()
+  expect_named(
+    summary,
+    c("has_critical_errors", "critical_error_count", "warning_count")
+  )
   expect_equal(summary$critical_error_count, 1)
   expect_equal(summary$warning_count, 1)
+})
+
+test_that("validationResult exposes no dead `data` surface", {
+  result <- validationResult$new()
+
+  # `data`/`set_data()`/`has_data` were removed (#1066): in the JSON-primary
+  # model the parsed Project is the validated payload, nothing populates a
+  # separate one.
+  expect_null(result$data)
+  expect_null(result$set_data)
+  expect_false("has_data" %in% names(result$get_summary()))
 })
 
 test_that("isAnyCriticalErrors detects errors in validation results", {
@@ -72,13 +87,19 @@ test_that("validationSummary correctly counts errors and warnings", {
 
   summary <- validationSummary(validationResults)
 
+  expect_named(
+    summary,
+    c(
+      "total_critical_errors",
+      "total_warnings",
+      "sections_with_errors",
+      "sections_with_warnings"
+    )
+  )
   expect_equal(summary$total_critical_errors, 2)
   expect_equal(summary$total_warnings, 2)
-  expect_equal(length(summary$files_with_errors), 1)
-  expect_equal(length(summary$files_with_warnings), 2)
-  expect_true("scenarios" %in% summary$files_with_errors)
-  expect_true("scenarios" %in% summary$files_with_warnings)
-  expect_true("plots" %in% summary$files_with_warnings)
+  expect_setequal(summary$sections_with_errors, "scenarios")
+  expect_setequal(summary$sections_with_warnings, c("scenarios", "plots"))
 })
 
 test_that("validationSummary handles empty validation results", {
@@ -89,8 +110,8 @@ test_that("validationSummary handles empty validation results", {
 
   expect_equal(summary$total_critical_errors, 0)
   expect_equal(summary$total_warnings, 0)
-  expect_equal(length(summary$files_with_errors), 0)
-  expect_equal(length(summary$files_with_warnings), 0)
+  expect_equal(summary$sections_with_errors, character())
+  expect_equal(summary$sections_with_warnings, character())
 })
 
 test_that("validationResult get_formatted_messages works correctly", {

--- a/vignettes/project-structure.Rmd
+++ b/vignettes/project-structure.Rmd
@@ -151,7 +151,7 @@ validation_results <- validateAllConfigurations(exampleProjectConfigurationPath(
 if (isAnyCriticalErrors(validation_results)) {
   # Get detailed summary
   summary <- validationSummary(validation_results)
-  print(paste("Critical errors found in:", paste(summary$files_with_errors, collapse = ", ")))
+  print(paste("Critical errors found in:", paste(summary$sections_with_errors, collapse = ", ")))
   print(paste("Total critical errors:", summary$total_critical_errors))
 } else {
   print("All validations passed!")


### PR DESCRIPTION
Completes the v6 Validation Result contract by removing a payload that was never populated and renaming the summary keys to match the section-oriented validator model. In the JSON-primary model `validateProject()` takes an already-parsed `Project` and only reports problems against it, so there is no separate validated payload to store; the `data` surface was dead in every caller. This was split out of #1051 (the rest of which lands in #1063) because it is a contract-completion decision rather than one of the reproduced correctness bugs.

This PR is stacked on #1063 (`validation-gaps`), which carries the `validation.R` rewrite this builds on; it should be reviewed and merged after #1063.

## Validation Result

Removes the dead `data` field, the `set_data()` method, and the `has_data` key from `get_summary()` on `validationResult`. None had any caller in `R/`, the tests, or the vignettes.

## Validation summary keys

Renames the `validationSummary()` keys `files_with_errors` / `files_with_warnings` to `sections_with_errors` / `sections_with_warnings`, matching the section-oriented validator model (one Validation Result per section) and the project vocabulary. Updates the two consumers, `vignettes/project-structure.Rmd` and `tests/testthat/test-validation.R`, and adds regression tests pinning both the trimmed `get_summary()` key set and the renamed summary keys.

No `NEWS.md` bullet: the validation framework is new in the 6.0.0 development cycle and has never shipped in a release, so trimming and renaming it is an intra-cycle refinement.

Closes #1066
