### PR TITLE
Bundle simulation.pkml with saved sensitivity calculations (#878)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Minor improvements and bug fixes
 
+- `saveSensitivityCalculation()` now writes the simulation as `simulation.pkml` into the output directory, and `loadSensitivityCalculation()` loads it from there, so a saved sensitivity calculation is self-contained and can be reloaded even when the original simulation file is unavailable (#878).
 - `isTableFormulasEqual()` now compares every point pair of the two table formulas instead of only the first, and treats two empty tables as equal (previously returned `NULL`) (#1056).
 - `loadSensitivityCalculation()` no longer rejects valid saved results that use per-parameter variation ranges, absolute variation, or that dropped failed runs; the integrity check now counts the actually saved result files (#1056).
 - `sensitivityCalculation()` now restores the simulation's original output selections after the analysis, including when an error occurs, so the supplied simulation is left unchanged (#1056).

--- a/R/messages.R
+++ b/R/messages.R
@@ -587,6 +587,13 @@ messages$errorSensitivityCalculationNotFound <- function(path) {
   cliFormat("Sensitivity calculation not found at path {.file {path}}.")
 }
 
+messages$errorNoRetainedSimulationResults <- function() {
+  cliFormat(
+    "The sensitivity calculation contains no simulation results to save.",
+    "All simulation runs appear to have failed."
+  )
+}
+
 messages$errorOutputDirExists <- function(outputDir) {
   cliFormat(
     "Directory {.file {outputDir}} already exists.",

--- a/R/utilities-sensitivity-calculation.R
+++ b/R/utilities-sensitivity-calculation.R
@@ -599,7 +599,9 @@
 #'
 #' Saves the results of a sensitivity analysis to a specified directory,
 #' including metadata and simulation output required for restoring or sharing
-#' the analysis.
+#' the analysis. The underlying simulation is written to `simulation.pkml` in the
+#' same directory so the saved calculation is self-contained and can be reloaded
+#' without access to the original simulation file.
 #'
 #' @param sensitivityCalculation A named list of class `SensitivityCalculation`
 #'   as returned by [sensitivityCalculation()], containing `simulationResults`,
@@ -657,8 +659,17 @@ saveSensitivityCalculation <- function(
   simulationResults <- sensitivityCalculation$simulationResults
 
   # Store the simulation source path so it can be reloaded later
-  simFilePath <- simulationResults[[1]][[1]]$simulation$sourceFile
+  simulation <- simulationResults[[1]][[1]]$simulation
+  simFilePath <- simulation$sourceFile
   sensitivityCalculation$simFilePath <- simFilePath
+
+  # Save the simulation itself into the output folder so the saved calculation
+  # is self-contained and can be reloaded even when the original source file is
+  # unavailable (e.g. moved, renamed, or the folder shared with another user).
+  ospsuite::saveSimulation(
+    simulation = simulation,
+    filePath = file.path(outputDir, "simulation.pkml")
+  )
 
   # Export each SimulationResults object to CSV
   for (i in seq_along(simulationResults)) {
@@ -688,13 +699,15 @@ saveSensitivityCalculation <- function(
 #'
 #' Restores a previously saved sensitivity calculation from a directory created
 #' with [saveSensitivityCalculation()]. If no simulation object is provided, the
-#' function attempts to load it from the saved simulation file path.
+#' function loads the `simulation.pkml` bundled in the directory, falling back to
+#' the simulation file path stored in the metadata for folders saved before the
+#' pkml was bundled.
 #'
 #' @param outputDir Path to the directory containing the saved sensitivity
 #'   calculation files.
 #' @param simulation Optional. A `Simulation` object. If not provided, the
-#'   function will attempt to load the simulation from the path stored in the
-#'   metadata.
+#'   function loads the `simulation.pkml` bundled in `outputDir`, or, if absent,
+#'   the simulation stored at the source path recorded in the metadata.
 #'
 #' @return A named list of class `SensitivityCalculation`.
 #'
@@ -717,17 +730,24 @@ loadSensitivityCalculation <- function(outputDir, simulation = NULL) {
   # Load sensitivityCalculation structure
   sensitivityCalculation <- readRDS(metaPath)
 
-  # Attempt to load simulation if not provided
+  # Resolve the simulation if not provided explicitly. Prefer the pkml bundled
+  # in `outputDir` (self-contained, portable) and fall back to the source path
+  # stored in the metadata for folders saved before the pkml was bundled.
   if (is.null(simulation)) {
-    simFilePath <- sensitivityCalculation$simFilePath
-    simulation <- tryCatch(
-      {
-        ospsuite::loadSimulation(simFilePath)
-      },
-      error = function(e) {
-        stop(messages$errorFailedToLoadSimulation(simFilePath, e$message))
-      }
-    )
+    bundledSimPath <- file.path(outputDir, "simulation.pkml")
+    if (file.exists(bundledSimPath)) {
+      simulation <- ospsuite::loadSimulation(bundledSimPath)
+    } else {
+      simFilePath <- sensitivityCalculation$simFilePath
+      simulation <- tryCatch(
+        {
+          ospsuite::loadSimulation(simFilePath)
+        },
+        error = function(e) {
+          stop(messages$errorFailedToLoadSimulation(simFilePath, e$message))
+        }
+      )
+    }
   }
 
   # Locate simulation result files

--- a/R/utilities-sensitivity-calculation.R
+++ b/R/utilities-sensitivity-calculation.R
@@ -595,6 +595,29 @@
 
 # save / load SensitivityCalculation ------------
 
+#' Simulation of the first retained `SimulationResults`
+#'
+#' The nested `simulationResults` structure drops entries whose runs all failed,
+#' so individual per-parameter buckets (and their factor entries) may be empty.
+#' Returns the `Simulation` of the first retained result, scanning across
+#' parameters and factors, rather than assuming `[[1]][[1]]` exists.
+#'
+#' @param simulationResults The nested `simulationResults` list from a
+#'   `SensitivityCalculation`.
+#'
+#' @keywords internal
+#' @noRd
+.firstRetainedSimulation <- function(simulationResults) {
+  for (parameterResults in simulationResults) {
+    for (simulationResult in parameterResults) {
+      if (!is.null(simulationResult)) {
+        return(simulationResult$simulation)
+      }
+    }
+  }
+  stop(messages$errorNoRetainedSimulationResults())
+}
+
 #' Save Sensitivity Calculation Results
 #'
 #' Saves the results of a sensitivity analysis to a specified directory,
@@ -658,8 +681,10 @@ saveSensitivityCalculation <- function(
 
   simulationResults <- sensitivityCalculation$simulationResults
 
-  # Store the simulation source path so it can be reloaded later
-  simulation <- simulationResults[[1]][[1]]$simulation
+  # Store the simulation source path so it can be reloaded later. The first
+  # parameter bucket can be empty when all of its runs failed, so locate the
+  # first retained result rather than assuming `[[1]][[1]]` exists.
+  simulation <- .firstRetainedSimulation(simulationResults)
   simFilePath <- simulation$sourceFile
   sensitivityCalculation$simFilePath <- simFilePath
 
@@ -732,22 +757,24 @@ loadSensitivityCalculation <- function(outputDir, simulation = NULL) {
 
   # Resolve the simulation if not provided explicitly. Prefer the pkml bundled
   # in `outputDir` (self-contained, portable) and fall back to the source path
-  # stored in the metadata for folders saved before the pkml was bundled.
+  # stored in the metadata for folders saved before the pkml was bundled. Both
+  # sources share the same error handling so callers get a consistent,
+  # actionable message when loading fails (e.g. a corrupt bundled pkml).
   if (is.null(simulation)) {
     bundledSimPath <- file.path(outputDir, "simulation.pkml")
-    if (file.exists(bundledSimPath)) {
-      simulation <- ospsuite::loadSimulation(bundledSimPath)
+    simSource <- if (file.exists(bundledSimPath)) {
+      bundledSimPath
     } else {
-      simFilePath <- sensitivityCalculation$simFilePath
-      simulation <- tryCatch(
-        {
-          ospsuite::loadSimulation(simFilePath)
-        },
-        error = function(e) {
-          stop(messages$errorFailedToLoadSimulation(simFilePath, e$message))
-        }
-      )
+      sensitivityCalculation$simFilePath
     }
+    simulation <- tryCatch(
+      {
+        ospsuite::loadSimulation(simSource)
+      },
+      error = function(e) {
+        stop(messages$errorFailedToLoadSimulation(simSource, e$message))
+      }
+    )
   }
 
   # Locate simulation result files

--- a/man/loadSensitivityCalculation.Rd
+++ b/man/loadSensitivityCalculation.Rd
@@ -11,8 +11,8 @@ loadSensitivityCalculation(outputDir, simulation = NULL)
 calculation files.}
 
 \item{simulation}{Optional. A \code{Simulation} object. If not provided, the
-function will attempt to load the simulation from the path stored in the
-metadata.}
+function loads the \code{simulation.pkml} bundled in \code{outputDir}, or, if absent,
+the simulation stored at the source path recorded in the metadata.}
 }
 \value{
 A named list of class \code{SensitivityCalculation}.
@@ -20,7 +20,9 @@ A named list of class \code{SensitivityCalculation}.
 \description{
 Restores a previously saved sensitivity calculation from a directory created
 with \code{\link[=saveSensitivityCalculation]{saveSensitivityCalculation()}}. If no simulation object is provided, the
-function attempts to load it from the saved simulation file path.
+function loads the \code{simulation.pkml} bundled in the directory, falling back to
+the simulation file path stored in the metadata for folders saved before the
+pkml was bundled.
 }
 \examples{
 \dontrun{

--- a/man/saveSensitivityCalculation.Rd
+++ b/man/saveSensitivityCalculation.Rd
@@ -28,7 +28,9 @@ folder.
 \description{
 Saves the results of a sensitivity analysis to a specified directory,
 including metadata and simulation output required for restoring or sharing
-the analysis.
+the analysis. The underlying simulation is written to \code{simulation.pkml} in the
+same directory so the saved calculation is self-contained and can be reloaded
+without access to the original simulation file.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-utilities-sensitivity-calculation.R
+++ b/tests/testthat/test-utilities-sensitivity-calculation.R
@@ -25,9 +25,11 @@ test_that("saveSensitivityCalculation() writes files and respects overwrite flag
     saveSensitivityCalculation(results, outputDir = tempDir, overwrite = TRUE)
   )
 
+  # One CSV per (parameter, factor), plus the metadata file and the bundled
+  # simulation.pkml.
   expect_length(
     list.files(tempDir),
-    (length(variationRange) + 1) * length(parameterPaths) + 1
+    (length(variationRange) + 1) * length(parameterPaths) + 2
   )
 
   # Save again without overwrite should fail
@@ -107,6 +109,10 @@ test_that("loadSensitivityCalculation() fails when simulation can't be retrieved
 
   saveSensitivityCalculation(results, outputDir = tempDir, overwrite = TRUE)
 
+  # Remove the bundled pkml so the source-path fallback is exercised, then point
+  # it at a non-existent file.
+  file.remove(file.path(tempDir, "simulation.pkml"))
+
   metaPath <- file.path(tempDir, "sensitivityCalculation.meta")
   meta <- readRDS(metaPath)
   meta$simFilePath <- tempfile(fileext = ".pkml")
@@ -121,6 +127,42 @@ test_that("loadSensitivityCalculation() fails when simulation can't be retrieved
     conditionMessage(err),
     messages$errorFailedToLoadSimulation(meta$simFilePath, "")
   ))
+})
+
+test_that("saveSensitivityCalculation() writes the simulation as simulation.pkml", {
+  tempDir <- withr::local_tempdir()
+
+  saveSensitivityCalculation(results, outputDir = tempDir, overwrite = TRUE)
+
+  expect_true(file.exists(file.path(tempDir, "simulation.pkml")))
+})
+
+test_that("loadSensitivityCalculation() uses the bundled simulation.pkml when the source path is invalid", {
+  # The saved folder must be self-contained: loading has to succeed from the
+  # bundled pkml even when the original source file is gone (moved/renamed or
+  # the folder was shared with another machine).
+  tempDir <- withr::local_tempdir()
+  saveSensitivityCalculation(results, outputDir = tempDir, overwrite = TRUE)
+
+  metaPath <- file.path(tempDir, "sensitivityCalculation.meta")
+  meta <- readRDS(metaPath)
+  meta$simFilePath <- tempfile(fileext = ".pkml")
+  saveRDS(meta, metaPath)
+
+  expect_no_error(resultLoaded <- loadSensitivityCalculation(tempDir))
+  expect_s3_class(resultLoaded, "SensitivityCalculation")
+})
+
+test_that("loadSensitivityCalculation() falls back to simFilePath when no bundled pkml is present", {
+  # Backward compatibility with folders saved before the pkml was bundled: the
+  # stored source path must still be used when simulation.pkml is absent.
+  tempDir <- withr::local_tempdir()
+  saveSensitivityCalculation(results, outputDir = tempDir, overwrite = TRUE)
+
+  file.remove(file.path(tempDir, "simulation.pkml"))
+
+  expect_no_error(resultLoaded <- loadSensitivityCalculation(tempDir))
+  expect_s3_class(resultLoaded, "SensitivityCalculation")
 })
 
 test_that(".simulationResultsToPKDataFrame() handles a parameter whose runs all failed", {

--- a/tests/testthat/test-utilities-sensitivity-calculation.R
+++ b/tests/testthat/test-utilities-sensitivity-calculation.R
@@ -159,10 +159,46 @@ test_that("loadSensitivityCalculation() falls back to simFilePath when no bundle
   tempDir <- withr::local_tempdir()
   saveSensitivityCalculation(results, outputDir = tempDir, overwrite = TRUE)
 
-  file.remove(file.path(tempDir, "simulation.pkml"))
+  # Assert removal so the test genuinely exercises the fallback rather than
+  # silently loading the still-present bundled pkml.
+  expect_true(file.remove(file.path(tempDir, "simulation.pkml")))
 
   expect_no_error(resultLoaded <- loadSensitivityCalculation(tempDir))
   expect_s3_class(resultLoaded, "SensitivityCalculation")
+})
+
+test_that("loadSensitivityCalculation() reports a clear error when the bundled pkml is corrupt", {
+  # A corrupt bundled pkml must surface the same actionable error as a failing
+  # source-path fallback, not an unwrapped low-level error.
+  tempDir <- withr::local_tempdir()
+  saveSensitivityCalculation(results, outputDir = tempDir, overwrite = TRUE)
+
+  bundledSimPath <- file.path(tempDir, "simulation.pkml")
+  writeLines("not a valid pkml", bundledSimPath)
+
+  err <- expect_error(loadSensitivityCalculation(tempDir), class = "error")
+  expect_true(startsWith(
+    conditionMessage(err),
+    messages$errorFailedToLoadSimulation(bundledSimPath, "")
+  ))
+})
+
+test_that("saveSensitivityCalculation() succeeds when the first parameter's runs all failed", {
+  # When every run for the first parameter fails, its bucket is dropped and
+  # `simulationResults[[1]]` is empty, so the simulation must be located by
+  # scanning for the first retained result rather than indexing [[1]][[1]].
+  resultsFirstFailed <- results
+  resultsFirstFailed$simulationResults[[1]] <- list()
+
+  tempDir <- withr::local_tempdir()
+  expect_no_error(
+    saveSensitivityCalculation(
+      resultsFirstFailed,
+      outputDir = tempDir,
+      overwrite = TRUE
+    )
+  )
+  expect_true(file.exists(file.path(tempDir, "simulation.pkml")))
 })
 
 test_that(".simulationResultsToPKDataFrame() handles a parameter whose runs all failed", {


### PR DESCRIPTION
## Summary

Closes #878.

`saveSensitivityCalculation()` previously stored only the simulation's original `sourceFile` **path** in the metadata. On load, `loadSensitivityCalculation()` reloaded the simulation from that path — which breaks whenever the original `.pkml` was moved, renamed, or the saved folder was shared with another user/machine.

This PR makes a saved sensitivity calculation **self-contained and portable**:

- **`saveSensitivityCalculation()`** now writes the simulation as `simulation.pkml` into the output directory (alongside the results CSVs and metadata).
- **`loadSensitivityCalculation()`** resolves the simulation in priority order:
  1. an explicitly passed `simulation` argument,
  2. the bundled `simulation.pkml` in the folder,
  3. the source path stored in the metadata (backward compatible with folders saved before this change).

The base `simulation` object is left in its original state by `sensitivityCalculation()` (output selections are restored via `on.exit()` and batch run values are applied transiently), so the bundled `.pkml` is equivalent to re-saving the original source file.

## Tests

- `simulation.pkml` is written into the output dir on save.
- Load resolves from the bundled `.pkml` even when the stored source path is invalid.
- Backward compatibility: a folder without `simulation.pkml` still loads via the stored source path.
- Updated the existing file-count assertion (+1 for the bundled pkml) and the "simulation can't be retrieved" test (removes the bundled pkml so the fallback failure is still exercised).

All tests in `test-utilities-sensitivity-calculation.R` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Saved sensitivity calculations now include a bundled `simulation.pkml` in the output folder, making results fully reloadable later.
* **Bug Fixes**
  * Reloading sensitivity calculations now prefers the bundled simulation file and falls back to the original recorded simulation path when needed.
  * Improved error messaging when no retained simulation results are available.
* **Documentation**
  * Updated help text for both saving and loading to reflect the new bundled `simulation.pkml` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->