### PR TITLE
Persistence engine: entity-file tree + id canonicalization

### DIFF
--- a/R/applications.R
+++ b/R/applications.R
@@ -1,8 +1,198 @@
 # Applications: parse + mutation API for the `applications` and
-# `applicationParameterSets` sections.
+# `parameterSets` references on applications.
 
-# Parse ----
+# Print ----
+
+#' @exportS3Method
+#' @noRd
+print.Application <- function(x, ...) {
+  ospsuite.utils::ospPrintClass(x)
+  ospsuite.utils::ospPrintItems(
+    list(
+      "Parameter Sets" = paste(x$parameterSets, collapse = ", ")
+    ),
+    print_empty = TRUE
+  )
+  invisible(x)
+}
+
+# Public CRUD: applications ----
+
+#' Add one or more application protocols to a Project
+#'
+#' Add protocols to `project$applications`, vectorizing over a vector of ids
+#' (see the recycling rule under Details). `parameterSets` is
+#' vector-valued-per-entity: it is applied whole to every protocol; to give a
+#' different set per protocol, pass a list of the same length as `id` (one
+#' character vector per protocol).
+#'
+#' @inherit vectorizedAuthoring details
+#'
+#' @param project A `Project` object.
+#' @param id Character vector of unique protocol ids (the number of protocols
+#'   to add). Each is canonicalized to a safe, lowercase id (a warning names
+#'   the result if it changed).
+#' @param parameterSets Optional character vector of set ids referencing
+#'   `project$parameterSets`, applied whole to every protocol. Defaults to
+#'   `NULL`. Use a list of the same length as `id` for a per-protocol set.
+#' @returns The `project` object, invisibly.
+#' @export
+#' @family application
+addApplication <- function(project, id, parameterSets = NULL) {
+  validateIsOfType(project, "Project")
+  .assertIdVector(id)
+  id <- .canonicalizeId(id)
+  n <- length(id)
+  perId <- .wholeField(parameterSets, n)
+
+  clash <- intersect(id, names(project$applications))
+  if (length(clash) > 0L) {
+    cli::cli_abort("application {.val {clash}} already exists")
+  }
+  call <- rlang::current_env()
+  apps <- .collectCanonicalizedRefs(lapply(seq_len(n), function(i) {
+    .buildApplicationEntry(project, perId[[i]], call = call)
+  }))
+
+  applications <- project$.getSection("applications") %||% list()
+  for (i in seq_len(n)) {
+    applications[[id[[i]]]] <- apps[[i]]
+  }
+  project$.setSection("applications", applications)
+  invisible(project)
+}
+
+#' Remove one or more application protocols from a Project
+#'
+#' Drop the protocols with matching ids in one write-through. Warns (and
+#' skips) any id not present, and warns when a removed protocol is still
+#' referenced.
+#'
+#' @param project A `Project` object.
+#' @param id Character vector of application ids to remove. Each is
+#'   canonicalized the same way [addApplication()] canonicalizes it.
+#' @returns The `project` object, invisibly.
+#' @export
+#' @family application
+removeApplication <- function(project, id) {
+  validateIsOfType(project, "Project")
+  .assertIdVector(id)
+  id <- .canonicalizeId(id)
+
+  missingIds <- setdiff(id, names(project$applications))
+  if (length(missingIds) > 0L) {
+    cli::cli_warn("application {.val {missingIds}} not found; no-op.")
+  }
+  toRemove <- intersect(id, names(project$applications))
+  if (length(toRemove) == 0L) {
+    return(invisible(project))
+  }
+  for (one in toRemove) {
+    .warnIfReferenced(project, "application", one)
+  }
+  applications <- project$.getSection("applications")
+  applications[toRemove] <- NULL
+  project$.setSection("applications", applications)
+  invisible(project)
+}
+
+#' Replace the parameter-set references on one or more applications
+#'
+#' @inherit vectorizedAuthoring details
+#'
+#' @param project A `Project` object.
+#' @param id Character vector of application ids. Each is canonicalized the
+#'   same way [addApplication()] canonicalizes it.
+#' @param parameterSets Character vector of set ids (from
+#'   `project$parameterSets`), applied whole to every application; use
+#'   `character(0)` to clear. To set a different list per application, pass a
+#'   list of the same length as `id` (one character vector per application).
+#' @returns The `project` object, invisibly.
+#' @export
+#' @family application
+setApplicationParameterSets <- function(
+  project,
+  id,
+  parameterSets
+) {
+  validateIsOfType(project, "Project")
+  .assertIdVector(id)
+  id <- .canonicalizeId(id)
+  n <- length(id)
+  missingIds <- setdiff(id, names(project$applications))
+  if (length(missingIds) > 0L) {
+    cli::cli_abort("application {.val {missingIds}} not found")
+  }
+  perId <- .wholeField(parameterSets, n)
+
+  call <- rlang::current_env()
+  resolved <- .collectCanonicalizedRefs(lapply(seq_len(n), function(i) {
+    sets <- perId[[i]]
+    if (!is.character(sets)) {
+      cli::cli_abort(
+        "{.arg parameterSets} must be a character vector",
+        call = call
+      )
+    }
+    sets <- .canonicalizeIdRef(sets)
+    bad <- setdiff(sets, names(project$parameterSets %||% list()))
+    if (length(bad) > 0L) {
+      cli::cli_abort(
+        c(
+          "{.arg parameterSets} references undefined parameter sets:",
+          "x" = "{.val {bad}}"
+        ),
+        call = call
+      )
+    }
+    sets
+  }))
+
+  applications <- project$.getSection("applications")
+  for (i in seq_len(n)) {
+    applications[[id[[i]]]]$parameterSets <- resolved[[i]]
+  }
+  project$.setSection("applications", applications)
+  invisible(project)
+}
+
+# Internal helpers ----
+
+# Build one classed `Application` entry from its (optional) parameterSets
+# references, validating the references resolve. Aborts on a problem.
 #
+# @keywords internal
+# @noRd
+.buildApplicationEntry <- function(
+  project,
+  parameterSets,
+  call = rlang::caller_env()
+) {
+  app <- list()
+  if (!is.null(parameterSets)) {
+    if (!is.character(parameterSets)) {
+      cli::cli_abort(
+        "{.arg parameterSets} must be a character vector of set ids",
+        call = call
+      )
+    }
+    parameterSets <- .canonicalizeIdRef(parameterSets)
+    bad <- setdiff(parameterSets, names(project$parameterSets %||% list()))
+    if (length(bad) > 0L) {
+      cli::cli_abort(
+        c(
+          "{.arg parameterSets} references undefined parameter sets:",
+          "x" = "{.val {bad}}"
+        ),
+        call = call
+      )
+    }
+    app$parameterSets <- parameterSets
+  }
+  class(app) <- c("Application", "list")
+  app
+}
+
 # Parse the `applications` JSON object. Each entry is stamped with
 # `class = c("Application", "list")`. The current schema stores
 # applications as a map of name -> object containing only
@@ -26,237 +216,4 @@
     result[[id]] <- app
   }
   result
-}
-
-# Public CRUD: applications ----
-
-#' Add an application protocol to a Project
-#'
-#' @param project A `Project` object.
-#' @param applicationId Character scalar, unique protocol id.
-#' @param parameterSets Optional character vector of set ids referencing
-#'   `project$applicationParameterSets`. Defaults to `NULL`.
-#' @returns The `project` object, invisibly.
-#' @export
-#' @family application
-addApplication <- function(project, applicationId, parameterSets = NULL) {
-  validateIsOfType(project, "Project")
-  if (
-    !is.character(applicationId) ||
-      length(applicationId) != 1L ||
-      is.na(applicationId) ||
-      nchar(applicationId) == 0
-  ) {
-    cli::cli_abort("{.arg applicationId} must be a non-empty string")
-  }
-  if (applicationId %in% names(project$applications)) {
-    cli::cli_abort("application {.val {applicationId}} already exists")
-  }
-  app <- list()
-  if (!is.null(parameterSets)) {
-    if (!is.character(parameterSets)) {
-      cli::cli_abort(
-        "{.arg parameterSets} must be a character vector of set ids"
-      )
-    }
-    bad <- setdiff(
-      parameterSets,
-      names(project$applicationParameterSets %||% list())
-    )
-    if (length(bad) > 0L) {
-      cli::cli_abort(c(
-        "{.arg parameterSets} references undefined application parameter sets:",
-        "x" = "{.val {bad}}"
-      ))
-    }
-    app$parameterSets <- parameterSets
-  }
-  class(app) <- c("Application", "list")
-  project$applications[[applicationId]] <- app
-  project$.markModified()
-  invisible(project)
-}
-
-#' Remove an application protocol from a Project
-#'
-#' @param project A `Project` object.
-#' @param applicationId Character scalar.
-#' @returns The `project` object, invisibly.
-#' @export
-#' @family application
-removeApplication <- function(project, applicationId) {
-  validateIsOfType(project, "Project")
-  if (
-    !is.character(applicationId) ||
-      length(applicationId) != 1L ||
-      is.na(applicationId) ||
-      nchar(applicationId) == 0
-  ) {
-    cli::cli_abort("{.arg applicationId} must be a non-empty string")
-  }
-  if (!(applicationId %in% names(project$applications))) {
-    cli::cli_warn("application {.val {applicationId}} not found; no-op.")
-    return(invisible(project))
-  }
-  .warnIfReferenced(project, "application", applicationId)
-  project$applications[[applicationId]] <- NULL
-  project$.markModified()
-  invisible(project)
-}
-
-#' Replace the parameter-set references on an application
-#'
-#' @param project A `Project` object.
-#' @param applicationId Character scalar.
-#' @param parameterSets Character vector of set ids (from
-#'   `project$applicationParameterSets`). Use `character(0)` to clear.
-#' @returns The `project` object, invisibly.
-#' @export
-#' @family application
-setApplicationParameterSets <- function(
-  project,
-  applicationId,
-  parameterSets
-) {
-  validateIsOfType(project, "Project")
-  if (!(applicationId %in% names(project$applications))) {
-    cli::cli_abort("application {.val {applicationId}} not found")
-  }
-  if (!is.character(parameterSets)) {
-    cli::cli_abort("{.arg parameterSets} must be a character vector")
-  }
-  bad <- setdiff(
-    parameterSets,
-    names(project$applicationParameterSets %||% list())
-  )
-  if (length(bad) > 0L) {
-    cli::cli_abort(c(
-      "{.arg parameterSets} references undefined application parameter sets:",
-      "x" = "{.val {bad}}"
-    ))
-  }
-  project$applications[[applicationId]]$parameterSets <- parameterSets
-  project$.markModified()
-  invisible(project)
-}
-
-# Public CRUD: applicationParameterSets ----
-
-#' Create an application parameter set
-#' @param project A `Project` object.
-#' @param id Character scalar, set name. Must not already exist.
-#' @returns The `project` object, invisibly.
-#' @export
-#' @family parameters
-addApplicationParameterSet <- function(project, id) {
-  validateIsOfType(project, "Project")
-  if (!is.character(id) || length(id) != 1L || is.na(id) || nchar(id) == 0) {
-    cli::cli_abort("{.arg id} must be a non-empty string")
-  }
-  if (id %in% names(project$applicationParameterSets)) {
-    cli::cli_abort("application parameter set {.val {id}} already exists")
-  }
-  project$applicationParameterSets[[id]] <- list()
-  project$.markModified()
-  invisible(project)
-}
-
-#' Remove an application parameter set
-#' @inheritParams addApplicationParameterSet
-#' @returns The `project` object, invisibly.
-#' @export
-#' @family parameters
-removeApplicationParameterSet <- function(project, id) {
-  validateIsOfType(project, "Project")
-  if (!(id %in% names(project$applicationParameterSets))) {
-    cli::cli_warn("application parameter set {.val {id}} not found; no-op.")
-    return(invisible(project))
-  }
-  .warnIfReferenced(project, "applicationParameterSet", id)
-  project$applicationParameterSets[[id]] <- NULL
-  project$.markModified()
-  invisible(project)
-}
-
-#' Add a parameter entry to a named application parameter set
-#'
-#' Adds one parameter entry to the named set in
-#' `project$applicationParameterSets`. The set is created on demand if
-#' it does not yet exist. Last-write-wins on duplicate `(containerPath,
-#' parameterName)` pairs.
-#'
-#' @param project A `Project` object.
-#' @param id Character scalar, set name. Created if not present.
-#' @param containerPath Character scalar.
-#' @param parameterName Character scalar.
-#' @param value Numeric scalar.
-#' @param units Character scalar.
-#' @returns The `project` object, invisibly.
-#' @export
-#' @family parameters
-addApplicationParameterEntry <- function(
-  project,
-  id,
-  containerPath,
-  parameterName,
-  value,
-  units
-) {
-  validateIsOfType(project, "Project")
-  if (!is.character(id) || length(id) != 1L || is.na(id) || nchar(id) == 0) {
-    cli::cli_abort("{.arg id} must be a non-empty string")
-  }
-  current <- project$applicationParameterSets[[id]]
-  project$applicationParameterSets[[id]] <- .addParameterEntry(
-    current,
-    containerPath,
-    parameterName,
-    value,
-    units
-  )
-  project$.markModified()
-  invisible(project)
-}
-
-#' Remove a parameter entry from a named application parameter set
-#'
-#' Removes one parameter entry from the named set. If the removed entry
-#' was the last in the set, the set itself is auto-removed from
-#' `project$applicationParameterSets`. Warns if the set or entry doesn't
-#' exist.
-#'
-#' @inheritParams addApplicationParameterEntry
-#' @returns The `project` object, invisibly.
-#' @export
-#' @family parameters
-removeApplicationParameterEntry <- function(
-  project,
-  id,
-  containerPath,
-  parameterName
-) {
-  validateIsOfType(project, "Project")
-  if (!is.character(id) || length(id) != 1L) {
-    cli::cli_abort("{.arg id} must be a string scalar")
-  }
-  if (!(id %in% names(project$applicationParameterSets))) {
-    cli::cli_warn("application parameter set {.val {id}} not found; no-op.")
-    return(invisible(project))
-  }
-  result <- .removeParameterEntry(
-    project$applicationParameterSets[[id]],
-    containerPath,
-    parameterName
-  )
-  if (!result$removed) {
-    return(invisible(project))
-  }
-  if (is.null(result$parameters)) {
-    .warnIfReferenced(project, "applicationParameterSet", id)
-    project$applicationParameterSets[[id]] <- NULL
-  } else {
-    project$applicationParameterSets[[id]] <- result$parameters
-  }
-  project$.markModified()
-  invisible(project)
 }

--- a/R/authoring-vectorize.R
+++ b/R/authoring-vectorize.R
@@ -1,0 +1,189 @@
+# Shared vectorization engine for the authoring API.
+#
+# Every `add*` / `set*` function accepts a vector of ids and vectorizes over
+# them under one recycling rule (locked 2026-06-30):
+#
+#   1. `project` is always length 1. The `id` argument sets N (the entity
+#      count) and CANNOT be recycled: when any scalar field has length > 1,
+#      `id` must have that same length. A length-1 `id` with all-scalar fields
+#      is the ordinary single-entity call (N = 1).
+#   2. Every scalar-per-entity field is length 1 (recycled to all N) or length
+#      N (aligned by position). Any other length is an error naming the field
+#      and the lengths.
+#   3. A vector-valued-per-entity field (an individual's / application's
+#      `parameterSets`, a scenario's `outputPaths` / `parameterSets`)
+#      is applied WHOLE to every entity, never split positionally. To give a
+#      different multi-valued list per entity, the caller passes a length-N
+#      list (one vector per entity); anything else is the one value applied to
+#      every entity. Whole fields are exempt from the length check.
+#   4. All-or-nothing: the caller validates all N entities first and writes
+#      nothing on any failure, then folds all N into the section and triggers
+#      exactly one write-through.
+#
+# Two families of authoring functions sit outside this id-sets-N rule.
+# `addParameterEntry()` / `removeParameterEntry()` vectorize over parameter
+# entries (parallel `containerPath` / `parameterName` / `value` / `units`
+# vectors) for a single named set, a different axis than the id-sets-N rule.
+# `renameScenario()`, `duplicateScenario()`, `addObservedData()`, and the
+# parameter-identification adders (`addPITask()` and its per-task sub-entity
+# helpers) act on a single definition per call.
+#
+# This file holds the pure recycle/align/length-check core. It is project-free
+# and unit-testable in isolation. The plot mutators in R/plots.R carry their own
+# specialized variant (`.recycleScalarArg` / `.dotsToPerEntityFields`), which
+# predates this engine; the two share the same rule.
+
+#' Vectorized authoring (the recycling rule)
+#'
+#' @description Every `add*` / `set*` / `remove*` function in the authoring
+#'   API accepts a vector of ids and vectorizes over them in one call (and one
+#'   write to disk).
+#'
+#' @details
+#' The id argument sets `N`, the number of definitions to act on, and cannot
+#' itself be recycled: when any scalar-per-entity field has length greater than
+#' 1, the id vector must have that same length. A length-1 id with all-scalar
+#' fields is the ordinary single-definition call.
+#'
+#' Each scalar-per-entity field is either length 1 (recycled to all `N`
+#' definitions) or length `N` (aligned to the ids by position). Any other
+#' length is an error naming the field and the lengths.
+#'
+#' A vector-valued-per-entity field (an individual's or application's
+#' `parameterSets`, a scenario's `outputPaths` and `parameterSets`) is
+#' applied whole to every definition, never split positionally. To give a
+#' different multi-valued list per definition, pass a list of the same length
+#' as the id vector (one vector per definition).
+#'
+#' The call is all-or-nothing: every definition is validated first, and if any
+#' fails the whole call aborts and writes nothing. On success all definitions
+#' are folded into the section and persisted in a single write-through.
+#'
+#' Two families of authoring functions sit outside this id-sets-`N` rule.
+#' `addParameterEntry()` and `removeParameterEntry()` vectorize over parameter
+#' entries (parallel `containerPath` / `parameterName` / `value` / `units`
+#' vectors) within a single named set, a different axis than the id-sets-`N`
+#' rule described here. `renameScenario()`, `duplicateScenario()`,
+#' `addObservedData()`, `addPITask()`, and the per-task
+#' parameter-identification sub-entity helpers act on a single definition per
+#' call.
+#'
+#' @name vectorizedAuthoring
+#' @keywords internal
+NULL
+
+# Validate the `id` vector that sets N for a vectorized authoring call: a
+# non-empty character vector with no NA / empty element. Returns the value
+# unchanged. The caller canonicalizes ids separately. `arg` names the argument
+# in the abort, `call` attributes it to the public caller.
+#
+# @keywords internal
+# @noRd
+.assertIdVector <- function(id, arg = "id", call = rlang::caller_env()) {
+  if (
+    !is.character(id) ||
+      length(id) == 0L ||
+      any(is.na(id)) ||
+      any(nchar(id) == 0)
+  ) {
+    cli::cli_abort(
+      "{.arg {arg}} must be a non-empty character vector with no NA or \\
+      empty element.",
+      call = call
+    )
+  }
+  invisible(id)
+}
+
+# Recycle / align one scalar-per-entity field to N entities. A length-1 value
+# is recycled to all N; a length-N value is aligned by position; any other
+# length aborts naming the field and the lengths. `NULL` passes through as
+# `NULL` (an absent field stays absent, recycled to all N). A list of length N
+# also aligns (so a per-entity scalar can be given as a length-N list).
+#
+# @keywords internal
+# @noRd
+.recycleField <- function(value, n, field, call = rlang::caller_env()) {
+  if (is.null(value)) {
+    return(rep(list(NULL), n))
+  }
+  len <- length(value)
+  if (len == 1L) {
+    return(rep(list(.element(value, 1L)), n))
+  }
+  if (len == n) {
+    return(lapply(seq_len(n), function(i) .element(value, i)))
+  }
+  cli::cli_abort(
+    c(
+      "{.arg {field}} must be length 1 or length {n} (the number of ids).",
+      "x" = "It is length {len}."
+    ),
+    call = call
+  )
+}
+
+# Resolve a whole-vector-per-entity field to N per-entity values. A length-N
+# list aligns by position (one element per entity); any other value (a scalar,
+# an atomic vector, or `NULL`) is applied verbatim to every entity. This is the
+# "applied whole, never split positionally" rule for vector-valued fields.
+#
+# @keywords internal
+# @noRd
+.wholeField <- function(value, n) {
+  if (is.list(value) && length(value) == n) {
+    return(value)
+  }
+  rep(list(value), n)
+}
+
+# Align an id vector + named scalar/whole field lists into N per-entity field
+# sets. `scalarFields` and `wholeFields` are named lists of argument values;
+# each scalar field is recycled/aligned (rule 2), each whole field applied
+# verbatim (rule 3). Returns a list of N named lists, one per entity, each
+# carrying every supplied field (NULL fields preserved as NULL so an `add*`
+# builder can tell "absent" from "present"). `call` attributes any length-error
+# abort to the public caller.
+#
+# @keywords internal
+# @noRd
+.alignAuthoringArgs <- function(
+  id,
+  scalarFields = list(),
+  wholeFields = list(),
+  call = rlang::caller_env()
+) {
+  n <- length(id)
+  perScalar <- lapply(names(scalarFields), function(nm) {
+    .recycleField(scalarFields[[nm]], n, nm, call = call)
+  })
+  names(perScalar) <- names(scalarFields)
+  perWhole <- lapply(names(wholeFields), function(nm) {
+    .wholeField(wholeFields[[nm]], n)
+  })
+  names(perWhole) <- names(wholeFields)
+
+  lapply(seq_len(n), function(i) {
+    fields <- list()
+    for (nm in names(perScalar)) {
+      fields[nm] <- list(perScalar[[nm]][[i]])
+    }
+    for (nm in names(perWhole)) {
+      fields[nm] <- list(perWhole[[nm]][[i]])
+    }
+    fields
+  })
+}
+
+# Extract element `i` of a vector or list, preserving the scalar shape. Used by
+# `.recycleField` so a character vector yields a length-1 string and a list
+# yields its i-th element.
+#
+# @keywords internal
+# @noRd
+.element <- function(value, i) {
+  if (is.list(value)) {
+    return(value[[i]])
+  }
+  value[[i]]
+}

--- a/R/entity-files.R
+++ b/R/entity-files.R
@@ -1,0 +1,1339 @@
+# Entity-files format layer ----
+#
+# Every authored Project section is stored as a tree of JSON files under
+# `definitions/<kind>/`, one subfolder per entity kind beneath the project's
+# `definitions/` root (next to `Project.json`), rather than as an array or
+# object inside the monolithic `Project.json`. The `definitions/` folder holds
+# the project's authored entity files, separated from the referenced working
+# files (`Models/`, `Data/`, `Populations/`, `Results/`) and the `Project.json`
+# container. Each file holds the same per-entity JSON the monolithic
+# serializer emitted, so the in-memory section shapes are unchanged and every
+# consumer (`runScenarios()`, `createPlots()`, validation, parameter
+# identification) is unaffected.
+#
+# Direction of truth: the entity files are authoritative. Loading globs each
+# kind's tree; the section mutators (every `add*` / `remove*` / `set*` and any
+# write-back through `project$<section>`) are write-through, structurally
+# validating the changed entity then writing (or deleting) its single file.
+# `saveSnapshot()` renders a derived single-file `Project.json` with every
+# section inlined, for sharing or archiving.
+#
+# Per-kind subfolder names and granularity (all under `definitions/`):
+#   scenarios                -> scenarios/                one file per scenario
+#   individuals              -> individuals/              one file per individual
+#   populations              -> populations/              one file per population
+#   parameterSets            -> parameter-sets/           one file per set
+#   initialConditions        -> initial-conditions/       one file per set
+#   applications             -> applications/             one file per application
+#   outputPaths              -> output-paths/             one file per path
+#   observedData             -> observed-data/            one file per declaration
+#   dataCombined             -> data-combined/            one file per entry
+#   plots                    -> plots/                    one file per plot
+#   plotGrids                -> plot-grids/               one file per grid
+#   parameterIdentification  -> parameter-identification/ one file per task
+#
+# A section keyed by an id is one file per id (the id is the filename). The
+# unnamed `observedData` list is keyed by the id `removeObservedData()` matches
+# on (file basename, or the programmatic DataSet name).
+#
+# The plots concern is three independent top-level keyed sections, each its own
+# kind: `dataCombined` (`data-combined/<dataCombinedId>.json`), `plots`
+# (`plots/<plotId>.json`, the plot list keyed by `plotId`), and `plotGrids`
+# (`plot-grids/<plotGridId>.json`), one file per entity like every other
+# section. The inner cross-references (a grid's `plotIds` -> a plot's `plotId`
+# -> a `dataCombinedId`) are validated lazily by `.validatePlots()`, not at
+# write, so a dangling inner ref stays a Critical Error surfaced at
+# `validateProject()` / `createPlots()`, never a write-time abort. The derived
+# single-file snapshot inlines all three as three top-level JSON sections.
+
+# Resolve the entity-definition root for a project directory. This is the
+# folder that holds the project's authored entity files, separated from the
+# referenced working files (`Models/`, `Data/`, `Populations/`, `Results/`)
+# and the `Project.json` container. Its name is configurable via the
+# container's `definitionsFolder` field (default `"definitions"`), passed in by
+# the caller (a project's `definitionsFolder` binding); the default keeps every
+# existing project working. Each entity kind lives in its own subfolder
+# (`<definitionsFolder>/<kind>/`); see `.entityKindDir()`. Returns NULL when the
+# project has no directory (an in-memory project), in which case no entity tree
+# is persisted.
+#
+# @keywords internal
+# @noRd
+.definitionsDir <- function(projectDirPath, definitionsFolder = "definitions") {
+  if (is.null(projectDirPath) || length(projectDirPath) == 0L) {
+    return(NULL)
+  }
+  file.path(projectDirPath, definitionsFolder %||% "definitions")
+}
+
+# Resolve the entity directory for one kind (`scenarios`, `individuals`,
+# `populations`, etc.) under the project's definitions root. This single
+# per-kind resolver is the one place a kind's on-disk location is computed, so
+# a future kind slots in by calling it with its own name rather than
+# re-deriving a path. The definitions root name is taken from
+# `definitionsFolder` (default `"definitions"`). Returns NULL for an in-memory
+# project (no directory).
+#
+# @keywords internal
+# @noRd
+.entityKindDir <- function(
+  projectDirPath,
+  kind,
+  definitionsFolder = "definitions"
+) {
+  root <- .definitionsDir(projectDirPath, definitionsFolder)
+  if (is.null(root)) {
+    return(NULL)
+  }
+  file.path(root, kind)
+}
+
+# Per-kind entity-tree spec registry ----
+#
+# Each kind has a spec describing how its section is read from and written to
+# the tree. Every kind is one-file-per-entity, keyed by id (the id is the
+# filename). A spec is a list with:
+#   - kind        : the `definitions/<kind>/` subfolder name.
+#   - serialize   : function(section, project) -> a named `id -> json-record`
+#                   list. Performs all structural validation, so any abort
+#                   happens before a file is touched
+#                   (serialize-all-before-write-any).
+#   - parse       : function(records, project) -> the in-memory section, given
+#                   `records`, the list of per-file JSON records.
+#   - inline      : function(jsonData) -> the inline section as it appears in a
+#                   single-file `Project.json` snapshot, used as the fallback
+#                   when no tree directory exists. Shaped exactly like what the
+#                   keyed `parse` consumes.
+#
+# The scenarios kind has its own dedicated serialize/parse helpers (the file
+# content differs structurally from the in-memory record); the others reuse
+# their section's existing per-entity JSON shape. The plots concern is three
+# independent top-level keyed sections (`dataCombined`, `plots`, `plotGrids`),
+# each its own kind like any other section.
+#
+# @keywords internal
+# @noRd
+.entityTreeSpec <- function(kind) {
+  specs <- .entityTreeSpecs()
+  spec <- specs[[kind]]
+  if (is.null(spec)) {
+    cli::cli_abort("No entity-tree spec for kind {.val {kind}}.")
+  }
+  spec
+}
+
+# All entity-tree specs, keyed by section field name.
+#
+# @keywords internal
+# @noRd
+.entityTreeSpecs <- function() {
+  list(
+    scenarios = list(
+      kind = "scenarios",
+      serialize = function(section, project) {
+        .serializeScenarioSet(section, project$outputPaths)
+      },
+      parse = function(records, project) {
+        .parseScenarios(records, project$outputPaths)
+      },
+      inline = function(jsonData) jsonData$scenarios
+    ),
+    individuals = list(
+      kind = "individuals",
+      serialize = function(section, project) {
+        .serializeIndividualSet(section)
+      },
+      parse = function(records, project) .parseIndividuals(records),
+      inline = function(jsonData) jsonData$individuals
+    ),
+    populations = list(
+      kind = "populations",
+      serialize = function(section, project) {
+        .serializePopulationSet(section)
+      },
+      parse = function(records, project) .parsePopulations(records),
+      inline = function(jsonData) jsonData$populations
+    ),
+    parameterSets = list(
+      kind = "parameter-sets",
+      serialize = function(section, project) {
+        .serializeParameterSetSet(section)
+      },
+      parse = function(records, project) .parseParameterSetTree(records),
+      # The inline fallback merges any legacy three-section `Project.json` into
+      # the one `parameterSets` map (a clash aborts), then re-expresses it as
+      # the per-record list shape the tree parser consumes. A genuinely absent
+      # section stays `NULL` (parsed to a bare `list()`); a present empty `{}`
+      # becomes an empty record list (parsed to a named-empty list), preserving
+      # the absent-vs-empty distinction the monolithic parser kept.
+      inline = function(jsonData) {
+        .mapSectionToRecords(
+          .mergeParameterSetSectionsOrNull(jsonData),
+          .parameterSetMapToRecords
+        )
+      }
+    ),
+    initialConditions = list(
+      kind = "initial-conditions",
+      serialize = function(section, project) {
+        .serializeInitialConditionSet(section)
+      },
+      parse = function(records, project) .parseInitialConditionTree(records),
+      # Absent (`NULL`) stays `NULL` so the parser yields a bare `list()`; a
+      # present empty `{}` becomes an empty record list so the parser yields a
+      # named-empty list. This preserves the absent-vs-empty distinction the
+      # monolithic parser kept for the map-shaped sections.
+      inline = function(jsonData) {
+        .mapSectionToRecords(
+          jsonData$initialConditions,
+          .initialConditionMapToRecords
+        )
+      }
+    ),
+    applications = list(
+      kind = "applications",
+      serialize = function(section, project) {
+        .serializeApplicationSet(section)
+      },
+      parse = function(records, project) .parseApplicationTree(records),
+      inline = function(jsonData) {
+        .applicationMapToRecords(jsonData$applications)
+      }
+    ),
+    outputPaths = list(
+      kind = "output-paths",
+      serialize = function(section, project) {
+        .serializeOutputPathSet(section)
+      },
+      parse = function(records, project) .parseOutputPathTree(records),
+      # Absent (`NULL`) stays `NULL` so the parser yields a bare `list()`; a
+      # present empty `{}` becomes an empty record list so the parser yields a
+      # named-empty list. This preserves the absent-vs-empty distinction the
+      # monolithic parser kept for the map-shaped sections.
+      inline = function(jsonData) {
+        .mapSectionToRecords(jsonData$outputPaths, .outputPathMapToRecords)
+      }
+    ),
+    observedData = list(
+      kind = "observed-data",
+      serialize = function(section, project) {
+        .serializeObservedDataSet(section)
+      },
+      parse = function(records, project) .parseObservedDataTree(records),
+      inline = function(jsonData) jsonData$observedData
+    ),
+    # The plots concern is three independent top-level keyed sections, each its
+    # own `definitions/<kind>/` tree: `dataCombined` (folder `data-combined`),
+    # `plots` (folder `plots`, the plot list keyed by `plotId`), and `plotGrids`
+    # (folder `plot-grids`). Each `serialize` turns its keyed list into an
+    # `id -> json-record` map; each `parse` rebuilds the keyed list from the
+    # per-file records; each `inline` falls back to its own top-level snapshot
+    # section so a single-file snapshot reloads each self-contained.
+    dataCombined = list(
+      kind = "data-combined",
+      serialize = function(section, project) {
+        .serializeDataCombinedSet(section)
+      },
+      parse = function(records, project) .parseDataCombinedTree(records),
+      inline = function(jsonData) jsonData$dataCombined
+    ),
+    plots = list(
+      kind = "plots",
+      serialize = function(section, project) {
+        .serializePlotConfigurationSet(section)
+      },
+      parse = function(records, project) .parsePlotConfigurationTree(records),
+      inline = function(jsonData) jsonData$plots
+    ),
+    plotGrids = list(
+      kind = "plot-grids",
+      serialize = function(section, project) {
+        .serializePlotGridSet(section)
+      },
+      parse = function(records, project) .parsePlotGridTree(records),
+      inline = function(jsonData) jsonData$plotGrids
+    ),
+    parameterIdentification = list(
+      kind = "parameter-identification",
+      serialize = function(section, project) {
+        .serializePITaskSet(section)
+      },
+      parse = function(records, project) .parsePITasks(records),
+      inline = function(jsonData) jsonData$parameterIdentification
+    )
+  )
+}
+
+# The list of all tree-backed spec names, each a one-to-one `project$<name>`
+# section field. This is the single source of truth for the set of section
+# kinds: it is derived from the keys of `.entityTreeSpecs()`, and the project
+# object's section membership check reads it too, so adding or renaming a kind
+# is a one-place edit (the spec) rather than three lists kept in lockstep. Used
+# by the whole-tree writers, where write order does not matter (each kind writes
+# into its own folder independently); the load order that must resolve
+# `outputPaths` before scenarios is fixed separately in `Project$.read_json()`.
+#
+# @keywords internal
+# @noRd
+.entityKindNames <- function() {
+  names(.entityTreeSpecs())
+}
+
+# Resolve the in-memory section a tree-spec name serializes: the
+# `project$<name>` field. Used by the whole-tree writer (`.writeProjectTree`)
+# so it can iterate `.entityKindNames()` uniformly. Strips the printable
+# DefinitionList wrapper a section accessor adds on read, so the whole-tree
+# writers operate on plain lists.
+#
+# @keywords internal
+# @noRd
+.sectionForKind <- function(project, name) {
+  .unwrapDefinitionList(project[[name]])
+}
+
+# Path to a single entity's file. The filename is `<id>.json`. Callers pass an
+# id already validated as a safe single path segment (canonicalized by the
+# authoring API and re-checked by the per-section structural validator), so
+# the id is used verbatim here.
+#
+# @keywords internal
+# @noRd
+.entityFilePath <- function(dir, id) {
+  file.path(dir, paste0(id, ".json"))
+}
+
+# Canonical JSON write options shared by every entity file and the snapshot,
+# for byte-stable round-trips.
+#
+# @keywords internal
+# @noRd
+.writeEntityJson <- function(content, path) {
+  jsonlite::write_json(
+    content,
+    path,
+    auto_unbox = TRUE,
+    null = "null",
+    pretty = TRUE
+  )
+  invisible(NULL)
+}
+
+# Load one kind's section into the raw shape its parser consumes.
+#
+# A tree-format project keeps the section as `definitions/<kind>/*.json`; those
+# files are globbed, parsed, and returned as the list of per-file records in
+# sorted-filename order for a stable load order. When there is no
+# `definitions/<kind>/` directory, the inline section from the `Project.json` is
+# used instead, so a derived single-file snapshot (see `saveSnapshot()`) reloads
+# self-contained. A malformed file is a structural error and aborts the load.
+#
+# @keywords internal
+# @noRd
+.loadEntityTree <- function(
+  projectDirPath,
+  kind,
+  inlineSection = NULL,
+  definitionsFolder = "definitions"
+) {
+  spec <- .entityTreeSpec(kind)
+  # The definitions root and the per-kind subfolder must each be a real
+  # directory when present. A path that exists but is a regular file is a
+  # corrupted or mis-synced tree, not an absent section, so it must abort rather
+  # than silently fall back to the inline section (which would load the project
+  # as structurally-valid but empty).
+  root <- definitionsFolder %||% "definitions"
+  .assertEntityTreePathIsDir(
+    .definitionsDir(projectDirPath, root),
+    root
+  )
+  dir <- .entityKindDir(projectDirPath, spec$kind, root)
+  .assertEntityTreePathIsDir(dir, file.path(root, spec$kind))
+
+  if (is.null(dir) || !dir.exists(dir)) {
+    # `inlineSection` is `NULL` for a genuinely absent section and an empty
+    # (possibly named) list for a present-but-empty one; the kind's parser
+    # turns each into the right empty shape, so pass it through verbatim.
+    return(inlineSection)
+  }
+  # `list.files()` returns paths in the native (unknown) encoding; a non-ASCII
+  # filename then makes `sort(method = "radix")` reject the vector on platforms
+  # whose native encoding is not UTF-8 (Windows, a non-UTF-8 locale), making
+  # the whole project unloadable. Normalize to UTF-8 first so the sort is
+  # encoding-stable and a non-ASCII id round-trips everywhere.
+  files <- sort(
+    enc2utf8(list.files(dir, pattern = "\\.json$", full.names = TRUE)),
+    method = "radix"
+  )
+  # Tag each record with the file it came from so the keyed parsers can name the
+  # offending file in a load error and check the inner id against the filename
+  # stem. An inline-snapshot fallback record carries no such tag.
+  lapply(files, function(f) {
+    rec <- .readEntityJsonFile(f)
+    attr(rec, ".entityFile") <- f
+    rec
+  })
+}
+
+# Abort when an entity-tree path exists on disk but is a regular file rather
+# than a directory. `dir.exists()` is FALSE for both an absent path and a path
+# that is a file, so the caller cannot tell a genuinely-missing section (a
+# legitimate inline fallback) from a corrupted tree. A NULL path (in-memory
+# project) or a genuinely-absent path is fine and returns silently; only an
+# existing non-directory aborts, naming the path and the expected `relLabel`.
+#
+# @keywords internal
+# @noRd
+.assertEntityTreePathIsDir <- function(path, relLabel) {
+  if (is.null(path) || !file.exists(path) || dir.exists(path)) {
+    return(invisible(NULL))
+  }
+  cli::cli_abort(c(
+    "Project entity path {.file {path}} exists but is not a directory.",
+    "x" = "{.file {relLabel}} must be a directory of entity files.",
+    "i" = "A regular file here is a corrupted or mis-synced project tree."
+  ))
+}
+
+# Parse one decoded entity file, aborting with a clear message on malformed
+# JSON.
+#
+# @keywords internal
+# @noRd
+.readEntityJsonFile <- function(f) {
+  tryCatch(
+    jsonlite::fromJSON(f, simplifyVector = FALSE),
+    error = function(e) {
+      cli::cli_abort(
+        "Failed to parse entity file {.file {f}} as JSON.",
+        parent = e
+      )
+    }
+  )
+}
+
+# Write a whole section's tree to `definitions/<kind>/`, one file per entity.
+# Removes files that no longer correspond to a section entity so the tree never
+# carries stale entries (an emptied section clears its folder). A NULL directory
+# (in-memory project) is a silent no-op. The full set is serialized in memory
+# first, so a serializer-hostile entity aborts before any file is touched.
+#
+# @keywords internal
+# @noRd
+.writeEntityTree <- function(section, kind, project, projectDirPath) {
+  spec <- .entityTreeSpec(kind)
+  dir <- .entityKindDir(projectDirPath, spec$kind, project$definitionsFolder)
+  if (is.null(dir)) {
+    return(invisible(NULL))
+  }
+  serialized <- spec$serialize(section, project)
+
+  if (!dir.exists(dir)) {
+    dir.create(dir, recursive = TRUE, showWarnings = FALSE)
+  }
+  keep <- character()
+  for (id in names(serialized)) {
+    .writeEntityJson(serialized[[id]], .entityFilePath(dir, id))
+    keep <- c(keep, paste0(id, ".json"))
+  }
+  existing <- list.files(dir, pattern = "\\.json$")
+  for (f in setdiff(existing, keep)) {
+    file.remove(file.path(dir, f))
+  }
+  invisible(NULL)
+}
+
+# Scenario tree helpers ----
+#
+# Scenarios keep dedicated serialize helpers because the on-disk file content
+# differs structurally from the in-memory `Scenario` record (the named-vector
+# `outputPaths` record field rebuilt as the `outputPaths` id array, parsed
+# `simulationTime` rejoined, base-unit `steadyStateTime` converted back). The
+# other kinds' file content is their existing per-entity JSON shape.
+
+# Serialize a whole set of scenarios to their JSON-list representation, keyed
+# by scenario name, without touching disk. Reuses the per-scenario structural
+# validator and serializer so any abort happens here, before any file is
+# written. The structural validator also enforces that each key is a canonical
+# (lowercase, safe) id, so two keys can never collide on a case-insensitive
+# filesystem.
+#
+# @keywords internal
+# @noRd
+.serializeScenarioSet <- function(scenarios, outputPaths) {
+  scenarios <- scenarios %||% list()
+  serialized <- list()
+  for (name in names(scenarios)) {
+    .validateScenarioStructure(scenarios[[name]], name)
+    serialized[[name]] <- .scenarioToJson(scenarios[[name]], outputPaths)
+  }
+  serialized
+}
+
+# Per-kind serialize/parse for the non-scenario sections ----
+#
+# Each `serialize` produces a named `id -> json-record` map (structurally
+# validating along the way); each `parse` reassembles the in-memory section
+# from the list of per-file records.
+
+# individuals: one file per individual, `{individualId, ...fields}`.
+#
+# @keywords internal
+# @noRd
+.serializeIndividualSet <- function(individuals) {
+  individuals <- individuals %||% list()
+  out <- list()
+  for (id in names(individuals)) {
+    .validateEntityTreeKey(id, "individual")
+    indiv <- unclass(individuals[[id]])
+    if (!is.null(indiv$parameterSets)) {
+      indiv$parameterSets <- as.list(indiv$parameterSets)
+    }
+    out[[id]] <- c(list(individualId = id), indiv)
+  }
+  out
+}
+
+# populations: one file per population, `{populationId, ...fields}`.
+#
+# @keywords internal
+# @noRd
+.serializePopulationSet <- function(populations) {
+  populations <- populations %||% list()
+  out <- list()
+  for (id in names(populations)) {
+    .validateEntityTreeKey(id, "population")
+    pop <- unclass(populations[[id]])
+    out[[id]] <- c(list(populationId = id), pop)
+  }
+  out
+}
+
+# parameterSets: one file per set, `{id, parameters: [entries]}`.
+#
+# @keywords internal
+# @noRd
+.serializeParameterSetSet <- function(parameterSets) {
+  parameterSets <- parameterSets %||% list()
+  out <- list()
+  for (id in names(parameterSets)) {
+    .validateEntityTreeKey(id, "parameterSet")
+    out[[id]] <- list(
+      id = id,
+      parameters = unclass(parameterSets[[id]] %||% list())
+    )
+  }
+  out
+}
+
+# @keywords internal
+# @noRd
+.parseParameterSetTree <- function(records) {
+  if (is.null(records)) {
+    return(list())
+  }
+  out <- structure(list(), names = character(0L))
+  for (rec in records) {
+    id <- .keyedTreeRecordId(rec, "id", "parameterSet")
+    .assertNoEmptyObjectFields(rec, "parameterSet")
+    out[[id]] <- .asParameterSet(rec$parameters %||% list())
+  }
+  out
+}
+
+# Stamp a parameter set's array-of-entries with `c("ParameterSet", "list")` so
+# a single set read from `project$parameterSets[[id]]` dispatches its print
+# method. The class is a transparent list wrapper; the serializers strip it
+# (`.serializeParameterSetSet` / `.parameterSetsToJson`) so it never reaches
+# JSON.
+#
+# @keywords internal
+# @noRd
+.asParameterSet <- function(parameters) {
+  parameters <- parameters %||% list()
+  class(parameters) <- c("ParameterSet", "list")
+  parameters
+}
+
+# Convert an inline map section to the per-record list the tree parser
+# consumes, preserving the absent-vs-empty distinction the monolithic parser
+# kept for the map-shaped sections: a genuinely absent section (`NULL`) stays
+# `NULL` (its parser yields a bare `list()`), while a present empty `{}` becomes
+# an empty record `list()` (its parser yields a named-empty list). `toRecords`
+# is the kind's map -> record-list helper.
+#
+# @keywords internal
+# @noRd
+.mapSectionToRecords <- function(mapSection, toRecords) {
+  if (is.null(mapSection)) {
+    return(NULL)
+  }
+  toRecords(mapSection)
+}
+
+# Merge the legacy/unified parameter-set sections, but preserve a genuinely
+# absent `parameterSets` (no section and no legacy sections) as `NULL` so the
+# inline fallback yields a bare `list()`, not a named-empty list.
+#
+# @keywords internal
+# @noRd
+.mergeParameterSetSectionsOrNull <- function(jsonData) {
+  hasLegacy <- any(
+    vapply(
+      list(
+        jsonData$modelParameterSets,
+        jsonData$individualParameterSets,
+        jsonData$applicationParameterSets
+      ),
+      function(x) length(x) > 0L,
+      logical(1)
+    )
+  )
+  if (is.null(jsonData$parameterSets) && !hasLegacy) {
+    return(NULL)
+  }
+  .mergeParameterSetSections(jsonData)
+}
+
+# Convert the inline `{id: [entries]}` parameter-set map (the snapshot shape)
+# to the per-record `[{id, parameters}, ...]` list the tree parser consumes.
+#
+# @keywords internal
+# @noRd
+.parameterSetMapToRecords <- function(setMap) {
+  setMap <- setMap %||% list()
+  lapply(names(setMap), function(id) {
+    list(id = id, parameters = setMap[[id]] %||% list())
+  })
+}
+
+# initialConditions: one file per set, `{id, initialConditions: [entries]}`.
+# Each entry is a flat molecule-start-value record `{path, value, unit}`. Its
+# own kind (not folded into `parameterSets`) because execution applies it via
+# `ospsuite::setQuantityValuesByPath()` rather than `setParameterValuesByPath()`
+# and scenarios reference it through a separate field.
+#
+# @keywords internal
+# @noRd
+.serializeInitialConditionSet <- function(initialConditions) {
+  initialConditions <- initialConditions %||% list()
+  out <- list()
+  for (id in names(initialConditions)) {
+    .validateEntityTreeKey(id, "initialConditionSet")
+    out[[id]] <- list(
+      id = id,
+      initialConditions = unclass(initialConditions[[id]] %||% list())
+    )
+  }
+  out
+}
+
+# @keywords internal
+# @noRd
+.parseInitialConditionTree <- function(records) {
+  if (is.null(records)) {
+    return(list())
+  }
+  out <- structure(list(), names = character(0L))
+  for (rec in records) {
+    id <- .keyedTreeRecordId(rec, "id", "initialConditionSet")
+    .assertNoEmptyObjectFields(rec, "initialConditionSet")
+    out[[id]] <- .asInitialConditionSet(rec$initialConditions %||% list())
+  }
+  out
+}
+
+# Stamp an initial-condition set's array-of-entries with
+# `c("InitialConditionSet", "list")` so a single set read from
+# `project$initialConditions[[id]]` dispatches its print method. The class is a
+# transparent list wrapper; the serializers strip it
+# (`.serializeInitialConditionSet` / `.initialConditionsToJson`) so it never
+# reaches JSON.
+#
+# @keywords internal
+# @noRd
+.asInitialConditionSet <- function(entries) {
+  entries <- entries %||% list()
+  class(entries) <- c("InitialConditionSet", "list")
+  entries
+}
+
+# Convert the inline `{id: [entries]}` initial-conditions map (the snapshot
+# shape) to the per-record `[{id, initialConditions}, ...]` list the tree parser
+# consumes.
+#
+# @keywords internal
+# @noRd
+.initialConditionMapToRecords <- function(setMap) {
+  setMap <- setMap %||% list()
+  lapply(names(setMap), function(id) {
+    list(id = id, initialConditions = setMap[[id]] %||% list())
+  })
+}
+
+# applications: one file per protocol, `{id, parameterSets: [...]}`.
+#
+# @keywords internal
+# @noRd
+.serializeApplicationSet <- function(applications) {
+  applications <- applications %||% list()
+  out <- list()
+  for (id in names(applications)) {
+    .validateEntityTreeKey(id, "application")
+    app <- applications[[id]]
+    rec <- list(id = id)
+    if (!is.null(app$parameterSets) && length(app$parameterSets) > 0L) {
+      rec$parameterSets <- as.list(app$parameterSets)
+    }
+    out[[id]] <- rec
+  }
+  out
+}
+
+# @keywords internal
+# @noRd
+.parseApplicationTree <- function(records) {
+  appsObj <- list()
+  for (rec in records) {
+    id <- .keyedTreeRecordId(rec, "id", "application")
+    .assertNoEmptyObjectFields(rec, "application")
+    entry <- list()
+    if (!is.null(rec$parameterSets)) {
+      entry$parameterSets <- rec$parameterSets
+    }
+    appsObj[[id]] <- entry
+  }
+  .parseApplications(appsObj)
+}
+
+# Convert the inline `{id: {parameterSets}}` application map (the snapshot
+# shape) to the per-record `[{id, parameterSets}, ...]` list the tree parser
+# consumes.
+#
+# @keywords internal
+# @noRd
+.applicationMapToRecords <- function(appMap) {
+  appMap <- appMap %||% list()
+  lapply(names(appMap), function(id) {
+    rec <- list(id = id)
+    ps <- appMap[[id]]$parameterSets
+    if (!is.null(ps)) {
+      rec$parameterSets <- ps
+    }
+    rec
+  })
+}
+
+# outputPaths: one file per path, `{id, path}`.
+#
+# @keywords internal
+# @noRd
+.serializeOutputPathSet <- function(outputPaths) {
+  outputPaths <- outputPaths %||% list()
+  ids <- names(outputPaths)
+  if (length(outputPaths) > 0L && (is.null(ids) || any(ids == ""))) {
+    cli::cli_abort(c(
+      "{.field outputPaths} must be a named map of id to path string.",
+      "i" = "Found an entry without an id."
+    ))
+  }
+  out <- list()
+  for (id in ids) {
+    .validateEntityTreeKey(id, "outputPath")
+    out[[id]] <- list(id = id, path = outputPaths[[id]])
+  }
+  out
+}
+
+# @keywords internal
+# @noRd
+.parseOutputPathTree <- function(records) {
+  if (is.null(records)) {
+    return(list())
+  }
+  out <- structure(list(), names = character(0L))
+  for (rec in records) {
+    id <- .keyedTreeRecordId(rec, "id", "outputPath")
+    .assertNoEmptyObjectFields(rec, "outputPath")
+    out[[id]] <- rec$path
+  }
+  out
+}
+
+# Convert the inline `{id: "path"}` output-path map (the snapshot shape) to the
+# per-record `[{id, path}, ...]` list the tree parser consumes.
+#
+# @keywords internal
+# @noRd
+.outputPathMapToRecords <- function(pathMap) {
+  pathMap <- pathMap %||% list()
+  lapply(names(pathMap), function(id) {
+    list(id = id, path = pathMap[[id]])
+  })
+}
+
+# observedData: one file per declaration, keyed by the id `removeObservedData()`
+# matches on (file basename, or the programmatic DataSet name).
+#
+# @keywords internal
+# @noRd
+.serializeObservedDataSet <- function(observedData) {
+  observedData <- observedData %||% list()
+  out <- list()
+  for (entry in observedData) {
+    id <- .observedDataEntryId(entry)
+    # The on-disk id is the file basename (or the programmatic DataSet name).
+    # Two declarations whose `file` differs only by directory derive the same
+    # basename and would silently overwrite each other (one file on disk, the
+    # second declaration lost on reload). Fail fast naming the collision rather
+    # than dropping a declaration.
+    if (!is.null(out[[id]])) {
+      cli::cli_abort(c(
+        "Two observedData declarations map to the same entity file {.file {id}.json}.",
+        "x" = "The on-disk id is the file basename (or the programmatic name), \\
+        so two sources sharing a basename collide.",
+        "i" = "Rename one source so the basenames differ."
+      ))
+    }
+    out[[id]] <- unclass(entry)
+  }
+  out
+}
+
+# @keywords internal
+# @noRd
+.parseObservedDataTree <- function(records) {
+  # The in-memory `observedData` shape is an unnamed list of declarations; an
+  # absent section (`NULL`) is a bare `list()`.
+  if (is.null(records)) {
+    return(list())
+  }
+  # Drop the transient `.entityFile` load tag the tree loader attaches; it is
+  # used only for error messages, and must not leak into the in-memory record
+  # (which would make a tree-loaded section differ from an inline-loaded one).
+  # Stamp each declaration with `c("ObservedDataSource", "list")` so a single
+  # source dispatches its print method (the serializers strip it before JSON).
+  records <- lapply(records, function(rec) {
+    attr(rec, ".entityFile") <- NULL
+    .asObservedDataSource(rec)
+  })
+  unname(records)
+}
+
+# Stamp an observed-data declaration with `c("ObservedDataSource", "list")`.
+# A transparent list wrapper carried for the print method only; both
+# serialize paths (`.serializeObservedDataSet` and `.observedDataToJson`)
+# strip it so it never reaches JSON.
+#
+# @keywords internal
+# @noRd
+.asObservedDataSource <- function(entry) {
+  class(entry) <- c("ObservedDataSource", "list")
+  entry
+}
+
+# The on-disk id of an observed-data declaration: the file basename for
+# `excel`/`pkml`/`script`, the DataSet name for `programmatic`. This is the id
+# `removeObservedData()` matches on, so the filename and that id agree.
+#
+# @keywords internal
+# @noRd
+.observedDataEntryId <- function(entry) {
+  if (identical(entry$type, "programmatic")) {
+    id <- entry$name
+  } else {
+    id <- basename(entry[["file"]] %||% "")
+  }
+  if (is.null(id) || !nzchar(id)) {
+    cli::cli_abort(c(
+      "An observedData declaration has no id to name its entity file.",
+      "i" = "A file-based entry needs a {.field file}; a programmatic entry \\
+      needs a {.field name}."
+    ))
+  }
+  id
+}
+
+# plots: three keyed kinds, one part of the `project$plots` trio each.
+#
+# The serializers turn a part into an `id -> json-record` map keyed by the
+# part's id field (`dataCombinedId` / `plotId` / `plotGridId`); the parsers
+# reassemble the part from the per-file records, validating each record's inner
+# id against its filename (`.keyedTreeRecordId`) so the on-disk filename stays
+# the authoritative key. Each part's in-memory shape (a keyed list whose entries
+# are the per-record fields) is the per-file JSON shape, so the serialize side
+# is near-identity (it only strips the entry class) and the file content is
+# byte-identical to the inlined snapshot's per-entry shape.
+
+# data-combined: one file per dataCombined entry, the nested JSON object with
+# its `dataCombinedId` re-added (the list key). The serializer canonicalizes
+# nothing; `.validateEntityTreeKey` enforces the key is already canonical.
+#
+# @keywords internal
+# @noRd
+.serializeDataCombinedSet <- function(dataCombined) {
+  dataCombined <- dataCombined %||% list()
+  out <- list()
+  for (id in names(dataCombined)) {
+    .validateEntityTreeKey(id, "dataCombined")
+    dc <- dataCombined[[id]]
+    rec <- list(dataCombinedId = id)
+    if (length(dc$simulated %||% list()) > 0) {
+      rec$simulated <- dc$simulated
+    }
+    if (length(dc$observed %||% list()) > 0) {
+      rec$observed <- dc$observed
+    }
+    out[[id]] <- rec
+  }
+  out
+}
+
+# @keywords internal
+# @noRd
+.parseDataCombinedTree <- function(records) {
+  if (is.null(records)) {
+    return(list())
+  }
+  # Re-tag each record with the filename-checked key, then delegate to the
+  # shared nested-dataCombined parser (which re-keys by `dataCombinedId` and
+  # drops the id field). The key check guarantees the inner `dataCombinedId`
+  # agrees with the filename for a tree-loaded record.
+  for (rec in records) {
+    .keyedTreeRecordId(rec, "dataCombinedId", "dataCombined")
+  }
+  .parseNestedDataCombined(lapply(records, function(rec) {
+    attr(rec, ".entityFile") <- NULL
+    rec
+  }))
+}
+
+# plots: one file per plotConfiguration entry, the entry as a JSON object keyed
+# by `plotId`.
+#
+# @keywords internal
+# @noRd
+.serializePlotConfigurationSet <- function(plotConfiguration) {
+  .serializePlotEntrySet(plotConfiguration, "plotId", "plot")
+}
+
+# @keywords internal
+# @noRd
+.parsePlotConfigurationTree <- function(records) {
+  .parsePlotEntryTree(records, "plotId", "plot", "Plot")
+}
+
+# plot-grids: one file per plotGrids entry, the entry as a JSON object keyed by
+# `plotGridId`.
+#
+# @keywords internal
+# @noRd
+.serializePlotGridSet <- function(plotGrids) {
+  .serializePlotEntrySet(plotGrids, "plotGridId", "plotGrid")
+}
+
+# @keywords internal
+# @noRd
+.parsePlotGridTree <- function(records) {
+  .parsePlotEntryTree(records, "plotGridId", "plotGrid", "PlotGrid")
+}
+
+# Shared serializer for the two keyed-list plots parts. Each entry of the keyed
+# list is already the per-file record shape, so this maps the in-memory
+# reference field back to its suffixless on-disk key (`dataCombinedId` ->
+# `dataCombined`, `plotIds` -> `plots`), drops the entry class (so `c("Plot",
+# "list")` never leaks into JSON), validates the key, and emits an
+# `id -> record` map. An empty / NULL part serializes to an empty map.
+#
+# @keywords internal
+# @noRd
+.serializePlotEntrySet <- function(entries, idField, entityLabel) {
+  entries <- entries %||% list()
+  out <- list()
+  for (id in names(entries)) {
+    rec <- entries[[id]]
+    recId <- rec[[idField]]
+    if (
+      is.null(recId) ||
+        !is.character(recId) ||
+        length(recId) != 1L ||
+        is.na(recId) ||
+        !nzchar(recId)
+    ) {
+      cli::cli_abort(c(
+        "A {.field {entityLabel}} entry has no usable {.field {idField}}.",
+        "x" = "{.field {idField}} must be a single non-empty string."
+      ))
+    }
+    .validateEntityTreeKey(id, entityLabel)
+    rec <- .plotRefFieldToKey(rec, class(rec)[[1]])
+    class(rec) <- "list"
+    out[[id]] <- rec
+  }
+  out
+}
+
+# Shared parser for the two keyed-list plots parts. Validates each record's
+# inner id against its filename, drops the load tag, and re-keys the entries
+# into a keyed list (each entry classed `c("<idClass>", "list")`).
+#
+# @keywords internal
+# @noRd
+.parsePlotEntryTree <- function(records, idField, entityLabel, idClass) {
+  if (is.null(records) || length(records) == 0L) {
+    return(list())
+  }
+  cleaned <- lapply(records, function(rec) {
+    .keyedTreeRecordId(rec, idField, entityLabel)
+    attr(rec, ".entityFile") <- NULL
+    rec
+  })
+  .parsePlotEntries(cleaned, idField, idClass)
+}
+
+# parameterIdentification: one file per task, the task's JSON object.
+#
+# @keywords internal
+# @noRd
+.serializePITaskSet <- function(tasks) {
+  tasks <- tasks %||% list()
+  out <- list()
+  for (id in names(tasks)) {
+    .validateEntityTreeKey(id, "parameterIdentification task")
+    task <- tasks[[id]]
+    out[[id]] <- list(
+      id = task$id,
+      scenarios = as.list(task$scenarios),
+      parameters = lapply(task$parameters, .piParameterToJson),
+      outputMappings = lapply(task$outputMappings, .piOutputMappingToJson),
+      configuration = task$configuration
+    )
+  }
+  out
+}
+
+# Structural backstop shared by the keyed kinds: a write-back under a key that
+# is not already canonical (mixed case, a forbidden character) is rejected,
+# pointing the user at the canonicalizing authoring API. The authoring API
+# (`add*` / `set*`) canonicalizes ids before they reach here, so a normal
+# mutation always passes; this catches a raw write-back
+# (`project$<section>[[key]] <- record`) that bypassed canonicalization. This
+# subsumes the old case-insensitive-collision guard: two keys differing only in
+# case cannot both be canonical, so they can never both reach the tree.
+#
+# @keywords internal
+# @noRd
+.validateEntityTreeKey <- function(key, entityLabel) {
+  canonical <- suppressWarnings(.canonicalizeId(key))
+  if (!identical(key, canonical)) {
+    cli::cli_abort(c(
+      "{entityLabel} id {.val {key}} is not a canonical entity-file id.",
+      "i" = "Use the add/set API, which canonicalizes it to {.val {canonical}}, \\
+      or store the entity under the key {.val {canonical}}."
+    ))
+  }
+  invisible(NULL)
+}
+
+# Load-side id guard shared by the keyed kinds. The write path enforces the
+# "id is the filename" contract (`.validateEntityTreeKey`), but the load path
+# applied none of it: a record missing its id field aborted with an opaque
+# base-R `list[[NULL]] <- x` error naming nothing, and a record whose inner id
+# disagreed with its filename loaded keyed by the inner id (breaking
+# canonicalized references and silently collapsing two files with the same inner
+# id into one). This returns the validated key to store the record under,
+# given the record, the name of its id field, and a human label for the kind:
+#   - the id field must be a non-empty scalar string (else abort naming the
+#     file, mirroring the PI-task message);
+#   - for a record loaded from a tree file (tagged with `.entityFile`), the
+#     inner id must equal the filename stem, so the on-disk filename stays the
+#     authoritative key and two files can never collapse onto one id.
+# An inline-snapshot record (no `.entityFile` tag) skips the filename check.
+#
+# @keywords internal
+# @noRd
+.keyedTreeRecordId <- function(record, idField, entityLabel) {
+  file <- attr(record, ".entityFile")
+  id <- record[[idField]]
+  if (!is.character(id) || length(id) != 1L || is.na(id) || !nzchar(id)) {
+    where <- if (is.null(file)) {
+      character()
+    } else {
+      c("i" = "Check {.file {file}}.")
+    }
+    cli::cli_abort(c(
+      "An entity file for kind {.field {entityLabel}} has no usable \\
+      {.field {idField}}.",
+      "x" = "{.field {idField}} must be a single non-empty string \\
+      (it names the entity and its file).",
+      where
+    ))
+  }
+  if (!is.null(file)) {
+    stem <- tools::file_path_sans_ext(basename(file))
+    if (!identical(id, stem)) {
+      cli::cli_abort(c(
+        "An entity file for kind {.field {entityLabel}} has a stored \\
+        {.field {idField}} that disagrees with its filename.",
+        "x" = "{.field {idField}} is {.val {id}} but the file is \\
+        {.val {stem}}.json.",
+        "i" = "The filename stem is the entity's id; rename the file or the \\
+        {.field {idField}} so they match. Check {.file {file}}."
+      ))
+    }
+  }
+  id
+}
+
+# Detect the `null -> {}` hand-edit corruption on a keyed record. The natural
+# `jsonlite::fromJSON(simplifyVector = FALSE) |> toJSON(auto_unbox = TRUE)`
+# round-trip re-emits each JSON `null` as an empty object `{}`, which decodes
+# back to a zero-length list with names `character(0)` (a JSON array `[]`
+# decodes to a zero-length list with `NULL` names, so the two are
+# distinguishable). None of the keyed record shapes
+# (scenarios / individuals / populations / parameter-sets / applications /
+# output-paths) holds a bare `{}` in any field, so any field that is an empty
+# object is the corruption signature, where a scalar (or `null`) was meant.
+# Aborts naming the field and the file with the generic fix.
+#
+# @keywords internal
+# @noRd
+.assertNoEmptyObjectFields <- function(record, entityLabel) {
+  file <- attr(record, ".entityFile")
+  for (field in names(record)) {
+    value <- record[[field]]
+    if (
+      is.list(value) &&
+        length(value) == 0L &&
+        identical(names(value), character(0))
+    ) {
+      where <- if (is.null(file)) {
+        character()
+      } else {
+        c("i" = "Check {.file {file}}.")
+      }
+      cli::cli_abort(c(
+        "An entity of kind {.field {entityLabel}} has an invalid \\
+        {.field {field}}.",
+        "x" = "{.field {field}} is an empty object {.code {{}}} where a single \\
+        value or {.code null} was expected.",
+        "i" = "A hand-edit that turned {.code \"{field}\": null} into {.code {{}}} \\
+        (the usual {.pkg jsonlite} round-trip) is the usual cause; restore the \\
+        value or remove the field.",
+        where
+      ))
+    }
+  }
+  invisible(NULL)
+}
+
+# Snapshot ----
+
+#' Write a derived single-file Project snapshot
+#'
+#' @description Renders a `Project` to a single self-contained `.esqlabsR`
+#'   snapshot file with every section inlined. The content is JSON; the
+#'   `.esqlabsR` extension marks the file as a portable shareable freeze-frame,
+#'   distinguishing it at a glance from the `Project.json` container of a live
+#'   tree project. The snapshot is derived; the authoritative form remains the
+#'   definitions tree (the `definitions/` directory next to the project file).
+#'   Reloading a snapshot with [loadSnapshot()] writes the project back out as
+#'   an on-disk `definitions/` tree (loading a snapshot materializes it) and
+#'   yields a `Project` structurally identical to the source, so snapshot then
+#'   load then snapshot is a fixed point.
+#'
+#'   Authoring is write-through: every `add*` / `remove*` / `set*` edit lands
+#'   in its definition file immediately, so `saveSnapshot()` is not needed to
+#'   persist edits. It produces the single-file shareable freeze-frame.
+#'
+#' @param project A `Project` object.
+#' @param path Path where the snapshot should be written. The output is
+#'   normalized to a `.esqlabsR` file: a path with no extension or a `.json`
+#'   extension is written as `.esqlabsR` (e.g. `"study1"` and `"study1.json"`
+#'   both write `study1.esqlabsR`); a `.esqlabsR` path is used verbatim; any
+#'   other explicit extension is honored as given (with an informational note
+#'   that `.esqlabsR` is the canonical form). Must resolve to a location other
+#'   than the project's own container (`project$jsonPath`): a snapshot is a
+#'   derived artifact, so writing it onto the authoritative tree's container
+#'   would inline sections that the `definitions/` tree already owns and the
+#'   two would diverge on reload. For an in-memory project (no `jsonPath`),
+#'   `path` is required.
+#'
+#' @returns Invisibly returns the (normalized) path the snapshot was written
+#'   to.
+#' @export
+#' @family project persistence
+#' @seealso [loadSnapshot()], [loadProject()].
+#' @examples
+#' # Scaffold a throwaway example project and snapshot it to a single file.
+#' dir <- file.path(tempdir(), "snapshot-example")
+#' dir.create(dir, showWarnings = FALSE)
+#' initProject(dir, type = "example", createExcel = FALSE)
+#' project <- loadProject(file.path(dir, "Project.json"))
+#' snapshot <- saveSnapshot(project, file.path(tempdir(), "study"))
+#' snapshot # the normalized .esqlabsR path
+saveSnapshot <- function(project, path = NULL) {
+  validateIsOfType(project, "Project")
+
+  if (is.null(path)) {
+    if (is.null(project$jsonPath)) {
+      cli::cli_abort(messages$noProjectPath())
+    }
+    cli::cli_abort(messages$snapshotOntoOwnContainer())
+  }
+
+  rawPath <- path
+  path <- .normalizeSnapshotPath(path)
+
+  # A snapshot is a derived freeze-frame, not the authoritative form. Writing
+  # it onto the project's own container would inline the sections while the
+  # `definitions/` tree (which wins on reload) stays in place, so the two would
+  # diverge. Refuse and point the user at a distinct location. Check both the
+  # path as given (so passing `project$jsonPath`, a `Project.json`, is refused
+  # even though it normalizes to `Project.esqlabsR`) and the normalized path
+  # (so a path that *lands* on the container is also caught).
+  if (!is.null(project$jsonPath)) {
+    container <- as.character(fs::path_abs(project$jsonPath))
+    targets <- c(
+      as.character(fs::path_abs(rawPath)),
+      as.character(fs::path_abs(path))
+    )
+    if (container %in% targets) {
+      cli::cli_abort(messages$snapshotOntoOwnContainer())
+    }
+  }
+
+  .saveProjectJson(project, path)
+  invisible(path)
+}
+
+# Normalize a snapshot output path to the `.esqlabsR` artifact extension. A
+# path with no extension or a `.json` extension becomes `.esqlabsR` (the
+# canonical portable-snapshot form); a `.esqlabsR` path is returned verbatim;
+# any other explicit extension is honored as given, with an informational note
+# that `.esqlabsR` is canonical so the user knows the convention but is not
+# overruled. The content is JSON either way.
+#
+# @keywords internal
+# @noRd
+.normalizeSnapshotPath <- function(path) {
+  ext <- fs::path_ext(path)
+  if (ext == "" || identical(tolower(ext), "json")) {
+    return(fs::path_ext_set(path, "esqlabsR"))
+  }
+  if (identical(ext, "esqlabsR")) {
+    return(path)
+  }
+  cli::cli_inform(c(
+    "i" = "Writing the snapshot to {.file {path}}, keeping the \\
+    {.field .{ext}} extension you gave.",
+    "i" = "The canonical single-file snapshot extension is {.field .esqlabsR}."
+  ))
+  path
+}
+
+#' Load a Project from a single-file snapshot, materializing its tree
+#'
+#' @description Reads a single self-contained snapshot file (a portable
+#'   freeze-frame with every section inlined) and writes it back out as a full
+#'   on-disk tree project at `dir`: a `Project.json` container plus a
+#'   `definitions/<kind>/` tree (one file per definition) for every section.
+#'   Loading a snapshot *is* materializing it; there is no separate materialize
+#'   step. The returned `Project` is bound to `dir`, so further `add*` /
+#'   `remove*` / `set*` edits are write-through to the new tree.
+#'
+#'   The canonical snapshot form is a `.esqlabsR` file (as written by
+#'   [saveSnapshot()]), but a plain inlined `Project.json` is also accepted for
+#'   back-compatibility (for example, the file [importProjectFromExcel()]
+#'   writes). The result is a normal tree project: [loadProject()] reads it back
+#'   from `dir` identically (section for section).
+#'
+#' @param file Path to the snapshot file to read (a `.esqlabsR` file, or a
+#'   plain inlined `Project.json`). Required; a snapshot path is never
+#'   optional.
+#' @param dir Target directory for the materialized tree project. Required.
+#'   It is created if it does not exist. If it already contains an esqlabsR
+#'   project, `loadSnapshot()` aborts rather than overwrite it; pass an empty
+#'   or new directory.
+#'
+#' @returns Object of type `Project`, bound to `dir`.
+#' @export
+#' @family project persistence
+#' @seealso [saveSnapshot()], [loadProject()].
+#' @examples
+#' # Write a snapshot, then materialize it into a fresh tree project.
+#' src <- file.path(tempdir(), "loadsnapshot-src")
+#' dir.create(src, showWarnings = FALSE)
+#' initProject(src, type = "example", createExcel = FALSE)
+#' snapshot <- saveSnapshot(
+#'   loadProject(file.path(src, "Project.json")),
+#'   file.path(tempdir(), "shared")
+#' )
+#' project <- loadSnapshot(snapshot, file.path(tempdir(), "restored"))
+loadSnapshot <- function(file, dir) {
+  validateIsString(file)
+  validateIsString(dir)
+  if (!file.exists(file)) {
+    cli::cli_abort(messages$fileNotFound(file))
+  }
+
+  if (isProjectInitialized(dir)) {
+    cli::cli_abort(messages$loadSnapshotDirNotEmpty(dir))
+  }
+  if (!dir.exists(dir)) {
+    dir.create(dir, recursive = TRUE, showWarnings = FALSE)
+  }
+
+  # A legacy or hand-authored snapshot may carry non-canonical ids (e.g.
+  # `Sim_A`, `Aciclovir_PVB`), but the entity tree keys files by canonical id,
+  # so the tree writer requires them. Canonicalize every id and every reference
+  # to one in the raw snapshot JSON before parsing it, so a legacy single-file
+  # `Project.json` migrates losslessly into the tree (definitions and references
+  # are transformed together with the same deterministic helper, so foreign keys
+  # still resolve). The canonicalized JSON is written to a throwaway file and
+  # loaded from there, so the in-memory project the tree is exploded from is
+  # already canonical.
+  jsonData <- jsonlite::fromJSON(file, simplifyVector = FALSE)
+  jsonData <- .canonicalizeProjectJsonIds(jsonData)
+  canonFile <- tempfile(fileext = ".json")
+  on.exit(unlink(canonFile), add = TRUE)
+  jsonlite::write_json(
+    jsonData,
+    canonFile,
+    auto_unbox = TRUE,
+    null = "null",
+    pretty = TRUE,
+    digits = NA
+  )
+
+  # Read the canonicalized snapshot into an in-memory `Project`, then explode it
+  # into the `definitions/<kind>/` tree at `dir`. Loading the materialized
+  # container back returns a tree-backed `Project` whose write-through edits land
+  # in `dir`.
+  snapshotProject <- loadProject(canonFile)
+  containerPath <- .writeProjectTree(snapshotProject, dir)
+  loadProject(containerPath)
+}
+
+# Explode an in-memory `Project` into a full on-disk tree project at `dir`: a
+# `Project.json` container plus a `definitions/<kind>/` tree (one file per
+# entity) for every section. Returns the container path. Reuses the
+# write-through serializer per kind (no parallel serializer); a keyed kind's
+# writer removes files that no longer correspond to a section entity, so a
+# re-run leaves no stale entries (idempotent overwrite). Shared by
+# `loadSnapshot()` and the Excel import.
+#
+# @keywords internal
+# @noRd
+.writeProjectTree <- function(project, dir) {
+  if (!dir.exists(dir)) {
+    dir.create(dir, recursive = TRUE, showWarnings = FALSE)
+  }
+  for (kind in .entityKindNames()) {
+    .writeEntityTree(.sectionForKind(project, kind), kind, project, dir)
+  }
+  # Write the container with the inline sections emptied: the tree owns them,
+  # matching the on-disk shape `loadProject()` reads for a tree project.
+  containerPath <- file.path(dir, "Project.json")
+  .saveProjectJson(project, containerPath, includeScenarios = FALSE)
+  containerPath
+}

--- a/R/entity-id.R
+++ b/R/entity-id.R
@@ -1,0 +1,321 @@
+# Entity id canonicalization + suggestion ----
+#
+# Every definition in a Project (a scenario, parameter set, individual,
+# population, application, output path, plot, ...) is referenced by its
+# **id**, and for the entity-file tree the id equals its on-disk filename.
+# Ids therefore have to be safe single path segments on every target
+# filesystem.
+#
+# Rather than rejecting an unsafe id, the authoring API runs it through a
+# deterministic canonicalizer (`.canonicalizeId()`) the moment it enters the
+# system: both when a definition is created (the `id` argument of an `add*`
+# / `set*` function) and when an id is referenced (a foreign-key argument
+# such as a scenario's `individualId` or its parameter-set list). Because the
+# transform is deterministic and applied identically on both sides, a
+# definition and a reference made from the same typed string always land on
+# the same canonical id, which is what makes lossy sanitization safe: a
+# reference still resolves even if the user types the un-sanitized form.
+#
+# A reference that has no matching definition (after canonicalization) is a
+# genuine referential problem; `.nearestMatch()` / `.suggestSuffix()` turn it
+# into a "did you mean '...'?" hint, surfaced by the cross-reference
+# validator.
+
+# Canonicalize one or more entity ids into safe, lowercase, single
+# path-segment ids. Vectorized over `ids`.
+#
+# Rules (intersection of Windows + macOS + Linux filename rules):
+#   - lowercase
+#   - replace each of `/ \ : * ? " < > |` and control characters with `_`
+#   - trim leading/trailing dots and spaces
+#   - an id that is empty or trims to nothing becomes `_`
+#   - a Windows reserved basename (CON, PRN, AUX, NUL, COM1-9, LPT1-9,
+#     case-insensitive) gets a `_` suffix so it is never a bare reserved name
+#
+# Warns (once per call) naming each `input -> canonical` pair that changed,
+# so the user knows the id that was actually used. Errors when two distinct
+# inputs in the same call canonicalize to the same id (real ambiguity, not a
+# fixable character issue).
+#
+# @keywords internal
+# @noRd
+.canonicalizeId <- function(ids) {
+  if (!is.character(ids)) {
+    cli::cli_abort("{.arg id} must be a character vector.")
+  }
+  if (length(ids) == 0L) {
+    return(ids)
+  }
+
+  canonical <- vapply(ids, .canonicalizeOneId, character(1), USE.NAMES = FALSE)
+
+  changed <- !is.na(ids) & ids != canonical
+  if (any(changed)) {
+    pairs <- paste0(
+      "{.val ",
+      ids[changed],
+      "} -> {.val ",
+      canonical[changed],
+      "}"
+    )
+    cli::cli_warn(c(
+      "Canonicalized {sum(changed)} id{?s} to a safe form:",
+      stats::setNames(pairs, rep("*", length(pairs)))
+    ))
+  }
+
+  # Two distinct inputs that collapse to one canonical id are real ambiguity.
+  dup <- canonical[duplicated(canonical)]
+  if (length(dup) > 0L) {
+    clashing <- unique(dup)
+    bullets <- vapply(
+      clashing,
+      function(c) {
+        offenders <- unique(ids[canonical == c])
+        # Interpolate the variables (so cli quotes each safely) rather than
+        # inlining user text into the glue expression itself.
+        cli::format_inline("{.val {offenders}} -> {.val {c}}")
+      },
+      character(1)
+    )
+    cli::cli_abort(c(
+      "Ids collide after canonicalization:",
+      stats::setNames(bullets, rep("x", length(bullets))),
+      "i" = "Two distinct ids that canonicalize to the same id are ambiguous; \\
+      rename so they differ by more than case or forbidden characters."
+    ))
+  }
+
+  canonical
+}
+
+# Canonicalize a foreign-key reference argument (e.g. a scenario's
+# `individualId`, or its `modelParameterSets` / `outputPathIds` vector) the
+# same way `.canonicalizeId()` canonicalizes a definition's id, so a
+# reference made from the same typed string as the definition resolves to
+# it. `NULL` passes through unchanged (the reference is absent), and so does
+# `NA` (the FK validators reject NA with their own clearer message). Unlike
+# `.canonicalizeId()`, this does not error on within-vector collisions: a
+# reference list is deduplicated by the lookup anyway.
+#
+# @keywords internal
+# @noRd
+.canonicalizeIdRef <- function(ref) {
+  if (is.null(ref) || !is.character(ref) || length(ref) == 0L) {
+    return(ref)
+  }
+  keep <- !is.na(ref) & nzchar(ref)
+  if (!any(keep)) {
+    return(ref)
+  }
+  out <- ref
+  canon <- vapply(
+    ref[keep],
+    .canonicalizeOneId,
+    character(1),
+    USE.NAMES = FALSE
+  )
+  changed <- ref[keep] != canon
+  if (any(changed)) {
+    # When a batch authoring call is collecting reference canonicalizations
+    # (`.collectCanonicalizedRefs()`), record each changed pair and stay
+    # silent so the caller emits one consolidated warning per call instead of
+    # one per entity. Outside a collector (a standalone call) warn immediately.
+    inputs <- ref[keep][changed]
+    canonicals <- canon[changed]
+    if (.canonRefSink$depth > 0L) {
+      .canonRefSink$inputs <- c(.canonRefSink$inputs, inputs)
+      .canonRefSink$canonicals <- c(.canonRefSink$canonicals, canonicals)
+    } else {
+      .warnCanonicalizedRefs(inputs, canonicals)
+    }
+  }
+  out[keep] <- canon
+  out
+}
+
+# Sink for collecting reference-canonicalization changes across the per-entity
+# builds of one vectorized authoring call, so the whole call emits a single
+# warning naming each `input -> canonical` change rather than one warning per
+# entity. `depth` guards re-entrancy; the inputs/canonicals accumulate the
+# changed pairs.
+#
+# @keywords internal
+# @noRd
+.canonRefSink <- new.env(parent = emptyenv())
+.canonRefSink$depth <- 0L
+.canonRefSink$inputs <- character()
+.canonRefSink$canonicals <- character()
+
+# Run `expr` while collecting every reference canonicalization it triggers
+# (via `.canonicalizeIdRef()`), then emit ONE consolidated warning naming each
+# unique `input -> canonical` change. The consolidated warning is flushed on
+# normal completion and, via a calling handler, before an error propagates, so
+# a batch that aborts partway still surfaces the canonicalizations that
+# happened before the abort (preserving the warning-then-error order the
+# per-entity path had). Re-entrant collectors share the outermost sink; only
+# the outermost one flushes.
+#
+# @keywords internal
+# @noRd
+.collectCanonicalizedRefs <- function(expr) {
+  outermost <- .canonRefSink$depth == 0L
+  if (outermost) {
+    .canonRefSink$inputs <- character()
+    .canonRefSink$canonicals <- character()
+  }
+  .canonRefSink$depth <- .canonRefSink$depth + 1L
+  flushed <- FALSE
+  flush <- function() {
+    if (flushed || !outermost) {
+      return(invisible(NULL))
+    }
+    flushed <<- TRUE
+    inputs <- .canonRefSink$inputs
+    canonicals <- .canonRefSink$canonicals
+    if (length(inputs) > 0L) {
+      # Deduplicate by pair, keeping first-seen order, so a reference repeated
+      # across several entities in the batch is named once.
+      key <- paste(inputs, canonicals, sep = "\r")
+      firstSeen <- !duplicated(key)
+      .warnCanonicalizedRefs(inputs[firstSeen], canonicals[firstSeen])
+    }
+  }
+  on.exit(
+    {
+      .canonRefSink$depth <- .canonRefSink$depth - 1L
+    },
+    add = TRUE
+  )
+  withCallingHandlers(
+    {
+      result <- force(expr)
+      flush()
+      result
+    },
+    error = function(cnd) {
+      # Flush the collected canonicalizations before the error unwinds the
+      # stack; the handler does not catch the error, so it propagates unchanged.
+      flush()
+    }
+  )
+}
+
+# Render the consolidated reference-canonicalization warning. Shared by the
+# standalone `.canonicalizeIdRef()` path and the batch collector so both emit
+# byte-identical text.
+#
+# @keywords internal
+# @noRd
+.warnCanonicalizedRefs <- function(inputs, canonicals) {
+  pairs <- paste0("{.val ", inputs, "} -> {.val ", canonicals, "}")
+  cli::cli_warn(c(
+    "Canonicalized {length(inputs)} referenced id{?s} to a safe form:",
+    stats::setNames(pairs, rep("*", length(pairs)))
+  ))
+}
+
+# Reserved Windows device basenames (case-insensitive), never allowed as a
+# bare filename on Windows.
+.windowsReservedBasenames <- c(
+  "con",
+  "prn",
+  "aux",
+  "nul",
+  paste0("com", 1:9),
+  paste0("lpt", 1:9)
+)
+
+# Canonicalize a single id (scalar). NA passes through unchanged so the
+# vectorized caller can flag it the same way a malformed value is flagged
+# upstream.
+#
+# @keywords internal
+# @noRd
+.canonicalizeOneId <- function(id) {
+  if (is.na(id)) {
+    return(NA_character_)
+  }
+  # An id becomes a filename (`<id>.json`), so it must fit the filesystem's
+  # per-component byte limit. Bound it before the transform so an over-long id
+  # aborts with a clear message naming the id and the limit, rather than the
+  # opaque `cannot open the connection` the eventual `write_json` would raise.
+  # 255 bytes is the common single-component cap (ext4, APFS, NTFS); leave room
+  # for the `.json` suffix.
+  limit <- .maxEntityIdBytes
+  nbytes <- nchar(id, type = "bytes")
+  if (nbytes > limit) {
+    cli::cli_abort(c(
+      "Entity id is too long to be a safe filename: {nbytes} bytes \\
+      (limit {limit}).",
+      "x" = "{.val {id}}",
+      "i" = "An id becomes the file {.file <id>.json}; shorten it to at most \\
+      {limit} bytes."
+    ))
+  }
+  out <- tolower(id)
+  # Forbidden characters and control characters -> underscore.
+  out <- gsub("[/\\:*?\"<>|[:cntrl:]]", "_", out)
+  # Trim leading/trailing dots and spaces (illegal as a trailing segment on
+  # Windows, and a leading dot hides the file on Unix).
+  out <- gsub("^[. ]+|[. ]+$", "", out)
+  if (nchar(out) == 0L) {
+    return("_")
+  }
+  if (out %in% .windowsReservedBasenames) {
+    out <- paste0(out, "_")
+  }
+  out
+}
+
+# Maximum byte length of an entity id, so `<id>.json` fits the common
+# single-path-component filesystem cap (255 bytes on ext4 / APFS / NTFS) with
+# room for the `.json` suffix.
+.maxEntityIdBytes <- 250L
+
+# Find the candidate ids closest to `x` (typo-tolerant). Mirrors ESQmrg's
+# `nearest_match`: `utils::adist(ignore.case = TRUE)`, a distance threshold of
+# `max(1, min(3, ceiling(nchar(x) / 3)))`, returning at most the `n` closest.
+# Returns `character(0)` when there are no candidates or nothing is within
+# threshold.
+#
+# @keywords internal
+# @noRd
+.nearestMatch <- function(x, candidates, n = 3L) {
+  if (length(candidates) == 0L) {
+    return(character(0))
+  }
+  d <- utils::adist(x, candidates, ignore.case = TRUE)[1, ]
+  ord <- order(d)
+  thr <- max(1L, min(3L, ceiling(nchar(x) / 3)))
+  keep <- ord[d[ord] <= thr]
+  candidates[utils::head(keep, n)]
+}
+
+# Build a "did you mean '...'?" suffix for a dangling reference `x` against
+# the existing `candidates`, or `""` when no candidate is close enough.
+# Appended to cross-reference validation messages.
+#
+# @keywords internal
+# @noRd
+.suggestSuffix <- function(x, candidates) {
+  near <- .nearestMatch(x, candidates)
+  if (length(near) == 0L) {
+    return("")
+  }
+  paste0(" (did you mean ", paste0("'", near, "'", collapse = ", "), "?)")
+}
+
+# Build a single "did you mean ...?" suffix for a set of dangling references
+# `xs` against the existing `candidates`: collects the closest candidate for
+# each dangling id, deduplicates, and renders one combined suffix (or `""`).
+#
+# @keywords internal
+# @noRd
+.suggestSuffixMulti <- function(xs, candidates) {
+  near <- unique(unlist(lapply(xs, function(x) .nearestMatch(x, candidates))))
+  if (length(near) == 0L) {
+    return("")
+  }
+  paste0(" (did you mean ", paste0("'", near, "'", collapse = ", "), "?)")
+}

--- a/R/individuals.R
+++ b/R/individuals.R
@@ -16,6 +16,8 @@
   numericFields <- c("weight", "height", "age")
   result <- list()
   for (entry in individualsData) {
+    id <- .keyedTreeRecordId(entry, "individualId", "individual")
+    .assertNoEmptyObjectFields(entry, "individual")
     indiv <- list()
     for (field in names(entry)) {
       if (field == "individualId") {
@@ -33,7 +35,7 @@
       indiv[[field]] <- val
     }
     class(indiv) <- c("Individual", "list")
-    result[[entry$individualId]] <- indiv
+    result[[id]] <- indiv
   }
   result
 }
@@ -49,20 +51,11 @@
   .validateIndividuals(project$individuals)
 }
 
-#' @keywords internal
-#' @noRd
-.individualParameterSetsValidatorAdapter <- function(project) {
-  .validateParameterSets(
-    project$individualParameterSets,
-    "individualParameterSets"
-  )
-}
-
 #' Validate the `individuals` section of a Project
 #'
 #' Checks `species` and `gender` are present and warns when numeric
 #' fields (`weight`, `height`, `age`) are non-numeric. Cross-references
-#' to `individualParameterSets` are validated in
+#' to `parameterSets` are validated in
 #' `.validateCrossReferences()`.
 #'
 #' @param individuals Named list from `project$individuals`.
@@ -108,51 +101,108 @@
   result
 }
 
+# Print ----
+
+#' @exportS3Method
+#' @noRd
+print.Individual <- function(x, ...) {
+  ospsuite.utils::ospPrintClass(x)
+  ospsuite.utils::ospPrintItems(
+    list(
+      "Species" = x$species %||% "",
+      "Population" = x$population %||% "",
+      "Gender" = x$gender %||% "",
+      "Weight" = x$weight %||% "",
+      "Height" = x$height %||% "",
+      "Age" = x$age %||% "",
+      "Parameter Sets" = paste(x$parameterSets, collapse = ", ")
+    ),
+    print_empty = TRUE
+  )
+  invisible(x)
+}
+
 # Public CRUD: individuals ----
 
-#' Add an individual to a Project
+#' Add one or more individuals to a Project
+#'
+#' Add individuals to `project$individuals`, vectorizing over a vector of ids
+#' (see the recycling rule under Details). Scalar-per-entity fields (`species`
+#' and the `...` fields `population`, `gender`, `weight`, `height`, `age`,
+#' `proteinOntogenies`) follow the recycle/align rule; `parameterSets` is
+#' vector-valued-per-entity (applied whole to every individual, or one vector
+#' per individual via a length-`id` list).
+#'
+#' @inherit vectorizedAuthoring details
 #'
 #' @param project A `Project` object.
-#' @param individualId Character scalar, unique ID for the individual.
-#' @param species Character scalar, species name.
+#' @param id Character vector of unique ids for the individuals (the number of
+#'   individuals to add). Each is canonicalized to a safe, lowercase id (a
+#'   warning names the result if it changed).
+#' @param species Character scalar (recycled) or the same length as `id`,
+#'   species name.
 #' @param ... Optional named fields: `population`, `gender`, `weight`,
 #'   `height`, `age`, `proteinOntogenies`, `parameterSets`. Numeric
 #'   fields are coerced via `as.double()`. `parameterSets` is a
-#'   character vector of ids referencing
-#'   `project$individualParameterSets`. Unknown fields trigger an
-#'   error.
+#'   character vector of ids referencing `project$parameterSets`.
+#'   Unknown fields trigger an error.
 #' @returns The `project` object, invisibly.
 #' @export
 #' @family individual
-addIndividual <- function(project, individualId, species, ...) {
+addIndividual <- function(project, id, species, ...) {
   validateIsOfType(project, "Project")
-  errors <- character()
-
-  if (
-    !is.character(individualId) ||
-      length(individualId) != 1L ||
-      is.na(individualId) ||
-      nchar(individualId) == 0
-  ) {
-    errors <- c(errors, "individualId must be a non-empty string")
-  } else if (individualId %in% names(project$individuals)) {
-    errors <- c(
-      errors,
-      paste0("individual '", individualId, "' already exists")
-    )
-  }
-
-  if (
-    !is.character(species) ||
-      length(species) != 1L ||
-      is.na(species) ||
-      nchar(species) == 0
-  ) {
-    errors <- c(errors, "species must be a non-empty string")
-  }
+  .assertIdVector(id)
+  id <- .canonicalizeId(id)
+  n <- length(id)
 
   dots <- list(...)
+  # `parameterSets` is the one vector-valued-per-entity field; everything else
+  # is scalar-per-entity. `species` is a positional formal, not a `...` field.
+  wholeNames <- intersect("parameterSets", names(dots))
+  scalarDots <- dots[setdiff(names(dots), wholeNames)]
+  perEntity <- .alignAuthoringArgs(
+    id,
+    scalarFields = c(list(species = species), scalarDots),
+    wholeFields = dots[wholeNames]
+  )
+
+  # Validate all N first (all-or-nothing): build every entry before folding any,
+  # so an invalid entity in the batch writes nothing.
+  clash <- intersect(id, names(project$individuals))
+  if (length(clash) > 0L) {
+    cli::cli_abort("individual {.val {clash}} already exists")
+  }
+  call <- rlang::current_env()
+  entries <- .collectCanonicalizedRefs(lapply(seq_len(n), function(i) {
+    .buildIndividualEntry(project, id[[i]], perEntity[[i]], call = call)
+  }))
+
+  # Fold all N into the section in memory, then ONE assignment triggers one
+  # write-through.
+  individuals <- project$.getSection("individuals") %||% list()
+  for (i in seq_len(n)) {
+    individuals[[id[[i]]]] <- entries[[i]]
+  }
+  project$.setSection("individuals", individuals)
+  invisible(project)
+}
+
+# Build one classed `Individual` entry from its id and per-entity field list,
+# validating the same way the scalar path always has (`species` and `gender`
+# required non-empty, `parameterSets` a resolvable character vector). Aborts
+# naming the individual on the first problem.
+#
+# @keywords internal
+# @noRd
+.buildIndividualEntry <- function(
+  project,
+  id,
+  fields,
+  call = rlang::caller_env()
+) {
+  errors <- character()
   allowed <- c(
+    "species",
     "population",
     "gender",
     "weight",
@@ -161,7 +211,7 @@ addIndividual <- function(project, individualId, species, ...) {
     "proteinOntogenies",
     "parameterSets"
   )
-  unknown <- setdiff(names(dots), allowed)
+  unknown <- setdiff(names(fields), allowed)
   if (length(unknown) > 0L) {
     errors <- c(
       errors,
@@ -174,11 +224,21 @@ addIndividual <- function(project, individualId, species, ...) {
     )
   }
 
+  species <- fields$species
+  if (
+    !is.character(species) ||
+      length(species) != 1L ||
+      is.na(species) ||
+      nchar(species) == 0
+  ) {
+    errors <- c(errors, "species must be a non-empty string")
+  }
+
   # `gender` is a required field per `.validateIndividuals()`; reject it at
   # add time so a gender-less individual cannot enter the project only to be
   # flagged as a Critical Error later (mirrors the validator's contract:
   # missing, NA, or empty are all invalid).
-  gender <- dots$gender
+  gender <- fields$gender
   if (
     is.null(gender) ||
       !is.character(gender) ||
@@ -190,221 +250,261 @@ addIndividual <- function(project, individualId, species, ...) {
   }
 
   if (length(errors) > 0L) {
-    cli::cli_abort(c(
-      "Cannot add individual {.val {individualId}}:",
-      stats::setNames(errors, rep("x", length(errors)))
-    ))
+    cli::cli_abort(
+      c(
+        "Cannot add individual {.val {id}}:",
+        stats::setNames(errors, rep("x", length(errors)))
+      ),
+      call = call
+    )
   }
 
   entry <- list(species = species)
   for (field in c("population", "gender", "proteinOntogenies")) {
-    if (!is.null(dots[[field]])) entry[[field]] <- dots[[field]]
+    if (!is.null(fields[[field]])) entry[[field]] <- fields[[field]]
   }
   for (field in c("weight", "height", "age")) {
-    if (!is.null(dots[[field]])) {
-      entry[[field]] <- as.double(dots[[field]])
+    if (!is.null(fields[[field]])) {
+      entry[[field]] <- as.double(fields[[field]])
     }
   }
-  if (!is.null(dots$parameterSets)) {
-    if (!is.character(dots$parameterSets)) {
+  if (!is.null(fields$parameterSets)) {
+    if (!is.character(fields$parameterSets)) {
       cli::cli_abort(
-        "{.arg parameterSets} must be a character vector of set ids"
+        "{.arg parameterSets} must be a character vector of set ids",
+        call = call
       )
     }
-    bad <- setdiff(
-      dots$parameterSets,
-      names(project$individualParameterSets %||% list())
-    )
+    sets <- .canonicalizeIdRef(fields$parameterSets)
+    bad <- setdiff(sets, names(project$parameterSets %||% list()))
     if (length(bad) > 0L) {
-      cli::cli_abort(c(
-        "{.arg parameterSets} references undefined individual parameter sets:",
-        "x" = "{.val {bad}}"
-      ))
+      cli::cli_abort(
+        c(
+          "{.arg parameterSets} references undefined parameter sets:",
+          "x" = "{.val {bad}}"
+        ),
+        call = call
+      )
     }
-    entry$parameterSets <- dots$parameterSets
+    entry$parameterSets <- sets
   }
   class(entry) <- c("Individual", "list")
-
-  project$individuals[[individualId]] <- entry
-  project$.markModified()
-  invisible(project)
+  entry
 }
 
-#' Remove an individual from a Project
+#' Remove one or more individuals from a Project
+#'
+#' Drop the individuals with matching ids in one write-through. Warns (and
+#' skips) any id not present, and warns when a removed individual is still
+#' referenced.
 #'
 #' @param project A `Project` object.
-#' @param individualId Character scalar, ID of the individual to remove.
+#' @param id Character vector of individual ids to remove. Each is
+#'   canonicalized the same way [addIndividual()] canonicalizes it.
 #' @returns The `project` object, invisibly.
 #' @export
 #' @family individual
-removeIndividual <- function(project, individualId) {
+removeIndividual <- function(project, id) {
   validateIsOfType(project, "Project")
-  if (
-    !is.character(individualId) ||
-      length(individualId) != 1L ||
-      is.na(individualId) ||
-      nchar(individualId) == 0
-  ) {
-    cli::cli_abort("{.arg individualId} must be a non-empty string")
+  .assertIdVector(id)
+  id <- .canonicalizeId(id)
+
+  missingIds <- setdiff(id, names(project$individuals))
+  if (length(missingIds) > 0L) {
+    cli::cli_warn("individual {.val {missingIds}} not found; no-op.")
   }
-  if (!(individualId %in% names(project$individuals))) {
-    cli::cli_warn("individual {.val {individualId}} not found; no-op.")
+  toRemove <- intersect(id, names(project$individuals))
+  if (length(toRemove) == 0L) {
     return(invisible(project))
   }
-  .warnIfReferenced(project, "individual", individualId)
-  project$individuals[[individualId]] <- NULL
-  project$.markModified()
+  for (one in toRemove) {
+    .warnIfReferenced(project, "individual", one)
+  }
+  individuals <- project$.getSection("individuals")
+  individuals[toRemove] <- NULL
+  project$.setSection("individuals", individuals)
   invisible(project)
 }
 
-#' Replace the parameter-set references on an individual
+#' Modify fields of an existing individual
+#'
+#' @description Changes one or more fields of the individual identified by
+#'   `id` and persists the change immediately to the individual definition
+#'   (write-through). The `project$individuals` accessor is read-only, so this
+#'   is the way to revise an existing individual in place.
+#'
+#'   Only the arguments you pass via `...` are changed; every other field
+#'   keeps its current value (partial update). Validation matches
+#'   [addIndividual()]: numeric fields (`weight`, `height`, `age`) are
+#'   coerced via `as.double()`, `gender` (if supplied) must be a non-empty
+#'   string, and `parameterSets` (if supplied) must be a character vector of
+#'   ids that resolve in `project$parameterSets`. The required
+#'   `species` field, if supplied, must be a non-empty string.
+#'
+#' @inherit vectorizedAuthoring details
 #'
 #' @param project A `Project` object.
-#' @param individualId Character scalar.
-#' @param parameterSets Character vector of set ids (from
-#'   `project$individualParameterSets`). Use `character(0)` to clear.
+#' @param id Character vector. Ids of the individuals to modify. Each is
+#'   canonicalized the same way [addIndividual()] canonicalizes it, and must
+#'   already exist in `project$individuals`.
+#' @param ... Named fields to change. Accepted: `species`, `population`,
+#'   `gender`, `weight`, `height`, `age`, `proteinOntogenies`,
+#'   `parameterSets`. Scalar-per-entity fields recycle/align across `id`;
+#'   `parameterSets` is applied whole (or one vector per individual via a
+#'   length-`id` list). Unknown fields trigger an error.
+#'
 #' @returns The `project` object, invisibly.
 #' @export
 #' @family individual
-setIndividualParameterSets <- function(project, individualId, parameterSets) {
+setIndividual <- function(project, id, ...) {
   validateIsOfType(project, "Project")
-  if (!(individualId %in% names(project$individuals))) {
-    cli::cli_abort("individual {.val {individualId}} not found")
-  }
-  if (!is.character(parameterSets)) {
-    cli::cli_abort("{.arg parameterSets} must be a character vector")
-  }
-  bad <- setdiff(
-    parameterSets,
-    names(project$individualParameterSets %||% list())
-  )
-  if (length(bad) > 0L) {
+  .assertIdVector(id)
+  id <- .canonicalizeId(id)
+  n <- length(id)
+  missingIds <- setdiff(id, names(project$individuals))
+  if (length(missingIds) > 0L) {
     cli::cli_abort(c(
-      "{.arg parameterSets} references undefined individual parameter sets:",
-      "x" = "{.val {bad}}"
+      "Cannot modify individual {.val {missingIds}}: it does not exist.",
+      "i" = "Use {.fn addIndividual} to create it first."
     ))
   }
-  project$individuals[[individualId]]$parameterSets <- parameterSets
-  project$.markModified()
-  invisible(project)
-}
 
-# Public CRUD: individualParameterSets ----
-
-#' Create an individual parameter set
-#' @param project A `Project` object.
-#' @param id Character scalar, set name. Must not already exist.
-#' @returns The `project` object, invisibly.
-#' @export
-#' @family parameters
-addIndividualParameterSet <- function(project, id) {
-  validateIsOfType(project, "Project")
-  if (!is.character(id) || length(id) != 1L || is.na(id) || nchar(id) == 0) {
-    cli::cli_abort("{.arg id} must be a non-empty string")
-  }
-  if (id %in% names(project$individualParameterSets)) {
-    cli::cli_abort("individual parameter set {.val {id}} already exists")
-  }
-  project$individualParameterSets[[id]] <- list()
-  project$.markModified()
-  invisible(project)
-}
-
-#' Remove an individual parameter set
-#' @inheritParams addIndividualParameterSet
-#' @returns The `project` object, invisibly.
-#' @export
-#' @family parameters
-removeIndividualParameterSet <- function(project, id) {
-  validateIsOfType(project, "Project")
-  if (!(id %in% names(project$individualParameterSets))) {
-    cli::cli_warn("individual parameter set {.val {id}} not found; no-op.")
-    return(invisible(project))
-  }
-  .warnIfReferenced(project, "individualParameterSet", id)
-  project$individualParameterSets[[id]] <- NULL
-  project$.markModified()
-  invisible(project)
-}
-
-#' Add a parameter entry to a named individual parameter set
-#'
-#' Adds one parameter entry to the named set in
-#' `project$individualParameterSets`. The set is created on demand if it
-#' does not yet exist. Last-write-wins on duplicate paths.
-#'
-#' @param project A `Project` object.
-#' @param id Character scalar, set name. Created if not present.
-#' @param containerPath Character scalar.
-#' @param parameterName Character scalar.
-#' @param value Numeric scalar.
-#' @param units Character scalar.
-#' @returns The `project` object, invisibly.
-#' @export
-#' @family parameters
-addIndividualParameterEntry <- function(
-  project,
-  id,
-  containerPath,
-  parameterName,
-  value,
-  units
-) {
-  validateIsOfType(project, "Project")
-  if (!is.character(id) || length(id) != 1L || is.na(id) || nchar(id) == 0) {
-    cli::cli_abort("{.arg id} must be a non-empty string")
-  }
-  current <- project$individualParameterSets[[id]]
-  project$individualParameterSets[[id]] <- .addParameterEntry(
-    current,
-    containerPath,
-    parameterName,
-    value,
-    units
+  dots <- list(...)
+  wholeNames <- intersect("parameterSets", names(dots))
+  scalarDots <- dots[setdiff(names(dots), wholeNames)]
+  perEntity <- .alignAuthoringArgs(
+    id,
+    scalarFields = scalarDots,
+    wholeFields = dots[wholeNames]
   )
-  project$.markModified()
+  # Only the field names the caller actually supplied are applied (partial
+  # update); the engine carries every supplied field for each entity.
+  suppliedNames <- names(dots)
+
+  call <- rlang::current_env()
+  entries <- .collectCanonicalizedRefs(lapply(seq_len(n), function(i) {
+    .setOneIndividual(
+      project,
+      id[[i]],
+      perEntity[[i]][suppliedNames],
+      call = call
+    )
+  }))
+
+  individuals <- project$.getSection("individuals")
+  for (i in seq_len(n)) {
+    individuals[[id[[i]]]] <- entries[[i]]
+  }
+  project$.setSection("individuals", individuals)
   invisible(project)
 }
 
-#' Remove a parameter entry from a named individual parameter set
+# Apply a partial-update field set to one existing individual, returning the
+# updated classed entry. Validates only the supplied fields, matching the
+# scalar partial-update contract. Aborts naming the individual on a problem.
+#
+# @keywords internal
+# @noRd
+.setOneIndividual <- function(project, id, fields, call = rlang::caller_env()) {
+  allowed <- c(
+    "species",
+    "population",
+    "gender",
+    "weight",
+    "height",
+    "age",
+    "proteinOntogenies",
+    "parameterSets"
+  )
+  unknown <- setdiff(names(fields), allowed)
+  if (length(unknown) > 0L) {
+    cli::cli_abort(
+      c(
+        "Cannot modify individual {.val {id}}:",
+        "x" = "unknown fields: {.val {unknown}}. Allowed: {.val {allowed}}."
+      ),
+      call = call
+    )
+  }
+
+  if ("species" %in% names(fields)) {
+    species <- fields$species
+    if (
+      !is.character(species) ||
+        length(species) != 1L ||
+        is.na(species) ||
+        nchar(species) == 0
+    ) {
+      cli::cli_abort("{.arg species} must be a non-empty string", call = call)
+    }
+  }
+  if ("gender" %in% names(fields)) {
+    gender <- fields$gender
+    if (
+      is.null(gender) ||
+        !is.character(gender) ||
+        length(gender) != 1L ||
+        is.na(gender) ||
+        nchar(gender) == 0
+    ) {
+      cli::cli_abort("{.arg gender} must be a non-empty string", call = call)
+    }
+  }
+  if ("parameterSets" %in% names(fields)) {
+    if (!is.character(fields$parameterSets)) {
+      cli::cli_abort(
+        "{.arg parameterSets} must be a character vector of set ids",
+        call = call
+      )
+    }
+    fields$parameterSets <- .canonicalizeIdRef(fields$parameterSets)
+    bad <- setdiff(
+      fields$parameterSets,
+      names(project$parameterSets %||% list())
+    )
+    if (length(bad) > 0L) {
+      cli::cli_abort(
+        c(
+          "{.arg parameterSets} references undefined parameter sets:",
+          "x" = "{.val {bad}}"
+        ),
+        call = call
+      )
+    }
+  }
+
+  entry <- project$individuals[[id]]
+  for (field in names(fields)) {
+    if (field %in% c("weight", "height", "age")) {
+      entry[[field]] <- as.double(fields[[field]])
+    } else {
+      entry[[field]] <- fields[[field]]
+    }
+  }
+  class(entry) <- c("Individual", "list")
+  entry
+}
+
+#' Replace the parameter-set references on one or more individuals
 #'
-#' Removes one parameter entry from the named set. If the removed entry
-#' was the last in the set, the set itself is auto-removed from
-#' `project$individualParameterSets`. Warns if the set or entry doesn't
-#' exist.
+#' @description A convenience wrapper for
+#'   `setIndividual(project, id, parameterSets = parameterSets)`, which is the
+#'   canonical way to change an individual's parameter-set references.
+#'   Prefer [setIndividual()] directly; this function exists for callers that
+#'   only need to replace the references.
 #'
-#' @inheritParams addIndividualParameterEntry
+#' @inherit vectorizedAuthoring details
+#'
+#' @param project A `Project` object.
+#' @param id Character vector of individual ids. Each is canonicalized the
+#'   same way [addIndividual()] canonicalizes it.
+#' @param parameterSets Character vector of set ids (from
+#'   `project$parameterSets`), applied whole to every individual; use
+#'   `character(0)` to clear. To set a different list per individual, pass a
+#'   list of the same length as `id` (one character vector per individual).
 #' @returns The `project` object, invisibly.
 #' @export
-#' @family parameters
-removeIndividualParameterEntry <- function(
-  project,
-  id,
-  containerPath,
-  parameterName
-) {
-  validateIsOfType(project, "Project")
-  if (!is.character(id) || length(id) != 1L) {
-    cli::cli_abort("{.arg id} must be a string scalar")
-  }
-  if (!(id %in% names(project$individualParameterSets))) {
-    cli::cli_warn("individual parameter set {.val {id}} not found; no-op.")
-    return(invisible(project))
-  }
-  result <- .removeParameterEntry(
-    project$individualParameterSets[[id]],
-    containerPath,
-    parameterName
-  )
-  if (!result$removed) {
-    return(invisible(project))
-  }
-  if (is.null(result$parameters)) {
-    .warnIfReferenced(project, "individualParameterSet", id)
-    project$individualParameterSets[[id]] <- NULL
-  } else {
-    project$individualParameterSets[[id]] <- result$parameters
-  }
-  project$.markModified()
-  invisible(project)
+#' @family individual
+setIndividualParameterSets <- function(project, id, parameterSets) {
+  setIndividual(project, id, parameterSets = parameterSets)
 }

--- a/R/observed-data.R
+++ b/R/observed-data.R
@@ -25,6 +25,25 @@
   project$.__enclos_env__$private
 }
 
+# Print ----
+
+#' @exportS3Method
+#' @noRd
+print.ObservedDataSource <- function(x, ...) {
+  ospsuite.utils::ospPrintClass(x)
+  ospsuite.utils::ospPrintItems(
+    list(
+      "Type" = x$type %||% "",
+      "File" = x$file %||% "",
+      "Name" = x$name %||% "",
+      "Importer Configuration" = x$importerConfiguration %||% "",
+      "Sheets" = paste(unlist(x$sheets), collapse = ", ")
+    ),
+    print_empty = TRUE
+  )
+  invisible(x)
+}
+
 # Section validation adapter ----
 
 #' @keywords internal
@@ -247,10 +266,13 @@ addObservedData <- function(project, entry) {
       )
     }
     state$.programmaticDataSets[[name]] <- entry
-    sentinel <- list(type = "programmatic", name = name)
+    sentinel <- .asObservedDataSource(list(type = "programmatic", name = name))
     # The observedData setter resets the names cache, so the cache must be
     # rebuilt after the write, from the names known before it.
-    project$observedData <- c(project$observedData, list(sentinel))
+    project$.setSection(
+      "observedData",
+      c(project$.getSection("observedData"), list(sentinel))
+    )
     state$.observedDataNamesCache <- c(existingNames, name)
     cli::cli_inform(c(
       "i" = paste0(
@@ -293,7 +315,13 @@ addObservedData <- function(project, entry) {
       )
     }
     state$.observedDataNamesCache <- NULL
-    project$observedData <- c(project$observedData, list(entry))
+    project$.setSection(
+      "observedData",
+      c(
+        project$.getSection("observedData"),
+        list(.asObservedDataSource(entry))
+      )
+    )
     return(invisible(project))
   }
 
@@ -302,67 +330,90 @@ addObservedData <- function(project, entry) {
   )
 }
 
-#' Remove observed data from a Project
+#' Remove one or more observed-data sources from a Project
 #'
 #' Removes by DataSet name (for `type = "programmatic"` entries) or by
 #' `file` basename (for `type` `"excel"` / `"pkml"` / `"script"`
-#' entries). Warns and is a no-op if no matching entry is found.
+#' entries). Vectorizes over a vector of ids, removing each in one
+#' write-through. Warns and skips any id with no matching entry.
+#'
+#' Unlike the other authoring functions, `addObservedData()` is not
+#' vectorized over ids: its second argument is a `DataSet` or a configuration
+#' list, not an id, so it adds a single source per call. Add several sources
+#' with several calls.
 #'
 #' @param project A `Project` object.
-#' @param name DataSet name or config entry file basename.
+#' @param id Character vector of ids. An observed-data id comes from the data
+#'   source (an OSPS `DataSet` name or a file basename) and is matched
+#'   verbatim, not canonicalized.
 #' @returns The `project` object, invisibly.
 #' @export
 #' @family observedData
-removeObservedData <- function(project, name) {
+removeObservedData <- function(project, id) {
   validateIsOfType(project, "Project")
-  if (
-    !is.character(name) ||
-      length(name) != 1L ||
-      is.na(name) ||
-      nchar(name) == 0
-  ) {
-    cli::cli_abort("{.arg name} must be a non-empty string")
-  }
+  .assertIdVector(id)
   state <- .projectPrivate(project)
+  observedData <- project$.getSection("observedData")
 
-  if (name %in% names(state$.programmaticDataSets)) {
-    .warnIfObservedDataReferenced(project, name)
-    state$.programmaticDataSets[[name]] <- NULL
+  # Resolve every id to the section index it removes (a programmatic sentinel or
+  # a file-based entry) before touching anything, so the whole batch is
+  # validated first and applied in a single write-through, matching the
+  # all-or-nothing invariant every other vectorized remove* upholds.
+  dropIdx <- integer()
+  programmaticNames <- character()
+  missingIds <- character()
+  for (one in id) {
+    if (one %in% names(state$.programmaticDataSets)) {
+      programmaticNames <- c(programmaticNames, one)
+      matchIdx <- which(vapply(
+        observedData,
+        function(e) {
+          identical(e$type, "programmatic") && identical(e$name, one)
+        },
+        logical(1)
+      ))
+      dropIdx <- c(dropIdx, matchIdx)
+      next
+    }
     matchIdx <- which(vapply(
-      project$observedData,
+      observedData,
       function(e) {
-        identical(e$type, "programmatic") && identical(e$name, name)
+        !is.null(e[["file"]]) && identical(basename(e[["file"]]), one)
       },
       logical(1)
     ))
-    if (length(matchIdx) > 0L) {
-      project$observedData <- project$observedData[-matchIdx[[1]]]
+    if (length(matchIdx) == 0L) {
+      missingIds <- c(missingIds, one)
+      next
     }
-    state$.observedDataNamesCache <- NULL
+    dropIdx <- c(dropIdx, matchIdx)
+  }
+
+  if (length(missingIds) > 0L) {
+    cli::cli_warn("observedData entry {.val {missingIds}} not found; no-op.")
+  }
+  # Warn once per removed id that is still referenced, then drop everything in a
+  # single write. A not-found id contributes nothing to the write.
+  for (one in setdiff(id, missingIds)) {
+    .warnIfObservedDataReferenced(project, one)
+  }
+  if (length(dropIdx) == 0L && length(programmaticNames) == 0L) {
     return(invisible(project))
   }
 
-  matchIdx <- which(vapply(
-    project$observedData,
-    function(e) {
-      !is.null(e[["file"]]) && identical(basename(e[["file"]]), name)
-    },
-    logical(1)
-  ))
-
-  if (length(matchIdx) == 0L) {
-    cli::cli_warn("observedData entry {.val {name}} not found; no-op.")
-    return(invisible(project))
+  for (name in programmaticNames) {
+    state$.programmaticDataSets[[name]] <- NULL
   }
-
-  .warnIfObservedDataReferenced(project, name)
-  project$observedData <- project$observedData[-matchIdx[[1]]]
+  if (length(dropIdx) > 0L) {
+    observedData <- observedData[-unique(dropIdx)]
+  }
+  project$.setSection("observedData", observedData)
   state$.observedDataNamesCache <- NULL
   invisible(project)
 }
 
 # Warn when a removed observedData name is still referenced as a
-# `dataSet` by any `plots$dataCombined` observed entry. Removal proceeds
+# `dataSet` by any `dataCombined` observed entry. Removal proceeds
 # anyway, leaving the dangling reference for the next validateProject()
 # call to surface, matching the .warnIfReferenced() convention used by
 # the other remove*() mutators.
@@ -370,7 +421,7 @@ removeObservedData <- function(project, name) {
 # @keywords internal
 # @noRd
 .warnIfObservedDataReferenced <- function(project, name) {
-  dataCombined <- project$plots$dataCombined %||% list()
+  dataCombined <- .unwrapDefinitionList(project$dataCombined) %||% list()
   holders <- character()
   for (dcName in names(dataCombined)) {
     observed <- dataCombined[[dcName]]$observed %||% list()

--- a/R/output-paths.R
+++ b/R/output-paths.R
@@ -5,6 +5,151 @@
 # parsing is shallow (no helpers needed beyond the parser default), so
 # this file owns validation and mutation.
 
+# Public CRUD: output paths ----
+
+#' Add one or more output paths to a Project
+#'
+#' Add output paths to `project$outputPaths`, vectorizing over a vector of ids
+#' (see the recycling rule under Details). `path` is scalar-per-entity: a
+#' single path is recycled to every id, or a length-`id` vector aligns by
+#' position.
+#'
+#' @inherit vectorizedAuthoring details
+#'
+#' @param project A `Project` object.
+#' @param id Character vector of output path ids (unique within the call and
+#'   not already present in `project$outputPaths`). Each is canonicalized.
+#' @param path Character vector of output paths, length 1 (recycled) or the
+#'   same length as `id`.
+#' @returns The `project` object, invisibly.
+#' @export
+#' @family output path
+addOutputPath <- function(project, id, path) {
+  validateIsOfType(project, "Project")
+  # Route the id-vector check through the shared helper every sibling add* uses,
+  # then canonicalize (which aborts on an in-batch collision, so no separate
+  # duplicate guard is needed).
+  .assertIdVector(id)
+  id <- .canonicalizeId(id)
+
+  if (
+    !is.character(path) ||
+      !(length(path) == 1L || length(path) == length(id))
+  ) {
+    cli::cli_abort(c(
+      "Cannot add outputPath:",
+      "x" = "path must be a character vector of length 1 or the same \\
+      length as id"
+    ))
+  }
+  clash <- intersect(id, names(project$outputPaths))
+  if (length(clash) > 0L) {
+    cli::cli_abort("outputPath {.val {clash}} already exists")
+  }
+
+  # Recycle a single path to every id (the scalar-per-entity rule).
+  if (length(path) == 1L) {
+    path <- rep(path, length(id))
+  }
+  newPaths <- as.list(path)
+  names(newPaths) <- id
+  outputPaths <- c(project$.getSection("outputPaths"), newPaths)
+  project$.setSection("outputPaths", outputPaths)
+  invisible(project)
+}
+
+#' Remove one or more output paths from a Project
+#'
+#' Drop the output paths with matching ids in one write-through. Warns (and
+#' skips) any id not present, and warns when a removed output path is still
+#' referenced.
+#'
+#' @param project A `Project` object.
+#' @param id Character vector of output-path ids to remove. Each is
+#'   canonicalized the same way [addOutputPath()] canonicalizes it.
+#' @returns The `project` object, invisibly.
+#' @export
+#' @family output path
+removeOutputPath <- function(project, id) {
+  validateIsOfType(project, "Project")
+  .assertIdVector(id)
+  id <- .canonicalizeId(id)
+
+  missingIds <- setdiff(id, names(project$outputPaths))
+  if (length(missingIds) > 0L) {
+    cli::cli_warn("outputPath {.val {missingIds}} not found; no-op.")
+  }
+  toRemove <- intersect(id, names(project$outputPaths))
+  if (length(toRemove) == 0L) {
+    return(invisible(project))
+  }
+  for (one in toRemove) {
+    .warnIfReferenced(project, "outputPath", one)
+  }
+  outputPaths <- project$.getSection("outputPaths")
+  outputPaths <- outputPaths[setdiff(names(outputPaths), toRemove)]
+  project$.setSection("outputPaths", outputPaths)
+  invisible(project)
+}
+
+#' Change the literal path of one or more existing output paths
+#'
+#' @description Updates the OSPS-notation path string bound to existing
+#'   output-path ids and persists the change immediately to the output-path
+#'   definition (write-through). The ids themselves are not changed (use
+#'   [removeOutputPath()] + [addOutputPath()] to rename), so
+#'   every scenario that records these output paths keeps referencing them.
+#'   The `project$outputPaths` accessor is read-only, so this is the way to
+#'   change a path in place. The call vectorizes over a vector of ids (see the
+#'   recycling rule under Details); `path` is scalar-per-entity (one path
+#'   recycled to every id, or a length-`id` vector aligned by position).
+#'
+#' @inherit vectorizedAuthoring details
+#'
+#' @param project A `Project` object.
+#' @param id Character vector. The output-path ids to modify. Each must
+#'   already exist in `project$outputPaths`.
+#' @param path Character vector of new non-empty OSPS-notation path strings,
+#'   length 1 (recycled) or the same length as `id`.
+#'
+#' @returns The `project` object, invisibly.
+#' @export
+#' @family output path
+setOutputPath <- function(project, id, path) {
+  validateIsOfType(project, "Project")
+  .assertIdVector(id)
+  id <- .canonicalizeId(id)
+  n <- length(id)
+  missingIds <- setdiff(id, names(project$outputPaths))
+  if (length(missingIds) > 0L) {
+    cli::cli_abort(c(
+      "Cannot modify output path {.val {missingIds}}: it does not exist.",
+      "i" = "Use {.fn addOutputPath} to create it first."
+    ))
+  }
+  perId <- .recycleField(path, n, "path")
+  for (i in seq_len(n)) {
+    one <- perId[[i]]
+    if (
+      !is.character(one) ||
+        length(one) != 1L ||
+        is.na(one) ||
+        nchar(one) == 0
+    ) {
+      cli::cli_abort("{.arg path} must contain non-empty strings")
+    }
+  }
+
+  outputPaths <- project$.getSection("outputPaths")
+  for (i in seq_len(n)) {
+    outputPaths[[id[[i]]]] <- perId[[i]]
+  }
+  project$.setSection("outputPaths", outputPaths)
+  invisible(project)
+}
+
+# Section validation adapter ----
+
 #' @keywords internal
 #' @noRd
 .outputPathsValidatorAdapter <- function(project) {
@@ -56,91 +201,4 @@
   }
 
   result
-}
-
-#' Add output paths to a Project
-#'
-#' @param project A `Project` object.
-#' @param id Character vector of output path IDs (unique within the call
-#'   and not already present in `project$outputPaths`).
-#' @param path Character vector of output paths, same length as `id`.
-#' @returns The `project` object, invisibly.
-#' @export
-#' @family scenario
-addOutputPath <- function(project, id, path) {
-  validateIsOfType(project, "Project")
-  errors <- character()
-
-  if (
-    !is.character(id) ||
-      length(id) < 1L ||
-      any(is.na(id)) ||
-      any(nchar(id) == 0)
-  ) {
-    errors <- c(errors, "id must be a non-empty character vector")
-  }
-  if (!is.character(path) || length(path) != length(id)) {
-    errors <- c(
-      errors,
-      "id and path must be character vectors of the same length"
-    )
-  }
-  if (is.character(id) && any(duplicated(id))) {
-    errors <- c(
-      errors,
-      paste0(
-        "duplicate ids within call: ",
-        paste(unique(id[duplicated(id)]), collapse = ", ")
-      )
-    )
-  }
-  if (is.character(id)) {
-    collisions <- intersect(id, names(project$outputPaths))
-    if (length(collisions) > 0) {
-      errors <- c(
-        errors,
-        paste0(
-          "outputPath id already exists: ",
-          paste(collisions, collapse = ", ")
-        )
-      )
-    }
-  }
-
-  if (length(errors) > 0) {
-    cli::cli_abort(c(
-      "Cannot add outputPath:",
-      stats::setNames(errors, rep("x", length(errors)))
-    ))
-  }
-
-  newPaths <- as.list(path)
-  names(newPaths) <- id
-  project$outputPaths <- c(project$outputPaths, newPaths)
-  project$.markModified()
-  invisible(project)
-}
-
-#' Remove an output path from a Project
-#' @param project A `Project` object.
-#' @param id Character scalar.
-#' @returns The `project` object, invisibly.
-#' @export
-#' @family scenario
-removeOutputPath <- function(project, id) {
-  validateIsOfType(project, "Project")
-  if (!is.character(id) || length(id) != 1L || is.na(id) || nchar(id) == 0) {
-    cli::cli_abort("{.arg id} must be a non-empty string")
-  }
-  if (!(id %in% names(project$outputPaths))) {
-    cli::cli_warn("outputPath {.val {id}} not found; no-op.")
-    return(invisible(project))
-  }
-  .warnIfReferenced(project, "outputPath", id)
-  project$outputPaths <- project$outputPaths[setdiff(
-    names(project$outputPaths),
-    id
-  )]
-  project$.markModified()
-  invisible(project)
 }

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -1,23 +1,61 @@
-# Section validation adapters ----
+# Section validation adapter ----
 #
 # Registered in `.validationAdapters` (R/validation.R) and called by
 # `.runProjectValidation()`. The actual shape check lives in
-# `.validateParameterSets()` (in `R/validation.R`), which is shared by
-# all three parameter-set sections.
+# `.validateParameterSets()` (in `R/validation.R`).
 
 #' @keywords internal
 #' @noRd
-.modelParameterSetsValidatorAdapter <- function(project) {
-  .validateParameterSets(project$modelParameterSets, "modelParameterSets")
+.parameterSetsValidatorAdapter <- function(project) {
+  .validateParameterSets(project$parameterSets, "parameterSets")
 }
 
-#' @keywords internal
-#' @noRd
-.applicationParameterSetsValidatorAdapter <- function(project) {
-  .validateParameterSets(
-    project$applicationParameterSets,
-    "applicationParameterSets"
+# Merge the parameter-set sections of a parsed `Project.json` into the single
+# unified `parameterSets` map. The canonical source is the `parameterSets`
+# section; a legacy project that still carries the three separate sections
+# (`modelParameterSets` / `individualParameterSets` /
+# `applicationParameterSets`) has them merged in. An id that appears in more
+# than one input section is a genuine collision and aborts, since the three
+# former namespaces now share one and a referrer cannot disambiguate.
+#
+# @keywords internal
+# @noRd
+.mergeParameterSetSections <- function(jsonData) {
+  legacy <- list(
+    modelParameterSets = jsonData$modelParameterSets %||% list(),
+    individualParameterSets = jsonData$individualParameterSets %||% list(),
+    applicationParameterSets = jsonData$applicationParameterSets %||% list()
   )
+  hasLegacy <- any(vapply(legacy, length, integer(1)) > 0L)
+
+  # No legacy sections to fold in: the `parameterSets` section is used as-is,
+  # preserving its own shape (absent -> bare `list()`, empty `{}` -> a named
+  # empty list, exactly like the other map sections). `%||%` covers an absent
+  # section.
+  if (!hasLegacy) {
+    return(jsonData$parameterSets %||% list())
+  }
+
+  sources <- c(list(parameterSets = jsonData$parameterSets %||% list()), legacy)
+  merged <- list()
+  origin <- character()
+  for (section in names(sources)) {
+    sets <- sources[[section]]
+    for (id in names(sets)) {
+      if (id %in% names(merged)) {
+        cli::cli_abort(c(
+          "Parameter set id {.val {id}} is defined in more than one section.",
+          "i" = "It appears in both {.field {origin[[id]]}} and \\
+          {.field {section}}; the three former parameter-set kinds now share \\
+          one {.field parameterSets} namespace, so ids must be unique. Rename \\
+          one of them."
+        ))
+      }
+      merged[[id]] <- sets[[id]]
+      origin[[id]] <- section
+    }
+  }
+  merged
 }
 
 #' Read parameter values from a structured Excel file. Each excel sheet must
@@ -65,6 +103,40 @@ readParametersFromXLS <- function(paramsXLSpath, sheets = NULL) {
       data = as.character(data[["Units"]]),
       replace = ""
     )
+  }
+
+  return(.parametersVectorToList(pathsValuesVector, pathsUnitsVector))
+}
+
+#' Read initial values (molecule start values) from a structured Excel file.
+#'
+#' @description Each excel sheet must consist of columns `Container Path`,
+#'   `Molecule Name`, `Is Present`, `Value`, `Units`, `Scale Divisor`, and
+#'   `Neg. Values Allowed`. Units are mandatory for every present molecule; a
+#'   present row with a blank `Units` cell is an error.
+#'
+#' @param filePath Path to the excel file
+#' @param sheets Names of the excel sheets containing the information about
+#'   the initial values. Multiple sheets can be processed. If no sheets are
+#'   provided, the first one in the Excel file is used.
+#'
+#' @returns A single list combining all processed sheets, containing vectors
+#'   `paths` with the full molecule paths, `values` with the values, and `units`
+#'   with the units the values are in. When multiple sheets are read, their rows
+#'   are merged into this one structure; if the same molecule path occurs more
+#'   than once, the last occurrence wins (last sheet, then last row). A duplicate
+#'   path, whether within a single sheet or repeated across sheets, triggers a
+#'   warning before the earlier value is replaced.
+#' @export
+#' @family parameters
+readInitialConditionsFromXLS <- function(filePath, sheets = NULL) {
+  rows <- .readInitialConditionsRows(filePath = filePath, sheets = sheets)
+
+  pathsValuesVector <- vector(mode = "numeric")
+  pathsUnitsVector <- vector(mode = "character")
+  for (row in rows) {
+    pathsValuesVector[row$fullPath] <- row$value
+    pathsUnitsVector[row$fullPath] <- row$unit
   }
 
   return(.parametersVectorToList(pathsValuesVector, pathsUnitsVector))
@@ -148,6 +220,165 @@ extendParameterStructure <- function(parameters, newParameters) {
   )
 
   return(returnVal)
+}
+
+# Read and validate initial-condition rows from a structured Excel file.
+#
+# Shared reader used by both `readInitialConditionsFromXLS()` (which collapses
+# the rows into a flat `{paths, values, units}` structure) and the Excel-import
+# parser `.parseExcelInitialConditions()` (which maps each row to a JSON
+# `{path, value, unit}` record). Centralising the column-structure, `Is
+# Present`, blank-path, duplicate-path, value and unit validation here keeps the
+# two readers from drifting apart.
+#
+# @param filePath Path to the excel file.
+# @param sheets Sheets to read. If `NULL`, only the first sheet is read.
+# @param call Environment used to attribute raised conditions to the public
+#   caller rather than this internal helper.
+#
+# @returns A list of per-row records (one per kept, present molecule), each a
+#   list with `sheet`, `containerPath`, `moleculeName`, `fullPath`, `value`,
+#   and `unit`. Rows where `Is Present` is explicitly `FALSE`/`0` are dropped.
+# @keywords internal
+# @noRd
+.readInitialConditionsRows <- function(
+  filePath,
+  sheets = NULL,
+  call = rlang::caller_env()
+) {
+  columnNames <- c(
+    "Container Path",
+    "Molecule Name",
+    "Is Present",
+    "Value",
+    "Units",
+    "Scale Divisor",
+    "Neg. Values Allowed"
+  )
+  validateIsString(filePath)
+  validateIsString(sheets, nullAllowed = TRUE)
+
+  if (is.null(sheets)) {
+    sheets <- readxl::excel_sheets(filePath)[1L]
+  }
+
+  rows <- list()
+  seenPaths <- character(0)
+
+  for (sheet in sheets) {
+    data <- readExcel(path = filePath, sheet = sheet)
+
+    if (!all(columnNames %in% names(data))) {
+      msg <- messages$errorWrongXLSStructure(
+        filePath = filePath,
+        expectedColNames = columnNames
+      )
+      cli::cli_abort(c("x" = "{msg}"), call = call)
+    }
+
+    # "Is Present" must be a logical value or empty. An empty/NA cell is
+    # treated as present. Numeric 0/1 (a common Excel representation of a
+    # logical column) is accepted. Any other value (e.g. "yes") is rejected
+    # rather than silently coerced to NA (which would be kept as present).
+    isPresentCol <- data[["Is Present"]]
+    isPresentChr <- trimws(as.character(isPresentCol))
+    isBlank <- is.na(isPresentCol) | isPresentChr == ""
+    isPresent <- as.logical(isPresentChr)
+    numericFlag <- isPresentChr %in% c("0", "1")
+    isPresent[numericFlag] <- isPresentChr[numericFlag] == "1"
+    invalidIsPresent <- !isBlank & is.na(isPresent)
+    if (any(invalidIsPresent)) {
+      msg <- messages$errorInvalidIsPresentInInitialConditions(
+        filePath = filePath,
+        moleculePaths = paste(
+          data[["Container Path"]],
+          data[["Molecule Name"]],
+          sep = "|"
+        )[invalidIsPresent]
+      )
+      cli::cli_abort(c("x" = "{msg}"), call = call)
+    }
+
+    # Only include rows where Is Present is not explicitly FALSE
+    keepRows <- isBlank | isPresent
+    keptRowNumbers <- which(keepRows)
+    data <- data[keepRows, ]
+
+    if (nrow(data) == 0) {
+      next
+    }
+
+    # Container Path and Molecule Name must be filled for every kept row,
+    # otherwise the constructed path contains "NA" and fails deep in the
+    # ospsuite layer with no reference to the originating row.
+    containerPath <- as.character(data[["Container Path"]])
+    moleculeName <- as.character(data[["Molecule Name"]])
+    missingPathParts <- is.na(containerPath) |
+      trimws(containerPath) == "" |
+      is.na(moleculeName) |
+      trimws(moleculeName) == ""
+    if (any(missingPathParts)) {
+      msg <- messages$errorMissingPathInInitialConditions(
+        filePath = filePath,
+        sheet = sheet,
+        rows = keptRowNumbers[missingPathParts]
+      )
+      cli::cli_abort(c("x" = "{msg}"), call = call)
+    }
+
+    fullPaths <- paste(containerPath, moleculeName, sep = "|")
+
+    # Warn (rather than silently overwrite) when the same molecule path appears
+    # more than once: either within this sheet, or already defined on a prior
+    # sheet. The last occurrence wins downstream.
+    duplicatePaths <- unique(c(
+      fullPaths[duplicated(fullPaths)],
+      intersect(fullPaths, seenPaths)
+    ))
+    if (length(duplicatePaths) > 0) {
+      msg <- messages$warningDuplicateInitialConditions(
+        filePath = filePath,
+        moleculePaths = duplicatePaths
+      )
+      cli::cli_warn(c("!" = "{msg}"), call = call)
+    }
+
+    # Validate values and units before accumulating rows, so a failure leaves
+    # no partial state behind.
+    parsedValues <- suppressWarnings(as.numeric(data[["Value"]]))
+    missingValues <- is.na(parsedValues)
+    if (any(missingValues)) {
+      msg <- messages$errorMissingValuesInInitialConditions(
+        filePath = filePath,
+        moleculePaths = fullPaths[missingValues]
+      )
+      cli::cli_abort(c("x" = "{msg}"), call = call)
+    }
+
+    unitsRaw <- as.character(data[["Units"]])
+    missingUnits <- is.na(data[["Units"]]) | trimws(unitsRaw) == ""
+    if (any(missingUnits)) {
+      msg <- messages$errorMissingUnitsInInitialConditions(
+        filePath = filePath,
+        moleculePaths = fullPaths[missingUnits]
+      )
+      cli::cli_abort(c("x" = "{msg}"), call = call)
+    }
+
+    for (i in seq_len(nrow(data))) {
+      rows[[length(rows) + 1L]] <- list(
+        sheet = sheet,
+        containerPath = containerPath[[i]],
+        moleculeName = moleculeName[[i]],
+        fullPath = fullPaths[[i]],
+        value = parsedValues[[i]],
+        unit = unitsRaw[[i]]
+      )
+    }
+    seenPaths <- union(seenPaths, fullPaths)
+  }
+
+  rows
 }
 
 #' @title Check if two parameters are equal with respect to certain properties.
@@ -347,62 +578,164 @@ setParameterValuesByPathWithCondition <- function(
   return(list(containerPath = containerPath, parameterName = paramName))
 }
 
-# Public CRUD: modelParameterSets ----
+# Print ----
 
-#' Create a model parameter set
+#' @exportS3Method
+#' @noRd
+print.ParameterSet <- function(x, ...) {
+  ospsuite.utils::ospPrintClass(x)
+  entries <- unclass(x)
+  ospsuite.utils::ospPrintItems(
+    list("Number of Entries" = length(entries)),
+    print_empty = TRUE
+  )
+  if (length(entries) > 0L) {
+    lines <- vapply(
+      entries,
+      function(e) {
+        units <- if (is.null(e$units) || !nzchar(e$units)) {
+          ""
+        } else {
+          paste0(" [", e$units, "]")
+        }
+        paste0(
+          e$containerPath,
+          "|",
+          e$parameterName,
+          " = ",
+          format(e$value),
+          units
+        )
+      },
+      character(1)
+    )
+    ospsuite.utils::ospPrintItems(
+      stats::setNames(as.list(lines), rep("", length(lines)))
+    )
+  }
+  invisible(x)
+}
+
+#' @exportS3Method
+#' @noRd
+print.InitialConditionSet <- function(x, ...) {
+  ospsuite.utils::ospPrintClass(x)
+  entries <- unclass(x)
+  ospsuite.utils::ospPrintItems(
+    list("Number of Entries" = length(entries)),
+    print_empty = TRUE
+  )
+  if (length(entries) > 0L) {
+    lines <- vapply(
+      entries,
+      function(e) {
+        unit <- if (is.null(e$unit) || !nzchar(e$unit)) {
+          ""
+        } else {
+          paste0(" [", e$unit, "]")
+        }
+        paste0(e$path, " = ", format(e$value), unit)
+      },
+      character(1)
+    )
+    ospsuite.utils::ospPrintItems(
+      stats::setNames(as.list(lines), rep("", length(lines)))
+    )
+  }
+  invisible(x)
+}
+
+# Public CRUD: parameterSets ----
+
+#' Create one or more parameter sets
+#'
+#' Adds empty parameter sets to the project's single `parameterSets` section,
+#' vectorizing over a vector of ids (all N added in one write-through). A
+#' scenario references the sets it applies through its `modelParameterSets`
+#' field, an individual or application through its `parameterSets` field; all
+#' three resolve against this one section.
+#'
+#' @inherit vectorizedAuthoring details
 #'
 #' @param project A `Project` object.
-#' @param id Character scalar, set name. Must not already exist.
+#' @param id Character vector of set ids. Each is canonicalized to a safe,
+#'   lowercase id (a warning names the result if it changed); each canonical
+#'   id must not already exist.
 #' @returns The `project` object, invisibly.
 #' @export
 #' @family parameters
-addModelParameterSet <- function(project, id) {
+addParameterSet <- function(project, id) {
   validateIsOfType(project, "Project")
-  if (!is.character(id) || length(id) != 1L || is.na(id) || nchar(id) == 0) {
-    cli::cli_abort("{.arg id} must be a non-empty string")
+  .assertIdVector(id)
+  id <- .canonicalizeId(id)
+  clash <- intersect(id, names(project$parameterSets))
+  if (length(clash) > 0L) {
+    cli::cli_abort("parameter set {.val {clash}} already exists")
   }
-  if (id %in% names(project$modelParameterSets)) {
-    cli::cli_abort("model parameter set {.val {id}} already exists")
+  parameterSets <- project$.getSection("parameterSets") %||% list()
+  for (one in id) {
+    parameterSets[[one]] <- .asParameterSet(list())
   }
-  project$modelParameterSets[[id]] <- list()
-  project$.markModified()
+  project$.setSection("parameterSets", parameterSets)
   invisible(project)
 }
 
-#' Remove a model parameter set
-#' @inheritParams addModelParameterSet
+#' Remove one or more parameter sets
+#'
+#' Drop the parameter sets with matching ids in one write-through. Warns (and
+#' skips) any id not present, and warns when a removed set is still
+#' referenced.
+#'
+#' @inherit vectorizedAuthoring details
+#' @inheritParams addParameterSet
 #' @returns The `project` object, invisibly.
 #' @export
 #' @family parameters
-removeModelParameterSet <- function(project, id) {
+removeParameterSet <- function(project, id) {
   validateIsOfType(project, "Project")
-  if (!(id %in% names(project$modelParameterSets))) {
-    cli::cli_warn("model parameter set {.val {id}} not found; no-op.")
+  .assertIdVector(id)
+  id <- .canonicalizeId(id)
+  missingIds <- setdiff(id, names(project$parameterSets))
+  if (length(missingIds) > 0L) {
+    cli::cli_warn("parameter set {.val {missingIds}} not found; no-op.")
+  }
+  toRemove <- intersect(id, names(project$parameterSets))
+  if (length(toRemove) == 0L) {
     return(invisible(project))
   }
-  .warnIfReferenced(project, "modelParameterSet", id)
-  project$modelParameterSets[[id]] <- NULL
-  project$.markModified()
+  for (one in toRemove) {
+    .warnIfReferenced(project, "parameterSet", one)
+  }
+  parameterSets <- project$.getSection("parameterSets")
+  parameterSets[toRemove] <- NULL
+  project$.setSection("parameterSets", parameterSets)
   invisible(project)
 }
 
-#' Add a parameter entry to a named model-parameter set
+#' Add one or many parameter entries to a named parameter set
 #'
-#' Adds one parameter entry to the named set in
-#' `project$modelParameterSets`. The set is created on demand if it does
-#' not yet exist. Last-write-wins on duplicate `(containerPath,
-#' parameterName)` pairs.
+#' Adds parameter entries to the named set in `project$parameterSets`.
+#' `containerPath`, `parameterName`, `value`, and `units` accept parallel
+#' vectors of equal length N to add all N entries in a single call (and a
+#' single write to disk); a scalar call (length-1 vectors) adds one entry.
+#' Building a large set with one vectorized call is far cheaper than a loop of
+#' scalar calls, since each call rewrites the whole set file.
+#'
+#' Unlike the other `add*` functions, which abort on a missing parent, this
+#' creates the parent set on demand if it does not yet exist (informing you
+#' when it does). Last-write-wins on duplicate `(containerPath, parameterName)`
+#' pairs, including duplicates within a single vectorized call.
 #'
 #' @param project A `Project` object.
-#' @param id Character scalar, set name. Created if not present.
-#' @param containerPath Character scalar.
-#' @param parameterName Character scalar.
-#' @param value Numeric scalar.
-#' @param units Character scalar.
+#' @param id Character scalar, set id. Canonicalized; created if not present.
+#' @param containerPath Character vector of container paths (length N).
+#' @param parameterName Character vector of parameter names (length N).
+#' @param value Numeric vector of values (length N).
+#' @param units Character vector of units (length N; use `""` for none).
 #' @returns The `project` object, invisibly.
 #' @export
 #' @family parameters
-addModelParameterEntry <- function(
+addParameterEntry <- function(
   project,
   id,
   containerPath,
@@ -414,33 +747,55 @@ addModelParameterEntry <- function(
   if (!is.character(id) || length(id) != 1L || is.na(id) || nchar(id) == 0) {
     cli::cli_abort("{.arg id} must be a non-empty string")
   }
-  current <- project$modelParameterSets[[id]]
-  project$modelParameterSets[[id]] <- .addParameterEntry(
-    current,
+  id <- .canonicalizeId(id)
+  # Validate the batch shape up front so a mismatched call fails fast, before
+  # any on-demand set creation is reported.
+  .assertParameterEntryVectorLengths(
     containerPath,
     parameterName,
     value,
     units
   )
-  project$.markModified()
+  current <- project$parameterSets[[id]]
+  # Unlike the other `add*` functions, `addParameterEntry()` creates its parent
+  # set on demand rather than aborting on a missing parent. Inform the user when
+  # it does, so the on-demand creation is not silent.
+  if (is.null(current)) {
+    cli::cli_inform(
+      "Created parameter set {.val {id}} on demand to hold the new entr{?y/ies}."
+    )
+  }
+  # Fold all N entries into the set in memory first, so the single write below
+  # triggers exactly one write-through (not one per entry).
+  parameterSets <- project$.getSection("parameterSets")
+  parameterSets[[id]] <- .asParameterSet(.addParameterEntries(
+    current,
+    containerPath,
+    parameterName,
+    value,
+    units
+  ))
+  project$.setSection("parameterSets", parameterSets)
   invisible(project)
 }
 
-#' Remove a parameter entry from a named model-parameter set
+#' Remove one or many parameter entries from a named parameter set
 #'
-#' Removes one parameter entry from the named set. If the removed entry
-#' was the last in the set, the set itself is auto-removed from
-#' `project$modelParameterSets`. Warns if the set or entry doesn't
-#' exist.
+#' Removes parameter entries from the named set. `containerPath` and
+#' `parameterName` accept parallel vectors of equal length N to remove all N
+#' entries in a single call (and a single write to disk); a scalar call
+#' (length-1 vectors) removes one entry. If every entry of the set is removed,
+#' the set itself is auto-removed from `project$parameterSets`. Warns if the
+#' set or any named entry doesn't exist.
 #'
 #' @param project A `Project` object.
-#' @param id Character scalar, set name.
-#' @param containerPath Character scalar.
-#' @param parameterName Character scalar.
+#' @param id Character scalar, set id. Canonicalized.
+#' @param containerPath Character vector of container paths (length N).
+#' @param parameterName Character vector of parameter names (length N).
 #' @returns The `project` object, invisibly.
 #' @export
 #' @family parameters
-removeModelParameterEntry <- function(
+removeParameterEntry <- function(
   project,
   id,
   containerPath,
@@ -450,25 +805,29 @@ removeModelParameterEntry <- function(
   if (!is.character(id) || length(id) != 1L) {
     cli::cli_abort("{.arg id} must be a string scalar")
   }
-  if (!(id %in% names(project$modelParameterSets))) {
-    cli::cli_warn("model parameter set {.val {id}} not found; no-op.")
+  id <- .canonicalizeId(id)
+  if (!(id %in% names(project$parameterSets))) {
+    cli::cli_warn("parameter set {.val {id}} not found; no-op.")
     return(invisible(project))
   }
-  result <- .removeParameterEntry(
-    project$modelParameterSets[[id]],
+  # Fold all N removals into the set in memory first, so the single assignment
+  # below triggers exactly one write-through (not one per entry).
+  result <- .removeParameterEntries(
+    project$parameterSets[[id]],
     containerPath,
     parameterName
   )
   if (!result$removed) {
     return(invisible(project))
   }
+  parameterSets <- project$.getSection("parameterSets")
   if (is.null(result$parameters)) {
-    .warnIfReferenced(project, "modelParameterSet", id)
-    project$modelParameterSets[[id]] <- NULL
+    .warnIfReferenced(project, "parameterSet", id)
+    parameterSets[[id]] <- NULL
   } else {
-    project$modelParameterSets[[id]] <- result$parameters
+    parameterSets[[id]] <- .asParameterSet(result$parameters)
   }
-  project$.markModified()
+  project$.setSection("parameterSets", parameterSets)
   invisible(project)
 }
 
@@ -508,6 +867,70 @@ removeModelParameterEntry <- function(
     errors <- c(errors, "units must be a string scalar (use \"\" for none)")
   }
   errors
+}
+
+# Assert that the parallel `(containerPath, parameterName, value, units)`
+# argument vectors all share the same length (the batch size). A scalar
+# call is the length-1 case. Aborts naming the lengths otherwise.
+#
+# @keywords internal
+# @noRd
+.assertParameterEntryVectorLengths <- function(
+  containerPath,
+  parameterName,
+  value,
+  units
+) {
+  lengths <- c(
+    containerPath = length(containerPath),
+    parameterName = length(parameterName),
+    value = length(value),
+    units = length(units)
+  )
+  if (length(unique(lengths)) != 1L) {
+    cli::cli_abort(c(
+      "{.arg containerPath}, {.arg parameterName}, {.arg value}, and \\
+      {.arg units} must be vectors of the same length.",
+      "x" = "Got lengths {.val {lengths[['containerPath']]}}, \\
+      {.val {lengths[['parameterName']]}}, {.val {lengths[['value']]}}, \\
+      and {.val {lengths[['units']]}}."
+    ))
+  }
+  invisible(lengths[["containerPath"]])
+}
+
+# Fold N parameter entries (parallel vectors) into a parameter set in one
+# pass, returning the updated list. Each entry is validated and appended (or
+# replaced, last-write-wins) via `.addParameterEntry`, so an in-batch duplicate
+# `(containerPath, parameterName)` resolves to the last value, matching the
+# scalar semantics. N=1 is the scalar case. Folding in memory first lets the
+# caller persist the whole set in a single write-through.
+#
+# @keywords internal
+# @noRd
+.addParameterEntries <- function(
+  parameters,
+  containerPath,
+  parameterName,
+  value,
+  units
+) {
+  n <- .assertParameterEntryVectorLengths(
+    containerPath,
+    parameterName,
+    value,
+    units
+  )
+  for (i in seq_len(n)) {
+    parameters <- .addParameterEntry(
+      parameters,
+      containerPath[[i]],
+      parameterName[[i]],
+      value[[i]],
+      units[[i]]
+    )
+  }
+  parameters
 }
 
 # Append (or replace, last-write-wins) one parameter entry to a
@@ -560,13 +983,48 @@ removeModelParameterEntry <- function(
   parameters
 }
 
+# Drop N parameter entries (parallel vectors) from a parameter set in one
+# pass, returning the same `list(parameters=, removed=)` shape as
+# `.removeParameterEntry`. `removed` is `TRUE` if ANY named entry was actually
+# removed (a not-found entry warns and is skipped, as in the scalar case);
+# `parameters` is `NULL` when the removals emptied the set, so the caller
+# auto-removes it. N=1 is the scalar case. Folding in memory first lets the
+# caller persist the whole set in a single write-through.
+#
+# @keywords internal
+# @noRd
+.removeParameterEntries <- function(parameters, containerPath, parameterName) {
+  if (length(containerPath) != length(parameterName)) {
+    cli::cli_abort(c(
+      "{.arg containerPath} and {.arg parameterName} must be vectors of \\
+      the same length.",
+      "x" = "Got lengths {.val {length(containerPath)}} and \\
+      {.val {length(parameterName)}}."
+    ))
+  }
+  anyRemoved <- FALSE
+  for (i in seq_along(containerPath)) {
+    result <- .removeParameterEntry(
+      parameters,
+      containerPath[[i]],
+      parameterName[[i]]
+    )
+    anyRemoved <- anyRemoved || result$removed
+    # A removal that empties the set yields `NULL`; preserve it so a later
+    # not-found entry warns against the empty set, matching the scalar path.
+    parameters <- result$parameters
+  }
+  list(parameters = parameters, removed = anyRemoved)
+}
+
 # Drop one parameter entry from a JSON-faithful array-of-records
 # parameter set. Returns a list with:
 #   - `parameters`: the updated set, or `NULL` if removal emptied the set
 #     (callers use the `NULL` to auto-remove the named set).
 #   - `removed`: `TRUE` if an entry was actually removed, `FALSE` for a
-#     no-op (entry not found). Callers gate `.markModified()` on this so
-#     a no-op warn doesn't invalidate the validation cache.
+#     no-op (entry not found). Callers gate the write-through on this so
+#     a no-op warn doesn't touch the section (and so doesn't invalidate the
+#     validation cache).
 #
 # @keywords internal
 # @noRd
@@ -610,6 +1068,350 @@ removeModelParameterEntry <- function(
       identical(e$containerPath, containerPath) &&
         identical(e$parameterName, parameterName)
     },
+    logical(1)
+  )
+  which(hits)
+}
+
+# Public CRUD: initialConditions ----
+
+#' Create one or more initial-condition sets
+#'
+#' Adds empty initial-condition sets to the project's `initialConditions`
+#' section, vectorizing over a vector of ids (all N added in one write-through).
+#' An initial-condition set holds molecule start values (`path`, `value`,
+#' `unit`) a scenario applies through its `initialConditions` field, distinct
+#' from parameter sets (which set model parameters, not molecule start values).
+#'
+#' @inherit vectorizedAuthoring details
+#'
+#' @param project A `Project` object.
+#' @param id Character vector of set ids. Each is canonicalized to a safe,
+#'   lowercase id (a warning names the result if it changed); each canonical
+#'   id must not already exist.
+#' @returns The `project` object, invisibly.
+#' @export
+#' @family parameters
+addInitialConditions <- function(project, id) {
+  validateIsOfType(project, "Project")
+  .assertIdVector(id)
+  id <- .canonicalizeId(id)
+  clash <- intersect(id, names(project$initialConditions))
+  if (length(clash) > 0L) {
+    cli::cli_abort("initial-condition set {.val {clash}} already exists")
+  }
+  initialConditions <- project$.getSection("initialConditions") %||% list()
+  for (one in id) {
+    initialConditions[[one]] <- .asInitialConditionSet(list())
+  }
+  project$.setSection("initialConditions", initialConditions)
+  invisible(project)
+}
+
+#' Remove one or more initial-condition sets
+#'
+#' Drop the initial-condition sets with matching ids in one write-through.
+#' Warns (and skips) any id not present, and warns when a removed set is still
+#' referenced.
+#'
+#' @inherit vectorizedAuthoring details
+#' @inheritParams addInitialConditions
+#' @returns The `project` object, invisibly.
+#' @export
+#' @family parameters
+removeInitialConditions <- function(project, id) {
+  validateIsOfType(project, "Project")
+  .assertIdVector(id)
+  id <- .canonicalizeId(id)
+  missingIds <- setdiff(id, names(project$initialConditions))
+  if (length(missingIds) > 0L) {
+    cli::cli_warn("initial-condition set {.val {missingIds}} not found; no-op.")
+  }
+  toRemove <- intersect(id, names(project$initialConditions))
+  if (length(toRemove) == 0L) {
+    return(invisible(project))
+  }
+  for (one in toRemove) {
+    .warnIfReferenced(project, "initialConditions", one)
+  }
+  initialConditions <- project$.getSection("initialConditions")
+  initialConditions[toRemove] <- NULL
+  project$.setSection("initialConditions", initialConditions)
+  invisible(project)
+}
+
+#' Add one or many entries to a named initial-condition set
+#'
+#' Adds molecule start-value entries to the named set in
+#' `project$initialConditions`. `path`, `value`, and `unit` accept parallel
+#' vectors of equal length N to add all N entries in a single call (and a
+#' single write to disk); a scalar call (length-1 vectors) adds one entry.
+#' Building a large set with one vectorized call is far cheaper than a loop of
+#' scalar calls, since each call rewrites the whole set file.
+#'
+#' Unlike the other `add*` functions, which abort on a missing parent, this
+#' creates the parent set on demand if it does not yet exist (informing you
+#' when it does). Last-write-wins on a duplicate `path`, including duplicates
+#' within a single vectorized call.
+#'
+#' @param project A `Project` object.
+#' @param id Character scalar, set id. Canonicalized; created if not present.
+#' @param path Character vector of molecule paths (length N).
+#' @param value Numeric vector of start values (length N).
+#' @param unit Character vector of units (length N). A unit is mandatory for a
+#'   molecule start value; a blank unit is rejected.
+#' @returns The `project` object, invisibly.
+#' @export
+#' @family parameters
+addInitialConditionEntry <- function(project, id, path, value, unit) {
+  validateIsOfType(project, "Project")
+  if (!is.character(id) || length(id) != 1L || is.na(id) || nchar(id) == 0) {
+    cli::cli_abort("{.arg id} must be a non-empty string")
+  }
+  id <- .canonicalizeId(id)
+  # Validate the batch shape up front so a mismatched call fails fast, before
+  # any on-demand set creation is reported.
+  .assertInitialConditionEntryVectorLengths(path, value, unit)
+  current <- project$initialConditions[[id]]
+  # Unlike the other `add*` functions, this creates its parent set on demand
+  # rather than aborting on a missing parent. Inform the user when it does, so
+  # the on-demand creation is not silent.
+  if (is.null(current)) {
+    cli::cli_inform(
+      "Created initial-condition set {.val {id}} on demand to hold the new entr{?y/ies}."
+    )
+  }
+  # Fold all N entries into the set in memory first, so the single write below
+  # triggers exactly one write-through (not one per entry).
+  initialConditions <- project$.getSection("initialConditions")
+  initialConditions[[id]] <- .asInitialConditionSet(.addInitialConditionEntries(
+    current,
+    path,
+    value,
+    unit
+  ))
+  project$.setSection("initialConditions", initialConditions)
+  invisible(project)
+}
+
+#' Remove one or many entries from a named initial-condition set
+#'
+#' Removes molecule start-value entries from the named set. `path` accepts a
+#' vector of length N to remove all N entries in a single call (and a single
+#' write to disk); a scalar call (length-1 vector) removes one entry. If every
+#' entry of the set is removed, the set itself is auto-removed from
+#' `project$initialConditions`. Warns if the set or any named entry doesn't
+#' exist.
+#'
+#' @param project A `Project` object.
+#' @param id Character scalar, set id. Canonicalized.
+#' @param path Character vector of molecule paths (length N).
+#' @returns The `project` object, invisibly.
+#' @export
+#' @family parameters
+removeInitialConditionEntry <- function(project, id, path) {
+  validateIsOfType(project, "Project")
+  if (!is.character(id) || length(id) != 1L) {
+    cli::cli_abort("{.arg id} must be a string scalar")
+  }
+  id <- .canonicalizeId(id)
+  if (!(id %in% names(project$initialConditions))) {
+    cli::cli_warn("initial-condition set {.val {id}} not found; no-op.")
+    return(invisible(project))
+  }
+  # Fold all N removals into the set in memory first, so the single assignment
+  # below triggers exactly one write-through (not one per entry).
+  result <- .removeInitialConditionEntries(
+    project$initialConditions[[id]],
+    path
+  )
+  if (!result$removed) {
+    return(invisible(project))
+  }
+  initialConditions <- project$.getSection("initialConditions")
+  if (is.null(result$entries)) {
+    .warnIfReferenced(project, "initialConditions", id)
+    initialConditions[[id]] <- NULL
+  } else {
+    initialConditions[[id]] <- .asInitialConditionSet(result$entries)
+  }
+  project$.setSection("initialConditions", initialConditions)
+  invisible(project)
+}
+
+# Validate scalar inputs for a `(path, value, unit)` initial-condition entry.
+# Returns a character vector of error messages (empty if validation passes).
+#
+# @keywords internal
+# @noRd
+.validateInitialConditionEntryArgs <- function(path, value, unit) {
+  errors <- character()
+  if (
+    !is.character(path) ||
+      length(path) != 1L ||
+      is.na(path) ||
+      nchar(path) == 0
+  ) {
+    errors <- c(errors, "path must be a non-empty string")
+  }
+  if (!is.numeric(value) || length(value) != 1L || is.na(value)) {
+    errors <- c(errors, "value must be a numeric scalar")
+  }
+  # A unit is mandatory for a molecule start value: `ospsuite::setQuantityValuesByPath()`
+  # rejects a blank unit at run time, so reject it here (fail fast at authoring)
+  # rather than deferring an opaque failure to the simulation.
+  if (
+    !is.character(unit) ||
+      length(unit) != 1L ||
+      is.na(unit) ||
+      nchar(unit) == 0L
+  ) {
+    errors <- c(errors, "unit must be a non-empty string")
+  }
+  errors
+}
+
+# Assert that the parallel `(path, value, unit)` argument vectors all share the
+# same length (the batch size). A scalar call is the length-1 case. Aborts
+# naming the lengths otherwise.
+#
+# @keywords internal
+# @noRd
+.assertInitialConditionEntryVectorLengths <- function(path, value, unit) {
+  lengths <- c(
+    path = length(path),
+    value = length(value),
+    unit = length(unit)
+  )
+  if (length(unique(lengths)) != 1L) {
+    cli::cli_abort(c(
+      "{.arg path}, {.arg value}, and {.arg unit} must be vectors of the \\
+      same length.",
+      "x" = "Got lengths {.val {lengths[['path']]}}, \\
+      {.val {lengths[['value']]}}, and {.val {lengths[['unit']]}}."
+    ))
+  }
+  invisible(lengths[["path"]])
+}
+
+# Fold N initial-condition entries (parallel vectors) into a set in one pass,
+# returning the updated list. Each entry is validated and appended (or replaced,
+# last-write-wins) via `.addInitialConditionEntry`, so an in-batch duplicate
+# `path` resolves to the last value, matching the scalar semantics. N=1 is the
+# scalar case. Folding in memory first lets the caller persist the whole set in
+# a single write-through.
+#
+# @keywords internal
+# @noRd
+.addInitialConditionEntries <- function(entries, path, value, unit) {
+  n <- .assertInitialConditionEntryVectorLengths(path, value, unit)
+  for (i in seq_len(n)) {
+    entries <- .addInitialConditionEntry(
+      entries,
+      path[[i]],
+      value[[i]],
+      unit[[i]]
+    )
+  }
+  entries
+}
+
+# Append (or replace, last-write-wins) one initial-condition entry to a
+# JSON-faithful array-of-records set. `entries` is a list of
+# `list(path, value, unit)` entries (or `NULL`); returns the updated list.
+#
+# @keywords internal
+# @noRd
+.addInitialConditionEntry <- function(entries, path, value, unit) {
+  errors <- .validateInitialConditionEntryArgs(path, value, unit)
+  if (length(errors) > 0L) {
+    cli::cli_abort(c(
+      "Invalid initial-condition entry:",
+      stats::setNames(errors, rep("x", length(errors)))
+    ))
+  }
+
+  if (is.null(entries)) {
+    entries <- list()
+  }
+
+  existingIdx <- .findInitialConditionEntryIndex(entries, path)
+  # A unit is mandatory (the validator above rejects a blank one), so it is
+  # always a real string here, distinct from a parameter entry's optional units.
+  newEntry <- list(
+    path = path,
+    value = as.double(value),
+    unit = unit
+  )
+  if (length(existingIdx) > 0L) {
+    entries[[existingIdx]] <- newEntry
+  } else {
+    entries[[length(entries) + 1L]] <- newEntry
+  }
+  entries
+}
+
+# Drop N initial-condition entries (parallel vector) from a set in one pass,
+# returning the same `list(entries=, removed=)` shape as
+# `.removeInitialConditionEntry`. `removed` is `TRUE` if ANY named entry was
+# actually removed (a not-found entry warns and is skipped, as in the scalar
+# case); `entries` is `NULL` when the removals emptied the set, so the caller
+# auto-removes it. N=1 is the scalar case. Folding in memory first lets the
+# caller persist the whole set in a single write-through.
+#
+# @keywords internal
+# @noRd
+.removeInitialConditionEntries <- function(entries, path) {
+  anyRemoved <- FALSE
+  for (i in seq_along(path)) {
+    result <- .removeInitialConditionEntry(entries, path[[i]])
+    anyRemoved <- anyRemoved || result$removed
+    # A removal that empties the set yields `NULL`; preserve it so a later
+    # not-found entry warns against the empty set, matching the scalar path.
+    entries <- result$entries
+  }
+  list(entries = entries, removed = anyRemoved)
+}
+
+# Drop one initial-condition entry from a JSON-faithful array-of-records set.
+# Returns a list with:
+#   - `entries`: the updated set, or `NULL` if removal emptied the set (callers
+#     use the `NULL` to auto-remove the named set).
+#   - `removed`: `TRUE` if an entry was actually removed, `FALSE` for a no-op
+#     (entry not found). Callers gate the write-through on this so a no-op warn
+#     doesn't touch the section (and so doesn't invalidate the validation cache).
+#
+# @keywords internal
+# @noRd
+.removeInitialConditionEntry <- function(entries, path) {
+  if (is.null(entries) || length(entries) == 0L) {
+    cli::cli_warn("initial condition {.val {path}} not found; no-op.")
+    return(list(entries = entries, removed = FALSE))
+  }
+  idx <- .findInitialConditionEntryIndex(entries, path)
+  if (length(idx) == 0L) {
+    cli::cli_warn("initial condition {.val {path}} not found; no-op.")
+    return(list(entries = entries, removed = FALSE))
+  }
+  entries <- entries[-idx]
+  if (length(entries) == 0L) {
+    return(list(entries = NULL, removed = TRUE))
+  }
+  list(entries = entries, removed = TRUE)
+}
+
+# Locate a `path` entry in an initial-condition array-of-records. Returns an
+# integer index or `integer(0)` if absent.
+#
+# @keywords internal
+# @noRd
+.findInitialConditionEntryIndex <- function(entries, path) {
+  if (is.null(entries) || length(entries) == 0L) {
+    return(integer(0))
+  }
+  hits <- vapply(
+    entries,
+    function(e) identical(e$path, path),
     logical(1)
   )
   which(hits)

--- a/R/populations.R
+++ b/R/populations.R
@@ -24,6 +24,8 @@
   )
   result <- list()
   for (entry in populationsData) {
+    id <- .keyedTreeRecordId(entry, "populationId", "population")
+    .assertNoEmptyObjectFields(entry, "population")
     popData <- list()
     for (field in names(entry)) {
       if (field == "populationId") {
@@ -39,7 +41,7 @@
       popData[[field]] <- val
     }
     class(popData) <- c("Population", "list")
-    result[[entry$populationId]] <- popData
+    result[[id]] <- popData
   }
   result
 }
@@ -122,6 +124,38 @@
   }
 
   result
+}
+
+# Print ----
+
+#' @exportS3Method
+#' @noRd
+print.Population <- function(x, ...) {
+  ospsuite.utils::ospPrintClass(x)
+  ospsuite.utils::ospPrintItems(
+    list(
+      "Species" = x$species %||% "",
+      "Number of Individuals" = x$numberOfIndividuals %||% "",
+      "Proportion of Females" = x$proportionOfFemales %||% "",
+      "Age Range" = .formatRange(x$ageMin, x$ageMax),
+      "Weight Range" = .formatRange(x$weightMin, x$weightMax),
+      "Height Range" = .formatRange(x$heightMin, x$heightMax)
+    ),
+    print_empty = TRUE
+  )
+  invisible(x)
+}
+
+# Format a "min - max" range for a population print, or "" when neither bound
+# is set.
+#
+# @keywords internal
+# @noRd
+.formatRange <- function(lo, hi) {
+  if (is.null(lo) && is.null(hi)) {
+    return("")
+  }
+  paste0(format(lo %||% NA), " - ", format(hi %||% NA))
 }
 
 #' Possible gender entries as integer values
@@ -222,8 +256,8 @@ extendPopulationFromXLS <- function(population, XLSpath, sheet = NULL) {
       data <- readExcel(path = XLSpath, sheet = sheet, col_types = columnTypes)
     },
     error = function(e) {
-      stop(
-        message = messages$errorWrongXLSStructure(
+      cli::cli_abort(
+        messages$errorWrongXLSStructure(
           filePath = XLSpath,
           expectedColNames = columnNames
         )
@@ -232,7 +266,7 @@ extendPopulationFromXLS <- function(population, XLSpath, sheet = NULL) {
   )
 
   if (!all(columnNames %in% names(data))) {
-    stop(
+    cli::cli_abort(
       messages$errorWrongXLSStructure(
         filePath = XLSpath,
         expectedColNames = columnNames
@@ -305,12 +339,21 @@ sampleRandomValue <- function(distribution, mean, sd, n) {
 
 # Public CRUD: populations ----
 
-#' Add a population to a Project
+#' Add one or more populations to a Project
+#'
+#' Add populations to `project$populations`, vectorizing over a vector of ids
+#' (see the recycling rule under Details). `species`, `numberOfIndividuals`,
+#' and the optional `...` fields are all scalar-per-entity (recycle/align).
+#'
+#' @inherit vectorizedAuthoring details
 #'
 #' @param project A `Project` object.
-#' @param populationId Character scalar, unique ID.
-#' @param species Character scalar.
-#' @param numberOfIndividuals Integer, positive.
+#' @param id Character vector of unique ids (the number of populations to add).
+#'   Each is canonicalized to a safe, lowercase id (a warning names the result
+#'   if it changed).
+#' @param species Character scalar (recycled) or the same length as `id`.
+#' @param numberOfIndividuals Positive number, scalar (recycled) or the same
+#'   length as `id`.
 #' @param ... Optional named fields. Accepted: `proportionOfFemales`,
 #'   `weightMin`, `weightMax`, `heightMin`, `heightMax`, `ageMin`,
 #'   `ageMax`, `BMIMin`, `BMIMax`, `gender`, `weightUnit`, `heightUnit`,
@@ -321,28 +364,72 @@ sampleRandomValue <- function(distribution, mean, sd, n) {
 #' @family population
 addPopulation <- function(
   project,
-  populationId,
+  id,
   species,
   numberOfIndividuals,
   ...
 ) {
   validateIsOfType(project, "Project")
-  errors <- character()
+  .assertIdVector(id)
+  id <- .canonicalizeId(id)
+  n <- length(id)
 
-  if (
-    !is.character(populationId) ||
-      length(populationId) != 1L ||
-      is.na(populationId) ||
-      nchar(populationId) == 0
-  ) {
-    errors <- c(errors, "populationId must be a non-empty string")
-  } else if (populationId %in% names(project$populations)) {
-    errors <- c(
-      errors,
-      paste0("population '", populationId, "' already exists")
+  perEntity <- .alignAuthoringArgs(
+    id,
+    scalarFields = c(
+      list(species = species, numberOfIndividuals = numberOfIndividuals),
+      list(...)
     )
-  }
+  )
 
+  clash <- intersect(id, names(project$populations))
+  if (length(clash) > 0L) {
+    cli::cli_abort("population {.val {clash}} already exists")
+  }
+  call <- rlang::current_env()
+  entries <- lapply(seq_len(n), function(i) {
+    .buildPopulationEntry(id[[i]], perEntity[[i]], call = call)
+  })
+
+  populations <- project$.getSection("populations") %||% list()
+  for (i in seq_len(n)) {
+    populations[[id[[i]]]] <- entries[[i]]
+  }
+  project$.setSection("populations", populations)
+  invisible(project)
+}
+
+.populationNumericFields <- c(
+  "proportionOfFemales",
+  "weightMin",
+  "weightMax",
+  "heightMin",
+  "heightMax",
+  "ageMin",
+  "ageMax",
+  "BMIMin",
+  "BMIMax"
+)
+
+.populationStringFields <- c(
+  "gender",
+  "weightUnit",
+  "heightUnit",
+  "ageUnit",
+  "BMIUnit",
+  "population",
+  "diseaseState"
+)
+
+# Build one classed `Population` entry from its id and per-entity field list,
+# validating the same way the scalar path always has (`species` non-empty,
+# `numberOfIndividuals` positive). Aborts naming the population on a problem.
+#
+# @keywords internal
+# @noRd
+.buildPopulationEntry <- function(id, fields, call = rlang::caller_env()) {
+  errors <- character()
+  species <- fields$species
   if (
     !is.character(species) ||
       length(species) != 1L ||
@@ -352,6 +439,7 @@ addPopulation <- function(
     errors <- c(errors, "species must be a non-empty string")
   }
 
+  numberOfIndividuals <- fields$numberOfIndividuals
   if (
     !is.numeric(numberOfIndividuals) ||
       length(numberOfIndividuals) != 1L ||
@@ -361,29 +449,13 @@ addPopulation <- function(
     errors <- c(errors, "numberOfIndividuals must be a positive number")
   }
 
-  dots <- list(...)
-  numericFields <- c(
-    "proportionOfFemales",
-    "weightMin",
-    "weightMax",
-    "heightMin",
-    "heightMax",
-    "ageMin",
-    "ageMax",
-    "BMIMin",
-    "BMIMax"
+  allowed <- c(
+    "species",
+    "numberOfIndividuals",
+    .populationNumericFields,
+    .populationStringFields
   )
-  stringFields <- c(
-    "gender",
-    "weightUnit",
-    "heightUnit",
-    "ageUnit",
-    "BMIUnit",
-    "population",
-    "diseaseState"
-  )
-  allowed <- c(numericFields, stringFields)
-  unknown <- setdiff(names(dots), allowed)
+  unknown <- setdiff(names(fields), allowed)
   if (length(unknown) > 0L) {
     errors <- c(
       errors,
@@ -391,57 +463,193 @@ addPopulation <- function(
         "unknown fields: ",
         paste(unknown, collapse = ", "),
         ". Allowed: ",
-        paste(allowed, collapse = ", ")
+        paste(
+          setdiff(allowed, c("species", "numberOfIndividuals")),
+          collapse = ", "
+        )
       )
     )
   }
 
   if (length(errors) > 0L) {
-    cli::cli_abort(c(
-      "Cannot add population {.val {populationId}}:",
-      stats::setNames(errors, rep("x", length(errors)))
-    ))
+    cli::cli_abort(
+      c(
+        "Cannot add population {.val {id}}:",
+        stats::setNames(errors, rep("x", length(errors)))
+      ),
+      call = call
+    )
   }
 
   entry <- list(
     species = species,
     numberOfIndividuals = as.double(numberOfIndividuals)
   )
-  for (field in numericFields) {
-    if (!is.null(dots[[field]])) entry[[field]] <- as.double(dots[[field]])
+  for (field in .populationNumericFields) {
+    if (!is.null(fields[[field]])) entry[[field]] <- as.double(fields[[field]])
   }
-  for (field in stringFields) {
-    if (!is.null(dots[[field]])) entry[[field]] <- dots[[field]]
+  for (field in .populationStringFields) {
+    if (!is.null(fields[[field]])) entry[[field]] <- fields[[field]]
   }
   class(entry) <- c("Population", "list")
-
-  project$populations[[populationId]] <- entry
-  project$.markModified()
-  invisible(project)
+  entry
 }
 
-#' Remove a population from a Project
+#' Remove one or more populations from a Project
+#'
+#' Drop the populations with matching ids in one write-through. Warns (and
+#' skips) any id not present, and warns when a removed population is still
+#' referenced.
+#'
 #' @param project A `Project` object.
-#' @param populationId Character scalar.
+#' @param id Character vector of population ids to remove. Each is
+#'   canonicalized the same way [addPopulation()] canonicalizes it.
 #' @returns The `project` object, invisibly.
 #' @export
 #' @family population
-removePopulation <- function(project, populationId) {
+removePopulation <- function(project, id) {
   validateIsOfType(project, "Project")
-  if (
-    !is.character(populationId) ||
-      length(populationId) != 1L ||
-      is.na(populationId) ||
-      nchar(populationId) == 0
-  ) {
-    cli::cli_abort("{.arg populationId} must be a non-empty string")
+  .assertIdVector(id)
+  id <- .canonicalizeId(id)
+
+  missingIds <- setdiff(id, names(project$populations))
+  if (length(missingIds) > 0L) {
+    cli::cli_warn("population {.val {missingIds}} not found; no-op.")
   }
-  if (!(populationId %in% names(project$populations))) {
-    cli::cli_warn("population {.val {populationId}} not found; no-op.")
+  toRemove <- intersect(id, names(project$populations))
+  if (length(toRemove) == 0L) {
     return(invisible(project))
   }
-  .warnIfReferenced(project, "population", populationId)
-  project$populations[[populationId]] <- NULL
-  project$.markModified()
+  for (one in toRemove) {
+    .warnIfReferenced(project, "population", one)
+  }
+  populations <- project$.getSection("populations")
+  populations[toRemove] <- NULL
+  project$.setSection("populations", populations)
   invisible(project)
+}
+
+#' Modify fields of an existing population
+#'
+#' @description Changes one or more fields of the population identified by
+#'   `id` and persists the change immediately to the population definition
+#'   (write-through). The `project$populations` accessor is read-only, so this
+#'   is the way to revise an existing population in place.
+#'
+#'   Only the arguments you pass via `...` are changed; every other field
+#'   keeps its current value (partial update). Validation matches
+#'   [addPopulation()]: the numeric range fields are coerced via
+#'   `as.double()` and `numberOfIndividuals` (if supplied) must be a
+#'   positive number. The required `species` field, if supplied, must be a
+#'   non-empty string.
+#'
+#' @inherit vectorizedAuthoring details
+#'
+#' @param project A `Project` object.
+#' @param id Character vector. Ids of the populations to modify. Each is
+#'   canonicalized the same way [addPopulation()] canonicalizes it, and must
+#'   already exist in `project$populations`.
+#' @param ... Named fields to change. Accepted: `species`,
+#'   `numberOfIndividuals`, `proportionOfFemales`, `weightMin`,
+#'   `weightMax`, `heightMin`, `heightMax`, `ageMin`, `ageMax`, `BMIMin`,
+#'   `BMIMax`, `gender`, `weightUnit`, `heightUnit`, `ageUnit`, `BMIUnit`,
+#'   `population`, `diseaseState`. Scalar-per-entity fields recycle/align
+#'   across `id`. Numeric fields are coerced via `as.double()`. Unknown
+#'   fields trigger an error.
+#'
+#' @returns The `project` object, invisibly.
+#' @export
+#' @family population
+setPopulation <- function(project, id, ...) {
+  validateIsOfType(project, "Project")
+  .assertIdVector(id)
+  id <- .canonicalizeId(id)
+  n <- length(id)
+  missingIds <- setdiff(id, names(project$populations))
+  if (length(missingIds) > 0L) {
+    cli::cli_abort(c(
+      "Cannot modify population {.val {missingIds}}: it does not exist.",
+      "i" = "Use {.fn addPopulation} to create it first."
+    ))
+  }
+
+  dots <- list(...)
+  perEntity <- .alignAuthoringArgs(id, scalarFields = dots)
+  suppliedNames <- names(dots)
+
+  call <- rlang::current_env()
+  entries <- lapply(seq_len(n), function(i) {
+    .setOnePopulation(
+      project,
+      id[[i]],
+      perEntity[[i]][suppliedNames],
+      call = call
+    )
+  })
+
+  populations <- project$.getSection("populations")
+  for (i in seq_len(n)) {
+    populations[[id[[i]]]] <- entries[[i]]
+  }
+  project$.setSection("populations", populations)
+  invisible(project)
+}
+
+# Apply a partial-update field set to one existing population, returning the
+# updated classed entry. Validates only the supplied fields. Aborts naming the
+# population on a problem.
+#
+# @keywords internal
+# @noRd
+.setOnePopulation <- function(project, id, fields, call = rlang::caller_env()) {
+  numericFields <- c("numberOfIndividuals", .populationNumericFields)
+  stringFields <- c("species", .populationStringFields)
+  allowed <- c(numericFields, stringFields)
+  unknown <- setdiff(names(fields), allowed)
+  if (length(unknown) > 0L) {
+    cli::cli_abort(
+      c(
+        "Cannot modify population {.val {id}}:",
+        "x" = "unknown fields: {.val {unknown}}. Allowed: {.val {allowed}}."
+      ),
+      call = call
+    )
+  }
+
+  if ("species" %in% names(fields)) {
+    species <- fields$species
+    if (
+      !is.character(species) ||
+        length(species) != 1L ||
+        is.na(species) ||
+        nchar(species) == 0
+    ) {
+      cli::cli_abort("{.arg species} must be a non-empty string", call = call)
+    }
+  }
+  if ("numberOfIndividuals" %in% names(fields)) {
+    count <- fields$numberOfIndividuals
+    if (
+      !is.numeric(count) ||
+        length(count) != 1L ||
+        is.na(count) ||
+        count <= 0
+    ) {
+      cli::cli_abort(
+        "{.arg numberOfIndividuals} must be a positive number",
+        call = call
+      )
+    }
+  }
+
+  entry <- project$populations[[id]]
+  for (field in names(fields)) {
+    if (field %in% numericFields) {
+      entry[[field]] <- as.double(fields[[field]])
+    } else {
+      entry[[field]] <- fields[[field]]
+    }
+  }
+  class(entry) <- c("Population", "list")
+  entry
 }

--- a/R/project-lifecycle.R
+++ b/R/project-lifecycle.R
@@ -16,11 +16,32 @@
 #'
 #' @returns Object of type `Project`
 #' @export
+#' @family project persistence
+#'
+#' @section Editing a loaded project is write-through:
+#'   A loaded project is bound to its directory on disk, and every
+#'   authoring edit is write-through: a single `addOutputPath()`,
+#'   `addScenario()`, `setIndividual()`, or `removeParameterSet()` writes (or
+#'   deletes) the affected entity's file immediately. The `project$<section>`
+#'   accessors are read-only, so a definition only ever changes through an
+#'   authoring function. There is no separate save step, and there is no undo:
+#'   the edit is on disk the moment the call returns.
+#'
+#'   To experiment without touching the on-disk project, work on a detached
+#'   copy. `project$clone()` returns an in-memory copy whose edits stay in
+#'   memory (they do not write to the source's `definitions/` tree) until it
+#'   is bound to a directory of its own. To capture a shareable freeze-frame
+#'   of the current state, use [saveSnapshot()], and reload it elsewhere
+#'   with [loadSnapshot()].
 #'
 #' @examples
 #' \dontrun{
 #' project <- loadProject("Project.json")
 #' results <- runScenarios(project)
+#'
+#' # Edits are write-through; clone first for scratch work.
+#' scratch <- project$clone()
+#' addOutputPath(scratch, "x", "Organism|A|Concentration in container")
 #' }
 loadProject <- function(path = "Project.json") {
   project <- Project$new(projectFilePath = path)
@@ -53,46 +74,6 @@ loadProject <- function(path = "Project.json") {
     "i" = "Run {.code validateProject(project)} for the full report."
   ))
   invisible(NULL)
-}
-
-#' Save a project to a JSON file
-#'
-#' @description Serializes the in-memory `Project` object back to JSON with
-#'   round-trip fidelity. This allows persisting changes made programmatically
-#'   (e.g., via [addScenario()]).
-#'
-#' @param project A `Project` object.
-#' @param path Path where the JSON file should be written. If `NULL` (default),
-#'   uses `project$jsonPath` (the path the project was loaded from).
-#'
-#' @returns Invisibly returns the path where the file was written.
-#' @export
-#'
-#' @examples
-#' \dontrun{
-#' project <- loadProject("Project.json")
-#' addScenario(project, "NewScenario", "Model.pkml", individualId = "Indiv1")
-#' saveProject(project)
-#' }
-saveProject <- function(project, path = NULL) {
-  validateIsOfType(project, "Project")
-
-  if (is.null(path)) {
-    path <- project$jsonPath
-    if (is.null(path)) {
-      cli::cli_abort(messages$noProjectPath())
-    }
-  }
-
-  # Delegate to the internal writer so the parent-directory guard and the
-  # canonical write options live in one place.
-  .saveProjectJson(project, path)
-
-  # Rebind to the written location so a save-as updates jsonPath /
-  # projectFilePath / projectDirPath; a no-op rebind for a bare save.
-  project$.rebindPath(path)
-  project$.markSaved()
-  invisible(path)
 }
 
 #' @rdname loadProject
@@ -156,8 +137,11 @@ isProjectInitialized <- function(destination = ".") {
 #'
 #' @description
 #'
-#' Creates the default project folder structure with Excel file templates in the
-#' working directory.
+#' Scaffolds a JSON-first esqlabsR project in `destination`: a `Project.json`
+#' container plus a `definitions/` tree of authored definitions, alongside the
+#' working folders (`Models/`, `Data/`, `Populations/`, `Results/`). By default
+#' it also writes optional Excel side-cars from the JSON; set
+#' `createExcel = FALSE` for a JSON-only project.
 #'
 #' @param destination A string defining the path where to initialize the
 #'   project. default to current working directory.
@@ -169,7 +153,10 @@ isProjectInitialized <- function(destination = ".") {
 #' @param overwrite If TRUE, overwrites existing project without asking for
 #'   permission. If FALSE and a project already exists, asks user for permission
 #'   to overwrite.
+#' @returns Invisibly returns `destination`, the path the project was
+#'   initialized in.
 #' @export
+#' @family project persistence
 initProject <- function(
   destination = ".",
   type = c("minimal", "example"),
@@ -180,7 +167,7 @@ initProject <- function(
   type <- match.arg(type)
 
   if (!fs::dir_exists(destination)) {
-    stop(
+    cli::cli_abort(
       messages$pathNotFound(destination)
     )
   }
@@ -273,6 +260,7 @@ initProject <- function(
 #' @returns A string representing the path to the example
 #'   `Project.json` file shipped with the package.
 #' @export
+#' @family project persistence
 #' @examples
 #' exampleProjectPath()
 exampleProjectPath <- function() {

--- a/R/project-to-json.R
+++ b/R/project-to-json.R
@@ -3,7 +3,7 @@
 # Inverse of `Project$.read_json()` (called by `Project$new()`). Walks a
 # `Project` and emits a v2.0 `Project.json` file. The contract is:
 #
-#   loadProject(path) |> saveProject(out)  produces a JSON file that, when
+#   loadProject(path) |> saveSnapshot(out)  produces a JSON file that, when
 #   re-loaded, yields a `Project` structurally identical to the first one.
 #
 # Layered to mirror the end-state shape: a top-level `.projectToJson()`
@@ -11,10 +11,10 @@
 # etc.). Today every per-section helper is essentially a passthrough — the
 # parser stores each section JSON-faithfully, so there is no transformation
 # to perform on the way out. The seams exist so future migrations
-# (relative-path resolution in `.filePathsToJson`, `outputPaths` →
-# `outputPathIds` rewriting in `.scenariosToJson`, unit conversions, plot
-# nesting, ...) can land in one section at a time without rearranging the
-# top-level call shape.
+# (relative-path resolution in `.filePathsToJson`, the named-vector
+# `outputPaths` record field rewritten to the `outputPaths` id array in
+# `.scenariosToJson`, unit conversions, plot nesting, ...) can land in one
+# section at a time without rearranging the top-level call shape.
 
 #' Internal: render a `Project` to a JSON-shaped R list in the v2.0 schema.
 #'
@@ -23,34 +23,116 @@
 #' writing and re-parsing it yields a structurally identical `Project`.
 #'
 #' @param project A `Project` (R6) instance.
+#' @param includeScenarios Logical. When `TRUE` (default), the `scenarios`
+#'   array is inlined (the self-contained snapshot shape). When `FALSE`,
+#'   `scenarios` is emitted as an empty array, because scenarios are
+#'   persisted as an entity tree alongside the container, not inline. Ignored
+#'   when `containerOnly` is `TRUE` (every section is emptied then).
+#' @param containerOnly Logical. When `TRUE`, every tree-owned section
+#'   (scenarios, individuals, populations, parameterSets, applications,
+#'   outputPaths, observedData, dataCombined, plots, plotGrids,
+#'   parameterIdentification) is emitted in its canonical empty shape rather
+#'   than serialized, leaving only the container itself (metadata, filePaths,
+#'   defaultSimulationRunOptions, excel). This is the on-disk `Project.json`
+#'   container shape: the `definitions/<kind>/` tree owns every section and
+#'   wins on reload, so re-serializing the sections here is wasted work. When
+#'   `FALSE` (default) the sections are serialized (the self-contained snapshot
+#'   shape).
 #'
 #' @return A nested list shaped exactly the v2.0 JSON schema, ready for
 #'   `jsonlite::write_json(..., auto_unbox = TRUE, null = "null")`.
 #'
 #' @keywords internal
 #' @noRd
-.projectToJson <- function(project) {
+.projectToJson <- function(
+  project,
+  includeScenarios = TRUE,
+  containerOnly = FALSE
+) {
   if (!inherits(project, "Project")) {
     cli::cli_abort("{.arg project} must be a {.cls Project} R6 instance.")
   }
 
+  # The container separates two path concerns: the four live working folders
+  # (`filePaths`) the runtime reads, and the seven Excel-bridge sheet names
+  # (`excel`). The `excel` block is emitted only when the project actually
+  # carries Excel-bridge fields (an Excel side-car exists); a from-scratch JSON
+  # project omits it. The `name` / `description` metadata, `definitionsFolder`,
+  # and `defaultSimulationRunOptions` are emitted only when set, so an empty
+  # `Project$new()` still serializes a minimal, round-trippable file.
+  #
+  # `containerOnly` serializes none of the tree-owned sections: each is emitted
+  # in its canonical empty shape (the same shape an empty project would yield),
+  # because the `definitions/<kind>/` tree on disk owns every section and is
+  # authoritative on reload. This makes a container write O(container size)
+  # instead of O(sum of all section sizes).
+  excel <- .excelToJson(project)
+  sections <- if (containerOnly) {
+    .emptyTreeSectionsJson()
+  } else {
+    list(
+      observedData = .observedDataToJson(project),
+      outputPaths = .outputPathsToJson(project),
+      scenarios = if (includeScenarios) .scenariosToJson(project) else list(),
+      parameterSets = .parameterSetsToJson(project),
+      initialConditions = .initialConditionsToJson(project),
+      individuals = .individualsToJson(project),
+      populations = .populationsToJson(project),
+      applications = .applicationsToJson(project),
+      dataCombined = .dataCombinedSectionToJson(project),
+      plots = .plotsSectionToJson(project),
+      plotGrids = .plotGridsSectionToJson(project),
+      parameterIdentification = .parameterIdentificationToJson(project)
+    )
+  }
+  out <- c(
+    list(
+      # Default the version so an empty `Project$new()` serializes a file that
+      # `loadProject()` accepts (mirrors the Excel bridge in project-excel.R).
+      schemaVersion = project$schemaVersion %||% "2.0",
+      esqlabsRVersion = project$esqlabsRVersion,
+      name = project$name,
+      description = project$description,
+      definitionsFolder = project$definitionsFolder,
+      filePaths = .filePathsToJson(project),
+      defaultSimulationRunOptions = project$defaultSimulationRunOptions
+    ),
+    sections
+  )
+  if (length(excel) > 0L) {
+    out$excel <- excel
+  }
+  out
+}
+
+# The canonical empty-shape JSON value for every tree-owned section, in the
+# same key order `.projectToJson()` emits. Used by the container-only write
+# path so a `Project.json` container holds only the container itself, the
+# `definitions/<kind>/` tree owning the sections. Each value matches what the
+# section's serializer returns for an empty project: the array-shaped sections
+# (`observedData`, `scenarios`, `individuals`, `populations`) emit `[]`; the
+# map-shaped sections (`outputPaths`, `parameterSets`, `initialConditions`,
+# `applications`) emit `{}`; the sections that round-trip an absent key
+# (`dataCombined`, `plots`, `plotGrids`, `parameterIdentification`) emit `NULL`.
+#
+# @keywords internal
+# @noRd
+.emptyTreeSectionsJson <- function() {
+  emptyArray <- list()
+  emptyObject <- structure(list(), names = character(0L))
   list(
-    # Default the version so an empty `Project$new()` serializes a file that
-    # `loadProject()` accepts (mirrors the Excel bridge in project-excel.R).
-    schemaVersion = project$schemaVersion %||% "2.0",
-    esqlabsRVersion = project$esqlabsRVersion,
-    filePaths = .filePathsToJson(project),
-    observedData = .observedDataToJson(project),
-    outputPaths = .outputPathsToJson(project),
-    scenarios = .scenariosToJson(project),
-    modelParameterSets = .modelParameterSetsToJson(project),
-    individuals = .individualsToJson(project),
-    individualParameterSets = .individualParameterSetsToJson(project),
-    populations = .populationsToJson(project),
-    applications = .applicationsToJson(project),
-    applicationParameterSets = .applicationParameterSetsToJson(project),
-    plots = .plotsToJson(project),
-    parameterIdentification = .parameterIdentificationToJson(project)
+    observedData = emptyArray,
+    outputPaths = emptyObject,
+    scenarios = emptyArray,
+    parameterSets = emptyObject,
+    initialConditions = emptyObject,
+    individuals = emptyArray,
+    populations = emptyArray,
+    applications = emptyObject,
+    dataCombined = NULL,
+    plots = NULL,
+    plotGrids = NULL,
+    parameterIdentification = NULL
   )
 }
 
@@ -61,12 +143,25 @@
 #'
 #' @param project A `Project` (R6) instance.
 #' @param path Destination path. Parent directory must exist.
+#' @param includeScenarios Logical. Passed to `.projectToJson()`: `TRUE`
+#'   (default) inlines the scenarios array (snapshot shape); `FALSE` writes
+#'   the container shape with scenarios held as an entity tree alongside.
+#'   Ignored when `containerOnly` is `TRUE`.
+#' @param containerOnly Logical. Passed to `.projectToJson()`: `TRUE` writes
+#'   only the container (metadata, filePaths, defaultSimulationRunOptions,
+#'   excel) with every tree-owned section emptied; `FALSE` (default)
+#'   serializes the sections too.
 #'
 #' @return `path`, invisibly.
 #'
 #' @keywords internal
 #' @noRd
-.saveProjectJson <- function(project, path) {
+.saveProjectJson <- function(
+  project,
+  path,
+  includeScenarios = TRUE,
+  containerOnly = FALSE
+) {
   if (
     !is.character(path) || length(path) != 1L || is.na(path) || !nzchar(path)
   ) {
@@ -78,7 +173,11 @@
   }
 
   jsonlite::write_json(
-    .projectToJson(project),
+    .projectToJson(
+      project,
+      includeScenarios = includeScenarios,
+      containerOnly = containerOnly
+    ),
     path,
     auto_unbox = TRUE,
     null = "null",
@@ -96,8 +195,10 @@
 # move here from caller code (e.g. relative-path normalization, ID
 # dereferencing, unit conversions).
 
-# JSON object. Walks the raw `{value, description}` records in
-# `.getFilePathsData()` and emits a flat `{name: value}` map.
+# JSON object (the `filePaths` block). Walks the raw `{value, description}`
+# records in `.getFilePathsData()` (the four live working folders only) and
+# emits a flat `{name: value}` map. The Excel-bridge sheet names are emitted
+# separately by `.excelToJson()`.
 .filePathsToJson <- function(project) {
   data <- project$.getFilePathsData()
   if (length(data) == 0L) {
@@ -105,6 +206,20 @@
   }
   result <- lapply(data, function(entry) entry$value)
   .asJsonObject(result)
+}
+
+# JSON object (the `excel` block) or an empty list when the project has no
+# Excel side-car. Walks the raw `{value, description}` records in
+# `.getExcelData()` (the seven Excel-bridge sheet-name fields) and emits a flat
+# `{name: value}` map. Returns `list()` (length 0) when there are no fields, so
+# `.projectToJson()` can omit the `excel` key entirely for a from-scratch JSON
+# project.
+.excelToJson <- function(project) {
+  data <- project$.getExcelData()
+  if (length(data) == 0L) {
+    return(list())
+  }
+  lapply(data, function(entry) entry$value)
 }
 
 # JSON object (map of id → output path string). Coerces a named character
@@ -127,119 +242,136 @@
   .asJsonObject(outputPaths)
 }
 
-# JSON array of scenario objects. Reverses the parse-time
-# transformations: literal `outputPaths` rebuilt as `outputPathIds`
-# against the project lookup, parsed `simulationTime` rejoined to
-# `"a, b, c; d, e, f"`, base-unit `steadyStateTime` converted back to
-# its declared unit. Field order matches the example fixture so
-# round-trip diffs stay zero-noise.
+# JSON array of scenario objects. A thin wrapper over the per-scenario
+# serializer `.scenarioToJson()`; used by the monolithic snapshot
+# (`.projectToJson()`). The entity-files writer calls `.scenarioToJson()`
+# directly, one scenario per file.
 .scenariosToJson <- function(project) {
   scenarios <- project$scenarios
   if (is.null(scenarios) || length(scenarios) == 0L) {
     return(list())
   }
+  unname(lapply(scenarios, .scenarioToJson, outputPaths = project$outputPaths))
+}
 
-  unname(lapply(scenarios, function(sc) {
-    # Default to `list()` so the JSON output is `[]` when the scenario
-    # has no resolved paths (whether the JSON had `outputPathIds: []`,
-    # omitted the key, or `sc$outputPaths` was set to `NULL`
-    # programmatically). Round-trip preserves array-shape symmetry with
-    # the parser, which collapses absent and empty-array to `NULL`.
-    outputPathIds <- list()
-    if (!is.null(sc$outputPaths)) {
-      pathIds <- names(sc$outputPaths)
-      if (is.null(pathIds) || any(pathIds == "")) {
-        cli::cli_abort(
-          c(
-            "Scenario {.val {sc$scenarioName}} has {.field outputPaths} without ids.",
-            "i" = "Expected a named character vector: id-as-name, literal-path-as-value."
-          )
+# Serialize one `Scenario` record to its JSON object shape. Reverses the
+# parse-time transformations: the literal `outputPaths` record field rebuilt
+# as the `outputPaths` id array against the project lookup, parsed
+# `simulationTime` rejoined to `"a, b, c; d, e, f"`, base-unit
+# `steadyStateTime` converted
+# back to its declared unit. Field order matches the example fixture so
+# round-trip diffs stay zero-noise. The same object is one element of the
+# monolithic `scenarios` array and the entire content of one scenario
+# entity file.
+#
+# @keywords internal
+# @noRd
+.scenarioToJson <- function(sc, outputPaths) {
+  # Default to `list()` so the JSON output is `[]` when the scenario
+  # has no resolved paths (whether the JSON had `outputPaths: []`,
+  # omitted the key, or `sc$outputPaths` was set to `NULL`
+  # programmatically). Round-trip preserves array-shape symmetry with
+  # the parser, which collapses absent and empty-array to `NULL`.
+  outputPathIds <- list()
+  if (!is.null(sc$outputPaths)) {
+    pathIds <- names(sc$outputPaths)
+    if (is.null(pathIds) || any(pathIds == "")) {
+      cli::cli_abort(
+        c(
+          "Scenario {.val {sc$scenarioName}} has {.field outputPaths} without ids.",
+          "i" = "Expected a named character vector: id-as-name, literal-path-as-value."
         )
-      }
-      unknown <- setdiff(pathIds, names(project$outputPaths))
-      if (length(unknown) > 0) {
-        cli::cli_abort(
-          "Scenario {.val {sc$scenarioName}} references unknown outputPathIds: {.val {unknown}}."
-        )
-      }
-      outputPathIds <- as.list(pathIds)
-    }
-
-    simTimeStr <- NULL
-    if (!is.null(sc$simulationTime)) {
-      intervals <- vapply(
-        sc$simulationTime,
-        function(int) paste(int, collapse = ", "),
-        character(1)
       )
-      simTimeStr <- paste(intervals, collapse = "; ")
     }
+    # A dangling outputPathId (one not in the project lookup) is a
+    # referential issue caught lazily by the cross-reference validator,
+    # not a serialization error; the id round-trips verbatim.
+    outputPathIds <- as.list(pathIds)
+  }
 
-    if (sc$simulateSteadyState && is.null(sc$steadyStateTimeUnit)) {
-      cli::cli_abort(c(
-        "Scenario {.val {sc$scenarioName}} has {.field simulateSteadyState}=TRUE \\
-        but {.field steadyStateTimeUnit} is NULL.",
-        "i" = "Set {.field steadyStateTimeUnit} (e.g. {.val min}) so the value \\
-        can round-trip."
-      ))
-    }
-
-    list(
-      name = sc$scenarioName,
-      individualId = sc$individualId,
-      # Emit the populationId verbatim rather than keying off the derived
-      # `simulationType`, so a drifted record (populationId set while the
-      # type reads "Individual") does not silently lose its populationId.
-      populationId = sc$populationId,
-      readPopulationFromCSV = sc$readPopulationFromCSV,
-      # `as.list(NULL)` -> `list()`; this collapses both "key absent" and
-      # "empty array" in the parsed scenario to JSON `[]`. Matches the
-      # end-state serializer in `json-as-primary-input-v2`.
-      modelParameterSets = as.list(sc$modelParameterSets),
-      applicationProtocol = if (
-        is.null(sc$applicationProtocol) || is.na(sc$applicationProtocol)
-      ) {
-        NULL
-      } else {
-        sc$applicationProtocol
-      },
-      simulationTime = simTimeStr,
-      simulationTimeUnit = sc$simulationTimeUnit,
-      steadyState = sc$simulateSteadyState,
-      # Emit the steady-state time/unit whenever a unit is declared,
-      # independently of `simulateSteadyState`. A declared time with the
-      # flag off (e.g. `steadyState: false` plus a preset time) is valid
-      # JSON the parser reads back, so dropping it would lose data.
-      steadyStateTime = if (!is.null(sc$steadyStateTimeUnit)) {
-        ospsuite::toUnit(
-          quantityOrDimension = ospDimensions$Time,
-          values = sc$steadyStateTime,
-          targetUnit = sc$steadyStateTimeUnit
-        )
-      } else {
-        NULL
-      },
-      steadyStateTimeUnit = sc$steadyStateTimeUnit,
-      overwriteFormulasInSS = sc$overwriteFormulasInSS,
-      modelFile = sc$modelFile,
-      outputPathIds = outputPathIds
+  simTimeStr <- NULL
+  if (!is.null(sc$simulationTime)) {
+    intervals <- vapply(
+      sc$simulationTime,
+      function(int) paste(int, collapse = ", "),
+      character(1)
     )
-  }))
+    simTimeStr <- paste(intervals, collapse = "; ")
+  }
+
+  if (sc$simulateSteadyState && is.null(sc$steadyStateTimeUnit)) {
+    cli::cli_abort(c(
+      "Scenario {.val {sc$scenarioName}} has {.field simulateSteadyState}=TRUE \\
+      but {.field steadyStateTimeUnit} is NULL.",
+      "i" = "Set {.field steadyStateTimeUnit} (e.g. {.val min}) so the value \\
+      can round-trip."
+    ))
+  }
+
+  list(
+    name = sc$scenarioName,
+    individual = sc$individualId,
+    # Emit the population id verbatim rather than keying off the derived
+    # `simulationType`, so a drifted record (populationId set while the
+    # type reads "Individual") does not silently lose its population.
+    population = sc$populationId,
+    readPopulationFromCSV = sc$readPopulationFromCSV,
+    # `as.list(NULL)` -> `list()`; this collapses both "key absent" and
+    # "empty array" in the parsed scenario to JSON `[]`. Matches the
+    # end-state serializer in `json-as-primary-input-v2`.
+    parameterSets = as.list(sc$modelParameterSets),
+    initialConditions = as.list(sc$initialConditions),
+    application = if (
+      is.null(sc$applicationProtocol) || is.na(sc$applicationProtocol)
+    ) {
+      NULL
+    } else {
+      sc$applicationProtocol
+    },
+    simulationTime = simTimeStr,
+    simulationTimeUnit = sc$simulationTimeUnit,
+    steadyState = sc$simulateSteadyState,
+    # Emit the steady-state time/unit whenever a unit is declared,
+    # independently of `simulateSteadyState`. A declared time with the
+    # flag off (e.g. `steadyState: false` plus a preset time) is valid
+    # JSON the parser reads back, so dropping it would lose data.
+    steadyStateTime = if (!is.null(sc$steadyStateTimeUnit)) {
+      ospsuite::toUnit(
+        quantityOrDimension = ospDimensions$Time,
+        values = sc$steadyStateTime,
+        targetUnit = sc$steadyStateTimeUnit
+      )
+    } else {
+      NULL
+    },
+    steadyStateTimeUnit = sc$steadyStateTimeUnit,
+    overwriteFormulasInSS = sc$overwriteFormulasInSS,
+    modelFile = sc$modelFile,
+    outputPaths = outputPathIds
+  )
 }
 
-# JSON object (map of parameter-set name → array of parameter entries).
-.modelParameterSetsToJson <- function(project) {
-  .asJsonObject(project$modelParameterSets)
+# JSON object (map of parameter-set id → array of parameter entries). The
+# single unified parameter-set section; a scenario / individual / application
+# all reference into it.
+.parameterSetsToJson <- function(project) {
+  sets <- project$parameterSets
+  # Strip the `ParameterSet` class wrapper from each set's array-of-entries so
+  # it never reaches JSON (the wrapper exists only for the print method).
+  sets <- lapply(sets, unclass)
+  .asJsonObject(sets)
 }
 
-# JSON object (map of parameter-set name → array of parameter entries).
-.individualParameterSetsToJson <- function(project) {
-  .asJsonObject(project$individualParameterSets)
-}
-
-# JSON object (map of parameter-set name → array of parameter entries).
-.applicationParameterSetsToJson <- function(project) {
-  .asJsonObject(project$applicationParameterSets)
+# JSON object (map of initial-condition set id → array of `{path, value, unit}`
+# records). Applied to a scenario's simulation via its `initialConditions`
+# field.
+.initialConditionsToJson <- function(project) {
+  sets <- project$initialConditions
+  # Strip the `InitialConditionSet` class wrapper from each set's array-of-
+  # entries so it never reaches JSON (the wrapper exists only for the print
+  # method).
+  sets <- lapply(sets, unclass)
+  .asJsonObject(sets)
 }
 
 # JSON array of individual objects. The in-memory shape is a named list
@@ -295,24 +427,28 @@
   result
 }
 
-# JSON array of observed-data source entries.
+# JSON array of observed-data source entries. Strips the
+# `ObservedDataSource` class wrapper from each entry (carried only for the
+# print method) so it never reaches JSON.
 .observedDataToJson <- function(project) {
-  project$observedData
+  lapply(project$observedData, unclass)
 }
 
-# `.plotsToJson` and its data-shape helpers (`.dataCombinedToNestedJson`,
-# `.dataFrameToListOfLists`) live in R/plots.R alongside the plots section
-# parse + validate + mutation API.
+# The three plots-section serializers (`.dataCombinedSectionToJson`,
+# `.plotsSectionToJson`, `.plotGridsSectionToJson`) and their data-shape
+# helpers (`.dataCombinedToNestedJson`, `.plotEntriesToJson`) live in R/plots.R
+# alongside the plots-section parse + validate + mutation API.
 
 # Shape-coercion helper -------------------------------------------------------
 
 # `list()` is ambiguous in JSON: jsonlite renders an empty list as `[]`, but
 # the schema requires `{}` for the map-shaped sections (`filePaths`,
-# `outputPaths`, `applications`, `modelParameterSets`,
-# `individualParameterSets`, `applicationParameterSets`). Setting a
-# zero-length names attribute triggers jsonlite's named-list serialization
-# path.
+# `outputPaths`, `applications`, `parameterSets`). Setting a zero-length
+# names attribute triggers jsonlite's named-list serialization path.
 .asJsonObject <- function(x) {
+  # Strip the printable DefinitionList wrapper a section accessor adds on read,
+  # so the class never reaches the serialized JSON.
+  x <- .unwrapDefinitionList(x)
   if (length(x) == 0L) {
     return(structure(list(), names = character(0L)))
   }
@@ -363,8 +499,11 @@
   list(
     id = m$id,
     scenarios = as.list(m$scenarios),
-    outputPathId = m$outputPathId,
-    observedDataId = m$observedDataId,
+    # The on-disk JSON keys are suffixless (`outputPath` / `observedData`); the
+    # kept record fields keep their id-suffixed names, mirroring the parser
+    # (`.parsePIOutputMappings`) and the `PIOutputMapping()` mapping seam.
+    outputPath = m$outputPathId,
+    observedData = m$observedDataId,
     scaling = m$scaling,
     xOffset = m$xOffset,
     yOffset = m$yOffset,

--- a/R/project.R
+++ b/R/project.R
@@ -1,5 +1,23 @@
 # Project R6 class ----
 
+# The seven container path fields that belong to the Excel import/export
+# bridge (the `excel` block), as opposed to the four live working folders
+# (`modelFolder`, `dataFolder`, `outputFolder`, `populationsFolder`) that the
+# runtime reads (the `filePaths` block). A legacy `Project.json` carries all
+# eleven in one flat `filePaths` block; this fixed mapping is what splits them
+# on read and routes each to its own container block on write.
+.excelFilePathFields <- c(
+  "configurationsFolder",
+  "modelParamsFile",
+  "individualsFile",
+  "populationsFile",
+  "scenariosFile",
+  "applicationsFile",
+  "plotsFile",
+  "parameterIdentificationFile",
+  "initialConditionsFile"
+)
+
 #' @title Project
 #' @docType class
 #' @description An R6 class representing an esqlabsR project
@@ -12,6 +30,13 @@
 #'   programmatic observed data added via [addObservedData()] with a
 #'   `DataSet` object; those `ospsuite::DataSet` objects wrap external
 #'   handles and are shared by reference between a project and its clone.
+#'
+#'   A clone is also detached from the source on disk: it does not own the
+#'   source's entity tree, so its write-through mutations (`addScenario()`,
+#'   `removeScenario()`, and the other `add*` / `remove*` / `set*` helpers)
+#'   stay in memory only and never touch the source's `definitions/`
+#'   directory. Use [saveSnapshot()] to write the clone to a single-file
+#'   snapshot you can reload with [loadSnapshot()].
 #' @format NULL
 #' @import fs
 #' @export
@@ -42,16 +67,6 @@ Project <- R6::R6Class(
       private$.projectDirPath
     },
 
-    #' @field modified Read-only logical. `TRUE` if any configuration property
-    #'   has been modified since the project was loaded or saved. Cleared
-    #'   internally by [saveProject()].
-    modified = function(value) {
-      if (!missing(value)) {
-        cli::cli_abort("{.field modified} is readonly")
-      }
-      private$.modified
-    },
-
     #' @field validatedSinceMutation Read-only logical. `TRUE` if a full
     #'   [validateProject()] has succeeded since the last project mutation
     #'   or load. Cleared by any mutation. Used internally by automatic
@@ -64,24 +79,94 @@ Project <- R6::R6Class(
       private$.validatedSinceMutation
     },
 
+    #' @field name Human-readable project name (the `name` JSON field). May be
+    #'   `NULL` when the project declares no name. Writing persists the
+    #'   container for a bound project.
+    name = function(value) {
+      if (!missing(value)) {
+        private$.name <- value
+        private$.invalidateContainer()
+        return(invisible(value))
+      }
+      private$.name
+    },
+
+    #' @field description Optional free-text project description (the
+    #'   `description` JSON field). May be `NULL`. Writing persists the
+    #'   container for a bound project.
+    description = function(value) {
+      if (!missing(value)) {
+        private$.description <- value
+        private$.invalidateContainer()
+        return(invisible(value))
+      }
+      private$.description
+    },
+
+    #' @field definitionsFolder Name of the folder (relative to
+    #'   `projectDirPath`) that holds the project's authored entity-definition
+    #'   tree. Defaults to `"definitions"`. Writing persists the container for
+    #'   a bound project; changing it moves where future write-through edits
+    #'   are read from and written to.
+    definitionsFolder = function(value) {
+      if (!missing(value)) {
+        private$.definitionsFolder <- value
+        private$.invalidateContainer()
+        return(invisible(value))
+      }
+      private$.definitionsFolder %||% "definitions"
+    },
+
+    #' @field defaultSimulationRunOptions Named list of the project-level
+    #'   default simulation run options (the `defaultSimulationRunOptions` JSON
+    #'   field), or `NULL` when none are declared. Used by [runScenarios()] as
+    #'   the default `simulationRunOptions` when the caller does not pass one.
+    #'   Recognized fields: `numberOfCores`, `checkForNegativeValues`,
+    #'   `showProgress`. Writing persists the container for a bound project.
+    defaultSimulationRunOptions = function(value) {
+      if (!missing(value)) {
+        private$.defaultSimulationRunOptions <- value
+        private$.invalidateContainer()
+        return(invisible(value))
+      }
+      private$.defaultSimulationRunOptions
+    },
+
+    #' @field excel Read-only named list of the Excel import/export bridge
+    #'   sheet-name fields (`configurationsFolder`, `modelParamsFile`,
+    #'   `individualsFile`, `populationsFile`, `scenariosFile`,
+    #'   `applicationsFile`, `plotsFile`, `parameterIdentificationFile`).
+    #'   Returned verbatim as strings (no resolution). Empty for a from-scratch
+    #'   JSON project that has no Excel side-car.
+    excel = function(value) {
+      if (!missing(value)) {
+        cli::cli_abort("{.field excel} is readonly")
+      }
+      data <- private$.excelData
+      if (length(data) == 0L) {
+        return(structure(list(), names = character(0L)))
+      }
+      lapply(data, function(entry) entry$value)
+    },
+
     #' @field schemaVersion Schema version declared in the JSON. Always "2.0"
-    #'   for projects loaded by this parser. Writing marks the project as
-    #'   modified.
+    #'   for projects loaded by this parser. Writing persists the container
+    #'   for a bound project.
     schemaVersion = function(value) {
       if (!missing(value)) {
         private$.schemaVersion <- value
-        private$.invalidate()
+        private$.invalidateContainer()
         return(invisible(value))
       }
       private$.schemaVersion
     },
 
     #' @field esqlabsRVersion Informational version string from the JSON.
-    #'   Writing marks the project as modified.
+    #'   Writing persists the container for a bound project.
     esqlabsRVersion = function(value) {
       if (!missing(value)) {
         private$.esqlabsRVersion <- value
-        private$.invalidate()
+        private$.invalidateContainer()
         return(invisible(value))
       }
       private$.esqlabsRVersion
@@ -100,7 +185,7 @@ Project <- R6::R6Class(
     modelFolder = function(value) {
       if (!missing(value)) {
         private$.filePathsData$modelFolder$value <- value
-        private$.invalidate()
+        private$.invalidateContainer()
         return(invisible(value))
       }
       private$.clean_path(
@@ -110,100 +195,135 @@ Project <- R6::R6Class(
     },
 
     #' @field configurationsFolder Path to the folder containing configuration
-    #'   files. Used by the Excel import/export bridge.
+    #'   files. Part of the Excel import/export bridge (the `excel` container
+    #'   block).
     configurationsFolder = function(value) {
       if (!missing(value)) {
-        private$.filePathsData$configurationsFolder$value <- value
-        private$.invalidate()
+        private$.excelData$configurationsFolder$value <- value
+        private$.invalidateContainer()
         return(invisible(value))
       }
       private$.clean_path(
-        private$.filePathsData$configurationsFolder$value,
+        private$.excelData$configurationsFolder$value,
         self$projectDirPath
       )
     },
 
     #' @field modelParamsFile Path to the Excel file with global model
-    #'   parameterization. Used by the Excel import/export bridge.
+    #'   parameterization. Part of the Excel import/export bridge (the `excel`
+    #'   container block).
     modelParamsFile = function(value) {
       if (!missing(value)) {
-        private$.filePathsData$modelParamsFile$value <- value
-        private$.invalidate()
+        private$.excelData$modelParamsFile$value <- value
+        private$.invalidateContainer()
         return(invisible(value))
       }
       private$.clean_path(
-        private$.filePathsData$modelParamsFile$value,
+        private$.excelData$modelParamsFile$value,
         self$configurationsFolder
       )
     },
 
     #' @field individualsFile Path to the Excel file with individual-specific
-    #'   model parameterization. Used by the Excel import/export bridge.
+    #'   model parameterization. Part of the Excel import/export bridge (the
+    #'   `excel` container block).
     individualsFile = function(value) {
       if (!missing(value)) {
-        private$.filePathsData$individualsFile$value <- value
-        private$.invalidate()
+        private$.excelData$individualsFile$value <- value
+        private$.invalidateContainer()
         return(invisible(value))
       }
       private$.clean_path(
-        private$.filePathsData$individualsFile$value,
+        private$.excelData$individualsFile$value,
         self$configurationsFolder
       )
     },
 
     #' @field populationsFile Path to the Excel file with population
-    #'   information. Used by the Excel import/export bridge.
+    #'   information. Part of the Excel import/export bridge (the `excel`
+    #'   container block).
     populationsFile = function(value) {
       if (!missing(value)) {
-        private$.filePathsData$populationsFile$value <- value
-        private$.invalidate()
+        private$.excelData$populationsFile$value <- value
+        private$.invalidateContainer()
         return(invisible(value))
       }
       private$.clean_path(
-        private$.filePathsData$populationsFile$value,
+        private$.excelData$populationsFile$value,
         self$configurationsFolder
       )
     },
 
     #' @field scenariosFile Path to the Excel file with scenario definitions.
-    #'   Used by the Excel import/export bridge.
+    #'   Part of the Excel import/export bridge (the `excel` container block).
     scenariosFile = function(value) {
       if (!missing(value)) {
-        private$.filePathsData$scenariosFile$value <- value
-        private$.invalidate()
+        private$.excelData$scenariosFile$value <- value
+        private$.invalidateContainer()
         return(invisible(value))
       }
       private$.clean_path(
-        private$.filePathsData$scenariosFile$value,
+        private$.excelData$scenariosFile$value,
         self$configurationsFolder
       )
     },
 
     #' @field applicationsFile Path to the Excel file with scenario-specific
-    #'   parameters such as application protocol parameters. Used by the
-    #'   Excel import/export bridge.
+    #'   parameters such as application protocol parameters. Part of the Excel
+    #'   import/export bridge (the `excel` container block).
     applicationsFile = function(value) {
       if (!missing(value)) {
-        private$.filePathsData$applicationsFile$value <- value
-        private$.invalidate()
+        private$.excelData$applicationsFile$value <- value
+        private$.invalidateContainer()
         return(invisible(value))
       }
       private$.clean_path(
-        private$.filePathsData$applicationsFile$value,
+        private$.excelData$applicationsFile$value,
         self$configurationsFolder
       )
     },
 
-    #' @field plotsFile Path to the Excel file with plot definitions. Used by
-    #'   the Excel import/export bridge.
+    #' @field plotsFile Path to the Excel file with plot definitions. Part of
+    #'   the Excel import/export bridge (the `excel` container block).
     plotsFile = function(value) {
       if (!missing(value)) {
-        private$.filePathsData$plotsFile$value <- value
-        private$.invalidate()
+        private$.excelData$plotsFile$value <- value
+        private$.invalidateContainer()
         return(invisible(value))
       }
       private$.clean_path(
-        private$.filePathsData$plotsFile$value,
+        private$.excelData$plotsFile$value,
+        self$configurationsFolder
+      )
+    },
+
+    #' @field parameterIdentificationFile Name of the Excel workbook holding
+    #'   the parameter-identification sheets (`PITasks`, `PIParameters`,
+    #'   `PIOutputMappings`). Resolved relative to `configurationsFolder`.
+    parameterIdentificationFile = function(value) {
+      if (!missing(value)) {
+        private$.excelData$parameterIdentificationFile$value <- value
+        private$.invalidateContainer()
+        return(invisible(value))
+      }
+      private$.clean_path(
+        private$.excelData$parameterIdentificationFile$value,
+        self$configurationsFolder
+      )
+    },
+
+    #' @field initialConditionsFile Name of the Excel workbook holding the
+    #'   initial-condition (molecule start value) sheets, one sheet per set.
+    #'   Part of the Excel import/export bridge (the `excel` container block);
+    #'   resolved relative to `configurationsFolder`.
+    initialConditionsFile = function(value) {
+      if (!missing(value)) {
+        private$.excelData$initialConditionsFile$value <- value
+        private$.invalidateContainer()
+        return(invisible(value))
+      }
+      private$.clean_path(
+        private$.excelData$initialConditionsFile$value,
         self$configurationsFolder
       )
     },
@@ -214,7 +334,7 @@ Project <- R6::R6Class(
     populationsFolder = function(value) {
       if (!missing(value)) {
         private$.filePathsData$populationsFolder$value <- value
-        private$.invalidate()
+        private$.invalidateContainer()
         return(invisible(value))
       }
       private$.clean_path(
@@ -228,7 +348,7 @@ Project <- R6::R6Class(
     dataFolder = function(value) {
       if (!missing(value)) {
         private$.filePathsData$dataFolder$value <- value
-        private$.invalidate()
+        private$.invalidateContainer()
         return(invisible(value))
       }
       private$.clean_path(
@@ -242,7 +362,7 @@ Project <- R6::R6Class(
     outputFolder = function(value) {
       if (!missing(value)) {
         private$.filePathsData$outputFolder$value <- value
-        private$.invalidate()
+        private$.invalidateContainer()
         return(invisible(value))
       }
       private$.clean_path(
@@ -251,144 +371,177 @@ Project <- R6::R6Class(
       )
     },
 
-    # Section data. Each binding stores the section in a private backing
-    # field and invalidates on write, so any assignment (including
-    # subscript forms like `project$scenarios[[name]] <- sc`, which R
-    # desugars into a full read-modify-write through the setter) marks
-    # the project modified and clears `validatedSinceMutation`.
+    # Section data. Each accessor is READ-ONLY from the handle: the getter
+    # returns the section wrapped in a printable, read-only `DefinitionList`,
+    # and every assignment form (`project$x <- v`, `project$x[["id"]] <- v`,
+    # the nested `project$x[["id"]]$f <- v`, `project$x[-i] <- v`) aborts. The
+    # only sanctioned way to change a section is an authoring function
+    # (`addScenario()` / `setScenario()` / `removeScenario()` and their
+    # per-section siblings) or editing the definition's JSON file; those write
+    # through the internal `.setSection()` entry point, which structurally
+    # validates each changed entity, persists it to (or deletes it from) its
+    # `definitions/<kind>/` tree, and clears `validatedSinceMutation` so the
+    # next run/plot re-validates.
 
-    #' @field outputPaths Named list mapping output-path IDs to OSPS-notation
-    #'   path strings (e.g. `list(PVB = "Organism|...")`). A named character
-    #'   vector is also accepted on write and coerced to a list on save.
-    #'   Writing marks the project as modified.
+    #' @field outputPaths Read-only named list mapping output-path IDs to
+    #'   OSPS-notation path strings (e.g. `list(PVB = "Organism|...")`). To
+    #'   change it, use [addOutputPath()] / [setOutputPath()] /
+    #'   [removeOutputPath()] or edit the entity files under
+    #'   `definitions/output-paths/`; an authoring write persists each changed
+    #'   output path to (or deletes it from) its file.
     outputPaths = function(value) {
       if (!missing(value)) {
-        private$.outputPaths <- value
-        private$.invalidate()
-        return(invisible(value))
+        .definitionListReadOnlyError("outputPaths")
       }
-      private$.outputPaths
+      .asDefinitionList(private$.outputPaths, "outputPaths")
     },
 
-    #' @field scenarios Named list of `Scenario` records, keyed by scenario
-    #'   name. Entries are plain-data records with copy semantics; write a
-    #'   modified entry back (e.g. `project$scenarios[[name]] <- sc`) to
-    #'   mutate the project. Writing marks the project as modified.
+    #' @field scenarios Read-only named list of `Scenario` records, keyed by
+    #'   scenario name. To change it, use [addScenario()] / [setScenario()] /
+    #'   [removeScenario()] (or [renameScenario()] / [duplicateScenario()]), or
+    #'   edit the entity files under `definitions/scenarios/`. The canonical
+    #'   edit loop is read-modify-resubmit: read a record
+    #'   (`sc <- project$scenarios[["id"]]`), change the detached copy
+    #'   (`sc$modelFile <- ...`), then re-submit it
+    #'   (`setScenario(project, "id", ...)`). An authoring write structurally
+    #'   validates each changed scenario and persists it to (or deletes it from)
+    #'   its file; an in-memory project (no directory) holds scenarios in memory
+    #'   only.
     scenarios = function(value) {
       if (!missing(value)) {
-        private$.scenarios <- value
-        private$.invalidate()
-        return(invisible(value))
+        .definitionListReadOnlyError("scenarios")
       }
-      private$.scenarios
+      .asDefinitionList(private$.scenarios, "scenarios")
     },
 
-    #' @field modelParameterSets Named list of parameter structures, keyed by
-    #'   set name. Writing marks the project as modified.
-    modelParameterSets = function(value) {
+    #' @field parameterSets Read-only named list of parameter structures, keyed
+    #'   by set id. This single section holds every parameter set in the
+    #'   project: a scenario references the sets it applies through its
+    #'   `modelParameterSets` field, an individual or application through its
+    #'   `parameterSets` field; all three resolve against this one map. To
+    #'   change it, use [addParameterSet()] / [removeParameterSet()] /
+    #'   [addParameterEntry()] / [removeParameterEntry()] or edit the entity
+    #'   files under `definitions/parameter-sets/`.
+    parameterSets = function(value) {
       if (!missing(value)) {
-        private$.modelParameterSets <- value
-        private$.invalidate()
-        return(invisible(value))
+        .definitionListReadOnlyError("parameterSets")
       }
-      private$.modelParameterSets
+      .asDefinitionList(private$.parameterSets, "parameterSets")
     },
 
-    #' @field individualParameterSets Named list of parameter structures,
-    #'   keyed by set name. Writing marks the project as modified.
-    individualParameterSets = function(value) {
+    #' @field initialConditions Read-only named list of initial-condition sets,
+    #'   keyed by set id. Each set is a list of molecule start-value records
+    #'   (`path`, `value`, `unit`), applied to a scenario's simulation via its
+    #'   `initialConditions` field. To change it, use [addInitialConditions()] /
+    #'   [removeInitialConditions()] / [addInitialConditionEntry()] /
+    #'   [removeInitialConditionEntry()] or edit the entity files under
+    #'   `definitions/initial-conditions/`.
+    initialConditions = function(value) {
       if (!missing(value)) {
-        private$.individualParameterSets <- value
-        private$.invalidate()
-        return(invisible(value))
+        .definitionListReadOnlyError("initialConditions")
       }
-      private$.individualParameterSets
+      .asDefinitionList(private$.initialConditions, "initialConditions")
     },
 
-    #' @field applicationParameterSets Named list of parameter structures,
-    #'   keyed by set name. Writing marks the project as modified.
-    applicationParameterSets = function(value) {
-      if (!missing(value)) {
-        private$.applicationParameterSets <- value
-        private$.invalidate()
-        return(invisible(value))
-      }
-      private$.applicationParameterSets
-    },
-
-    #' @field individuals Named list of plain lists, keyed by individualId.
-    #'   Writing marks the project as modified.
+    #' @field individuals Read-only named list of plain lists, keyed by
+    #'   individualId. To change it, use [addIndividual()] / [setIndividual()] /
+    #'   [removeIndividual()] or edit the entity files under
+    #'   `definitions/individuals/`.
     individuals = function(value) {
       if (!missing(value)) {
-        private$.individuals <- value
-        private$.invalidate()
-        return(invisible(value))
+        .definitionListReadOnlyError("individuals")
       }
-      private$.individuals
+      .asDefinitionList(private$.individuals, "individuals")
     },
 
-    #' @field populations Named list of plain lists, keyed by populationId.
-    #'   Writing marks the project as modified.
+    #' @field populations Read-only named list of plain lists, keyed by
+    #'   populationId. To change it, use [addPopulation()] / [setPopulation()] /
+    #'   [removePopulation()] or edit the entity files under
+    #'   `definitions/populations/`.
     populations = function(value) {
       if (!missing(value)) {
-        private$.populations <- value
-        private$.invalidate()
-        return(invisible(value))
+        .definitionListReadOnlyError("populations")
       }
-      private$.populations
+      .asDefinitionList(private$.populations, "populations")
     },
 
-    #' @field applications Named list of parameter structures, keyed by
-    #'   protocol name. Writing marks the project as modified.
+    #' @field applications Read-only named list of parameter structures, keyed
+    #'   by protocol name. To change it, use [addApplication()] /
+    #'   [removeApplication()] or edit the entity files under
+    #'   `definitions/applications/`.
     applications = function(value) {
       if (!missing(value)) {
-        private$.applications <- value
-        private$.invalidate()
-        return(invisible(value))
+        .definitionListReadOnlyError("applications")
       }
-      private$.applications
+      .asDefinitionList(private$.applications, "applications")
     },
 
-    #' @field observedData List of observed data source declarations parsed
-    #'   from JSON. Writing marks the project as modified and resets the
-    #'   cached observed-data names.
+    #' @field observedData Read-only list of observed data source declarations.
+    #'   To change it, use [addObservedData()] / [removeObservedData()] or edit
+    #'   the entity files under `definitions/observed-data/` (one file per
+    #'   declaration).
     observedData = function(value) {
       if (!missing(value)) {
-        private$.observedData <- value
-        private$.observedDataNamesCache <- NULL
-        private$.invalidate()
-        return(invisible(value))
+        .definitionListReadOnlyError("observedData")
       }
-      private$.observedData
+      .asDefinitionList(private$.observedData, "observedData")
     },
 
-    #' @field plots List with 3 elements: `dataCombined`, `plotConfiguration`,
-    #'   `plotGrids`. Writing marks the project as modified.
+    #' @field dataCombined Read-only named list of `DataCombined` definitions,
+    #'   keyed by `dataCombinedId`. Each entry pairs simulated and/or observed
+    #'   curves. To change it, use [addDataCombined()] / [removeDataCombined()]
+    #'   or edit the entity files under `definitions/data-combined/`.
+    dataCombined = function(value) {
+      if (!missing(value)) {
+        .definitionListReadOnlyError("dataCombined")
+      }
+      .asDefinitionList(private$.dataCombined, "dataCombined")
+    },
+
+    #' @field plots Read-only named list of plot definitions, keyed by `plotId`.
+    #'   Each entry is a single plot's configuration (`dataCombinedId`,
+    #'   `plotType`, and styling fields). To change it, use [addPlot()] /
+    #'   [removePlot()] or edit the entity files under `definitions/plots/`.
     plots = function(value) {
       if (!missing(value)) {
-        private$.plots <- value
-        private$.invalidate()
-        return(invisible(value))
+        .definitionListReadOnlyError("plots")
       }
-      private$.plots
+      .asDefinitionList(private$.plots, "plots")
     },
 
-    #' @field parameterIdentification Named list keyed by PI task id; each
-    #'   entry is a `PITask` record. May be `NULL` or an empty list when
-    #'   the project declares no PI tasks. Writing marks the project as
-    #'   modified.
+    #' @field plotGrids Read-only named list of plot-grid definitions, keyed by
+    #'   `plotGridId`. Each entry lays out one or more plots. To change it, use
+    #'   [addPlotGrid()] / [removePlotGrid()] or edit the entity files under
+    #'   `definitions/plot-grids/`.
+    plotGrids = function(value) {
+      if (!missing(value)) {
+        .definitionListReadOnlyError("plotGrids")
+      }
+      .asDefinitionList(private$.plotGrids, "plotGrids")
+    },
+
+    #' @field parameterIdentification Read-only named list keyed by PI task id;
+    #'   each entry is a `PITask` record. May be `NULL` or an empty list when the
+    #'   project declares no PI tasks. To change it, use [addPITask()] /
+    #'   [removePITask()] (and the per-task [addPIParameter()] /
+    #'   [addPIOutputMapping()] and their removals) or edit the entity files
+    #'   under `definitions/parameter-identification/`.
     parameterIdentification = function(value) {
       if (!missing(value)) {
-        private$.parameterIdentification <- value
-        private$.invalidate()
-        return(invisible(value))
+        .definitionListReadOnlyError("parameterIdentification")
       }
-      private$.parameterIdentification
+      .asDefinitionList(
+        private$.parameterIdentification,
+        "parameterIdentification"
+      )
     },
 
-    #' @field filePaths Read-only named list of declared file/folder paths
-    #'   (the `filePaths` JSON section). Values are returned verbatim as
-    #'   strings; no resolution is performed at this stage.
+    #' @field filePaths Read-only named list of the project's working-folder
+    #'   paths (the `filePaths` JSON block): `modelFolder`, `dataFolder`,
+    #'   `outputFolder`, and `populationsFolder`. Values are returned verbatim
+    #'   as strings; no resolution is performed at this stage. The Excel-bridge
+    #'   sheet-name fields live in the separate `excel` block (`project$excel`),
+    #'   not here.
     filePaths = function(value) {
       if (!missing(value)) {
         cli::cli_abort("{.field filePaths} is readonly")
@@ -416,7 +569,6 @@ Project <- R6::R6Class(
     #' @param projectFilePath A string representing the path to the project
     #'   JSON file.
     initialize = function(projectFilePath = character()) {
-      private$.modified <- FALSE
       private$.validatedSinceMutation <- FALSE
       if (is.character(projectFilePath) && length(projectFilePath) == 0L) {
         private$.projectDirPath <- NULL
@@ -434,29 +586,21 @@ Project <- R6::R6Class(
       invisible(self)
     },
 
-    #' @description Internal method to clear the `modified` flag after saving.
-    #'   Saving is not a mutation, so it leaves `validatedSinceMutation`
-    #'   untouched: a project validated before a save stays validated, and
-    #'   a later `runScenarios()` / `createPlots()` need not re-validate.
-    #'   Not intended for end-user use.
-    #' @keywords internal
-    .markSaved = function() {
-      private$.modified <- FALSE
-      invisible(self)
-    },
-
     #' @description Internal method to rebind the project to a new file
-    #'   location after a save-as. Updates `projectFilePath` / `jsonPath`
-    #'   and `projectDirPath` (the base for relative-path resolution) so a
-    #'   subsequent bare `saveProject()` and any relative-path access target
-    #'   the new file. Not a mutation, so it leaves the flags untouched.
-    #'   Not intended for end-user use.
-    #' @param path Absolute or relative path the project was saved to.
+    #'   location. Updates `projectFilePath` / `jsonPath` and `projectDirPath`
+    #'   (the base for relative-path resolution) so any relative-path access
+    #'   targets the new file, and re-claims the entity tree so a clone bound to
+    #'   its own location becomes write-through there. Not a mutation, so it
+    #'   leaves the flags untouched. Not intended for end-user use.
+    #' @param path Absolute or relative path the project was bound to.
     #' @keywords internal
     .rebindPath = function(path) {
       path <- fs::path_abs(path)
       private$.projectFilePath <- path
       private$.projectDirPath <- dirname(path)
+      # Re-binding makes this instance the owner of the (new) entity tree, so a
+      # clone bound to its own location becomes write-through there.
+      private$.claimEntityTree()
       invisible(self)
     },
 
@@ -470,27 +614,94 @@ Project <- R6::R6Class(
     },
 
     #' @description Internal method invoked by mutators after a successful
-    #'   programmatic change. Sets the `modified` flag and clears the
-    #'   `validatedSinceMutation` flag. Not intended for end-user use.
+    #'   programmatic change. Clears the `validatedSinceMutation` flag so the
+    #'   next `runScenarios()` / `createPlots()` re-validates the project. Not
+    #'   intended for end-user use.
     #' @keywords internal
     .markModified = function() {
       private$.invalidate()
       invisible(self)
     },
 
-    #' @description Internal method to retrieve the raw filePaths metadata
-    #'   (a named list of `list(value, description)` entries). Not intended for
-    #'   end-user use; consumed by the Excel import/export bridge.
+    #' @description Internal read accessor for one definition section. Returns
+    #'   the plain backing list (NOT wrapped in the read-only `DefinitionList`
+    #'   the public `project$<section>` getter returns), so an authoring
+    #'   function may bind it to a local copy and subscript-assign that copy
+    #'   before re-submitting it via `.setSection()`. Not intended for end-user
+    #'   use; the public accessor is the read-only end-user surface.
+    #' @param kind Character scalar naming the section (e.g. `"scenarios"`).
+    #' @keywords internal
+    .getSection = function(kind) {
+      private[[private$.sectionField(kind)]]
+    },
+
+    #' @description Internal write entry point for one definition section. This
+    #'   is the only sanctioned way to change a section: it runs the same
+    #'   structural validation and write-through persistence the public
+    #'   active-binding setter used to, then stores the new list in the private
+    #'   backing field and invalidates the validation cache. The public
+    #'   `project$<section> <- ...` setter no longer writes (it aborts
+    #'   read-only); every `add*`/`set*`/`remove*` authoring function routes its
+    #'   write here. Accepts a plain list; a `DefinitionList` is unwrapped
+    #'   defensively. Not intended for end-user use.
+    #' @param kind Character scalar naming the section (e.g. `"scenarios"`).
+    #' @param value The new section list.
+    #' @keywords internal
+    .setSection = function(kind, value) {
+      field <- private$.sectionField(kind)
+      value <- .unwrapDefinitionList(value)
+      old <- private[[field]]
+      # Persist before updating the backing store, so a structural failure
+      # during serialization aborts the write and leaves disk and memory
+      # unchanged (the same ordering the active-binding setter relied on).
+      private$.persistSectionChanges(kind, old, value)
+      private[[field]] <- value
+      # Writing observed data invalidates the cached observed-data names, as
+      # the active-binding setter did.
+      if (identical(kind, "observedData")) {
+        private$.observedDataNamesCache <- NULL
+      }
+      private$.invalidate()
+      invisible(value)
+    },
+
+    #' @description Internal method to retrieve the raw working-folder metadata
+    #'   (the `filePaths` block: a named list of `list(value, description)`
+    #'   entries for the four live folders). Not intended for end-user use;
+    #'   consumed by the Excel import/export bridge.
     #' @keywords internal
     .getFilePathsData = function() {
       private$.filePathsData
     },
 
-    #' @description Check synchronization status of a Project.
+    #' @description Internal method to retrieve the raw Excel-bridge metadata
+    #'   (the `excel` block: a named list of `list(value, description)` entries
+    #'   for the seven sheet-name fields). Empty when the project has no Excel
+    #'   side-car. Not intended for end-user use; consumed by the Excel
+    #'   import/export bridge.
+    #' @keywords internal
+    .getExcelData = function() {
+      private$.excelData
+    },
+
+    #' @description Report whether the project's Excel side-car is in sync
+    #'   with its entity files. Every section is write-through to its
+    #'   `definitions/<kind>/` tree and the `Project.json` container is a
+    #'   derived snapshot, so the only drift that can still occur is between
+    #'   the project and a sibling `Project.xlsx` produced by
+    #'   [exportProjectToExcel()]. This method compares the two; it is
+    #'   read-only and never reconciles them (use [exportProjectToExcel()] or
+    #'   [importProjectFromExcel()] to do that).
     #' @param silent Logical. If `TRUE`, suppresses informational messages.
     #'   Defaults to `FALSE`.
-    sync = function(silent = FALSE) {
-      .projectSync(self, silent = silent)
+    #' @return Invisibly, a list with two components: `excel_in_sync` (a
+    #'   logical, or `NA` when there is no Excel side-car to compare against)
+    #'   and `details` (a list of the per-section differences, empty when in
+    #'   sync or when there is nothing to compare). This is the same shape the
+    #'   path-based [projectStatus()] returns; the two share one comparison
+    #'   builder.
+    syncStatus = function(silent = FALSE) {
+      .projectSyncStatus(self, silent = silent)
     },
 
     #' @description Print a summary of the Project.
@@ -502,6 +713,12 @@ Project <- R6::R6Class(
         ")\n",
         sep = ""
       )
+      if (!is.null(self$name)) {
+        cat("  name:            ", self$name, "\n", sep = "")
+      }
+      if (!is.null(self$description)) {
+        cat("  description:     ", self$description, "\n", sep = "")
+      }
       if (!is.null(self$jsonPath)) {
         cat("  jsonPath:        ", self$jsonPath, "\n", sep = "")
       }
@@ -540,20 +757,14 @@ Project <- R6::R6Class(
       cat("  individuals:     ", length(self$individuals), "\n", sep = "")
       cat("  populations:     ", length(self$populations), "\n", sep = "")
       cat(
-        "  modelParameterSets:       ",
-        length(self$modelParameterSets),
+        "  parameterSets:   ",
+        length(self$parameterSets),
         " set(s)\n",
         sep = ""
       )
       cat(
-        "  individualParameterSets:  ",
-        length(self$individualParameterSets),
-        " set(s)\n",
-        sep = ""
-      )
-      cat(
-        "  applicationParameterSets: ",
-        length(self$applicationParameterSets),
+        "  initialConditions: ",
+        length(self$initialConditions),
         " set(s)\n",
         sep = ""
       )
@@ -565,58 +776,283 @@ Project <- R6::R6Class(
         " source(s)\n",
         sep = ""
       )
-      if (is.null(self$plots)) {
-        cat("  plots:           (none)\n")
-      } else {
-        # plotConfiguration / plotGrids are data frames (one row per plot /
-        # grid), dataCombined is a named list; count rows or length
-        # accordingly so the summary reports plot counts, not column counts.
-        countSection <- function(x) {
-          if (is.data.frame(x)) nrow(x) else length(x %||% list())
-        }
-        cat(
-          "  plots:           ",
-          countSection(self$plots$dataCombined),
-          " dataCombined / ",
-          countSection(self$plots$plotConfiguration),
-          " plot(s) / ",
-          countSection(self$plots$plotGrids),
-          " grid(s)\n",
-          sep = ""
-        )
-      }
+      cat("  dataCombined:    ", length(self$dataCombined), "\n", sep = "")
+      cat("  plots:           ", length(self$plots), "\n", sep = "")
+      cat("  plotGrids:       ", length(self$plotGrids), "\n", sep = "")
+      cat(
+        "  parameterIdentification: ",
+        length(self$parameterIdentification),
+        " task(s)\n",
+        sep = ""
+      )
       invisible(self)
     }
   ),
   private = list(
     .projectFilePath = NULL,
     .projectDirPath = NULL,
-    .modified = FALSE,
     .validatedSinceMutation = FALSE,
+    # Disk-ownership token for the project's entity tree. A bound project
+    # (one loaded with `loadProject()` or saved with `saveSnapshot()`/a re-bind)
+    # records itself as the token's owner. R6's `clone()` copies private fields
+    # by value but shares this token environment by reference, so a clone is not
+    # the recorded owner; `.ownsEntityTree()` returns `FALSE` for it and its
+    # write-through becomes an in-memory no-op until a re-bind to a new location.
+    # This keeps a clone's on-disk state independent of the source it was cloned
+    # from.
+    .entityTreeOwnerToken = NULL,
+    # Working-folder paths (the `filePaths` block): the four live folders the
+    # runtime reads (`modelFolder`, `dataFolder`, `outputFolder`,
+    # `populationsFolder`).
     .filePathsData = list(),
+    # Excel import/export bridge sheet names (the `excel` block): the seven
+    # vestigial fields only the Excel bridge reads. Empty for a from-scratch
+    # JSON project with no Excel side-car, in which case no `excel` block is
+    # written to `Project.json`.
+    .excelData = list(),
     .programmaticDataSets = list(),
     .observedDataNamesCache = NULL,
 
-    # Backing stores for the section-data active bindings. The parser
-    # writes these directly so loading does not flip `modified`.
+    # Backing stores for the container metadata + the section-data active
+    # bindings. The parser writes these directly so loading does not invalidate
+    # the validation cache.
     .schemaVersion = NULL,
     .esqlabsRVersion = NULL,
+    .name = NULL,
+    .description = NULL,
+    .definitionsFolder = NULL,
+    .defaultSimulationRunOptions = NULL,
     .outputPaths = NULL,
     .scenarios = NULL,
-    .modelParameterSets = NULL,
-    .individualParameterSets = NULL,
-    .applicationParameterSets = NULL,
+    .parameterSets = NULL,
+    .initialConditions = NULL,
     .individuals = NULL,
     .populations = NULL,
     .applications = NULL,
     .observedData = NULL,
+    .dataCombined = NULL,
     .plots = NULL,
-    .parameterIdentification = list(),
+    .plotGrids = NULL,
+    .parameterIdentification = NULL,
 
+    # Resolve a section kind to its private backing-field name (`.<kind>`),
+    # aborting on an unknown kind. Each section maps one-to-one onto a private
+    # backing field named `.<kind>` and onto its `definitions/<kind>/` tree. The
+    # set of valid kinds is the single source of truth `.entityKindNames()`
+    # (derived from the entity-tree specs), so a typo cannot silently create a
+    # stray `private$.<typo>` field and the kind list is not duplicated here.
+    .sectionField = function(kind) {
+      if (
+        !is.character(kind) ||
+          length(kind) != 1L ||
+          !(kind %in% .entityKindNames())
+      ) {
+        cli::cli_abort("Unknown project section {.val {kind}}.")
+      }
+      paste0(".", kind)
+    },
+
+    # Invalidate the validation cache. Any mutation clears
+    # `validatedSinceMutation` so the next `runScenarios()` / `createPlots()`
+    # re-validates the new shape.
     .invalidate = function() {
-      private$.modified <- TRUE
       private$.validatedSinceMutation <- FALSE
       invisible(self)
+    },
+
+    # Container-metadata edit: invalidate the validation cache, then write the
+    # container through to `Project.json` so the metadata (schema/version, file
+    # paths, folders) is persisted immediately, just as every section is.
+    .invalidateContainer = function() {
+      private$.invalidate()
+      private$.persistContainer()
+      invisible(self)
+    },
+
+    # Write the `Project.json` container (every inline section emptied, the
+    # tree owns them) to the project's own location, when this instance owns
+    # its entity tree. A NULL directory (in-memory project) or a non-owning
+    # clone is a silent no-op (its container edits stay in memory until it is
+    # bound to its own location).
+    .persistContainer = function() {
+      if (is.null(private$.projectFilePath) || !private$.ownsEntityTree()) {
+        return(invisible(NULL))
+      }
+      .saveProjectJson(
+        self,
+        private$.projectFilePath,
+        containerOnly = TRUE
+      )
+      invisible(NULL)
+    },
+
+    # Record this instance as the owner of its entity tree. Called whenever
+    # the project binds to a directory (`.read_json`, `.rebindPath`).
+    .claimEntityTree = function() {
+      private$.entityTreeOwnerToken <- new.env(parent = emptyenv())
+      private$.entityTreeOwnerToken$owner <- self
+      invisible(self)
+    },
+
+    # TRUE only when this instance recorded itself as the entity-tree owner.
+    # A clone shares the token by reference (its `owner` is the source), so it
+    # is not the owner until a re-bind to its own location.
+    .ownsEntityTree = function() {
+      token <- private$.entityTreeOwnerToken
+      !is.null(token) && identical(token$owner, self)
+    },
+
+    # Write-through for one project section: persist only what changed to its
+    # `definitions/<kind>/` tree. Every section now maps one-to-one onto a kind
+    # (the plots trio was split into three top-level sections
+    # `dataCombined` / `plots` / `plotGrids`, each its own keyed kind).
+    .persistSectionChanges = function(kind, old, new) {
+      private$.persistKindChanges(kind, old, new)
+    },
+
+    # Persist one kind's changes (the unit a single `definitions/<kind>/` tree
+    # owns). Persist only what changed between the old and new section value.
+    #
+    # An in-memory project (no directory) is a silent no-op, and so is a clone
+    # that does not own the tree (its mutations stay in memory until a re-bind
+    # to its own location). The caller invokes this before it updates the
+    # in-memory backing store, so a structural failure during serialization
+    # aborts the write and leaves both disk and memory unchanged.
+    #
+    # First write into a project whose `definitions/<kind>/` directory does not
+    # yet exist (a snapshot-loaded project, whose sections were inlined in
+    # `Project.json` with no tree on disk) takes a full-materialize path: the
+    # diff-only path would write just the changed entity and assume the
+    # untouched siblings already exist as files, but they do not, so on the
+    # next load the now-present tree would win and the inline siblings would be
+    # lost. `new` is the authoritative full set to write; the dir was absent,
+    # so there is nothing stale to remove.
+    .persistKindChanges = function(kind, old, new) {
+      spec <- .entityTreeSpec(kind)
+      dir <- .entityKindDir(
+        private$.projectDirPath,
+        spec$kind,
+        self$definitionsFolder
+      )
+      if (is.null(dir)) {
+        return(invisible(NULL))
+      }
+      if (!private$.ownsEntityTree()) {
+        return(invisible(NULL))
+      }
+
+      # First write into a not-yet-materialized tree writes the full set.
+      if (!dir.exists(dir)) {
+        .writeEntityTree(new, kind, self, private$.projectDirPath)
+        return(invisible(NULL))
+      }
+
+      old <- old %||% list()
+      new <- new %||% list()
+
+      # A keyed kind is a named map whose names are the entity ids (which equal
+      # the on-disk filenames). For such a kind the diff is computed directly on
+      # the in-memory maps (by key presence and per-entity value identity) and
+      # only the entities that actually changed are serialized and written, so a
+      # single mutation costs O(changed entities), not O(section size). The
+      # plots `plotConfiguration` / `plotGrids` parts are keyed lists, so they
+      # take this fast path too. An `observedData` section is an unnamed list
+      # keyed by a derived id (its `names()` are not the on-disk ids), so it
+      # cannot be diffed by name and falls back to the whole-section serialize
+      # diff below (it is small and never a buildup hot path).
+      keyed <- !is.data.frame(new) &&
+        !is.data.frame(old) &&
+        (length(new) == 0L || !is.null(names(new)))
+      if (keyed && (length(old) == 0L || !is.null(names(old)))) {
+        newNames <- names(new)
+        oldNames <- names(old)
+        # Added ids are new keys absent from old; removed ids are old keys
+        # absent from new (both via cheap name set ops, no value comparison).
+        # An id present in both whose value object is not the very same record
+        # (an in-place edit) is changed. `match()` aligns the common keys so
+        # only those need the per-entity `identical()` check, keeping the diff
+        # proportional to the number of common keys without re-checking added
+        # ones.
+        inOld <- newNames %in% oldNames
+        addedIds <- newNames[!inOld]
+        commonIds <- newNames[inOld]
+        # Extract the common-key sublists once (C-level subset) and compare them
+        # as whole objects first: an unchanged element shares its record object
+        # with the old list (an `[[<-` mutation does not copy untouched
+        # siblings), so when nothing in the common set changed this single
+        # `identical()` short-circuits on reference equality with no R-level
+        # per-element loop. Only when some common entity did change (an in-place
+        # edit) do we fall back to a per-element scan to find which one(s).
+        nc <- new[commonIds]
+        oc <- old[commonIds]
+        changedCommon <- character()
+        if (length(commonIds) > 0L && !identical(nc, oc)) {
+          changedCommon <- commonIds[
+            !vapply(
+              seq_along(commonIds),
+              function(i) identical(nc[[i]], oc[[i]]),
+              logical(1),
+              USE.NAMES = FALSE
+            )
+          ]
+        }
+        changedIds <- c(addedIds, changedCommon)
+        # Serialize only the changed entities (validating each), in memory and
+        # before writing any file, so a serializer-hostile record aborts the
+        # whole write and leaves the tree (and the not-yet-updated in-memory
+        # store) unchanged. The serializer also enforces that each key is a
+        # canonical (lowercase, safe) id, so two keys can never collide on a
+        # case-insensitive filesystem.
+        if (length(changedIds) > 0L) {
+          serializedChanged <- spec$serialize(new[changedIds], self)
+          for (id in names(serializedChanged)) {
+            .writeEntityJson(serializedChanged[[id]], .entityFilePath(dir, id))
+          }
+        }
+        # A genuinely-removed entity's on-disk id is its serialized key; for a
+        # keyed kind that equals the map key, so the removed files can be deleted
+        # without serializing.
+        #
+        # Stale removal is reconciled against the previous in-memory section
+        # (`old`), not against the directory listing. So a file created
+        # out-of-band on disk (an orphan with no in-memory entity, e.g. one a
+        # concurrent process or a hand-edit dropped in) is not deleted by an
+        # unrelated mutation here; it survives until the next `loadProject()`,
+        # which re-reads the whole tree and re-derives the section from what is
+        # actually on disk. This is deliberate: the in-memory diff cannot tell an
+        # orphan from a sibling it simply did not load, and reconciling against
+        # the directory on every write would couple each mutation to a directory
+        # scan for no data-safety gain (no entity is lost; the orphan is just
+        # picked up, or ignored, on the next load).
+        for (id in oldNames[!(oldNames %in% newNames)]) {
+          f <- .entityFilePath(dir, id)
+          if (file.exists(f)) {
+            file.remove(f)
+          }
+        }
+        return(invisible(NULL))
+      }
+
+      # Fallback for a kind whose on-disk id is derived rather than the map key
+      # (the unnamed `observedData` list): serialize the full old and new
+      # sections to their `id -> record` maps in memory before writing any file
+      # (same atomicity guarantee), then diff on the derived ids.
+      serializedNew <- spec$serialize(new, self)
+      serializedOld <- spec$serialize(old, self)
+      changed <- Filter(
+        function(id) !identical(serializedNew[[id]], serializedOld[[id]]),
+        names(serializedNew)
+      )
+      for (id in changed) {
+        .writeEntityJson(serializedNew[[id]], .entityFilePath(dir, id))
+      }
+      for (id in setdiff(names(serializedOld), names(serializedNew))) {
+        f <- .entityFilePath(dir, id)
+        if (file.exists(f)) {
+          file.remove(f)
+        }
+      }
+      invisible(NULL)
     },
 
     .replace_env_var = function(path) {
@@ -689,36 +1125,84 @@ Project <- R6::R6Class(
       }
       private$.schemaVersion <- jsonData$schemaVersion
       private$.esqlabsRVersion <- jsonData$esqlabsRVersion
+      private$.name <- jsonData$name
+      private$.description <- jsonData$description
+      private$.definitionsFolder <- jsonData$definitionsFolder
+      private$.defaultSimulationRunOptions <- jsonData$defaultSimulationRunOptions
       private$.projectFilePath <- jsonPath
       private$.projectDirPath <- dirname(jsonPath)
+      private$.claimEntityTree()
 
+      # The container separates two concerns: the four live working folders
+      # (the `filePaths` block) the runtime reads, and the seven Excel-bridge
+      # sheet-name fields (the `excel` block) only the Excel bridge reads. A
+      # legacy project carries all eleven in one flat `filePaths` block; split
+      # it on read so both on-disk shapes load (the field-to-block mapping is
+      # fixed, so the partition is deterministic). A new-shape project reads
+      # each block from its own key; any Excel field that still appears in
+      # `filePaths` (e.g. a hand-edited file) is routed to the Excel store too.
       fp <- jsonData$filePaths %||% list()
+      excel <- jsonData$excel %||% list()
       private$.filePathsData <- list()
+      private$.excelData <- list()
       for (n in names(fp)) {
-        private$.filePathsData[[n]] <- list(value = fp[[n]], description = "")
+        if (n %in% .excelFilePathFields) {
+          private$.excelData[[n]] <- list(value = fp[[n]], description = "")
+        } else {
+          private$.filePathsData[[n]] <- list(value = fp[[n]], description = "")
+        }
+      }
+      for (n in names(excel)) {
+        private$.excelData[[n]] <- list(value = excel[[n]], description = "")
       }
 
-      private$.outputPaths <- jsonData$outputPaths %||% list()
-      private$.modelParameterSets <- jsonData$modelParameterSets %||% list()
-      private$.individualParameterSets <- jsonData$individualParameterSets %||%
-        list()
-      private$.applicationParameterSets <- jsonData$applicationParameterSets %||%
-        list()
-      private$.individuals <- .parseIndividuals(jsonData$individuals)
-      private$.populations <- .parsePopulations(jsonData$populations)
-      private$.applications <- .parseApplications(jsonData$applications)
-      private$.scenarios <- .parseScenarios(
-        jsonData$scenarios,
-        private$.outputPaths
+      # Every authored section is an entity tree under `definitions/<kind>/`; a
+      # single-file snapshot with no tree falls back to the inline section in
+      # `Project.json`. `.loadEntityTree()` resolves tree-vs-inline per kind and
+      # the kind's spec parses the raw records into the in-memory shape. Output
+      # paths load before scenarios because scenarios dereference their
+      # `outputPathIds` against the project-level `outputPaths` map. The
+      # `parameterSets` inline fallback merges any legacy three-section
+      # `Project.json` into the one map (a clash aborts the load).
+      private$.outputPaths <- private$.loadSection("outputPaths", jsonData)
+      private$.parameterSets <- private$.loadSection("parameterSets", jsonData)
+      private$.initialConditions <- private$.loadSection(
+        "initialConditions",
+        jsonData
       )
-      private$.observedData <- jsonData$observedData %||% list()
-      private$.plots <- .parsePlots(jsonData$plots)
-      private$.parameterIdentification <- .parsePITasks(
-        jsonData$parameterIdentification
+      private$.individuals <- private$.loadSection("individuals", jsonData)
+      private$.populations <- private$.loadSection("populations", jsonData)
+      private$.applications <- private$.loadSection("applications", jsonData)
+      private$.scenarios <- private$.loadSection("scenarios", jsonData)
+      private$.observedData <- private$.loadSection("observedData", jsonData)
+      # The plots concern is three independent top-level sections, each its own
+      # keyed kind: `dataCombined` (`definitions/data-combined/`), `plots`
+      # (`definitions/plots/`, the plot list), and `plotGrids`
+      # (`definitions/plot-grids/`). Each loads from its own tree (or its own
+      # top-level inline snapshot section as the fallback).
+      private$.dataCombined <- private$.loadSection("dataCombined", jsonData)
+      private$.plots <- private$.loadSection("plots", jsonData)
+      private$.plotGrids <- private$.loadSection("plotGrids", jsonData)
+      private$.parameterIdentification <- private$.loadSection(
+        "parameterIdentification",
+        jsonData
       )
 
-      private$.modified <- FALSE
       private$.validatedSinceMutation <- FALSE
+    },
+
+    # Load one section: read its `definitions/<kind>/` tree (or the inline
+    # snapshot fallback) and parse the raw records into the in-memory shape via
+    # the kind's spec.
+    .loadSection = function(kind, jsonData) {
+      spec <- .entityTreeSpec(kind)
+      records <- .loadEntityTree(
+        private$.projectDirPath,
+        kind,
+        spec$inline(jsonData),
+        self$definitionsFolder
+      )
+      spec$parse(records, self)
     }
   )
 )

--- a/R/scenario-execution.R
+++ b/R/scenario-execution.R
@@ -2,11 +2,35 @@
 #
 # Modern (JSON-Project-driven) runtime path.
 
-# Convert a record-shape parameter list (one entry of any of the
-# project-level `*ParameterSets` bags: `modelParameterSets`,
-# `individualParameterSets`, or `applicationParameterSets`) into
-# the parallel-vector `list(paths, values, units)` shape consumed
-# by `extendParameterStructure()`.
+# Build an `ospsuite::SimulationRunOptions` from the project-level
+# `defaultSimulationRunOptions` record (a plain list parsed from the
+# `defaultSimulationRunOptions` JSON block), or return NULL when no defaults
+# are declared (so the caller keeps the package defaults). Only the three
+# settable fields are honored; an unset field keeps the `SimulationRunOptions`
+# default. Mirrors the PI-config builder in `R/parameter-identification.R`.
+# @keywords internal
+# @noRd
+.buildSimulationRunOptions <- function(defaults) {
+  if (is.null(defaults) || length(defaults) == 0L) {
+    return(NULL)
+  }
+  runOpts <- ospsuite::SimulationRunOptions$new()
+  if (!is.null(defaults$numberOfCores)) {
+    runOpts$numberOfCores <- as.integer(defaults$numberOfCores)
+  }
+  if (!is.null(defaults$checkForNegativeValues)) {
+    runOpts$checkForNegativeValues <- isTRUE(defaults$checkForNegativeValues)
+  }
+  if (!is.null(defaults$showProgress)) {
+    runOpts$showProgress <- isTRUE(defaults$showProgress)
+  }
+  runOpts
+}
+
+# Convert a record-shape parameter list (one set from the project's unified
+# `parameterSets` section) into the parallel-vector
+# `list(paths, values, units)` shape consumed by
+# `extendParameterStructure()`.
 # @keywords internal
 # @noRd
 .parameterSetToStructure <- function(entries) {
@@ -25,17 +49,58 @@
   list(paths = paths, values = values, units = units)
 }
 
+# Convert one initial-condition set (a list of `{path, value, unit}` records)
+# into the parallel-vector `list(paths, values, units)` shape consumed by
+# `initializeSimulation()`'s `additionalInitialConditions`. The IC path is the
+# full molecule path (no container/name split), so it maps straight to `paths`.
+# @keywords internal
+# @noRd
+.initialConditionSetToStructure <- function(entries) {
+  if (is.null(entries) || length(entries) == 0L) {
+    return(NULL)
+  }
+  paths <- vapply(entries, function(e) e$path, character(1))
+  values <- vapply(entries, function(e) as.numeric(e$value), numeric(1))
+  units <- vapply(entries, function(e) e$unit %||% "", character(1))
+  list(paths = paths, values = values, units = units)
+}
+
+# Build a `list(paths, values, units)` initial-condition structure (or `NULL`)
+# for one scenario, from its `initialConditions` set references. Each id is
+# looked up in the project's `initialConditions` section and its entries folded
+# in (last-write-wins on a repeated path, via `extendParameterStructure`).
+# Unknown set ids are silently skipped, matching `.mergeScenarioParameters`.
+# @keywords internal
+# @noRd
+.mergeScenarioInitialConditions <- function(scenario, project) {
+  if (is.null(scenario$initialConditions)) {
+    return(NULL)
+  }
+  conditions <- NULL
+  for (setId in scenario$initialConditions) {
+    setConditions <- .initialConditionSetToStructure(
+      project$initialConditions[[setId]]
+    )
+    if (!is.null(setConditions)) {
+      conditions <- extendParameterStructure(
+        parameters = conditions,
+        newParameters = setConditions
+      )
+    }
+  }
+  conditions
+}
+
 # Five-layer merge ----
 
 # Pure function. Builds a `list(paths, values, units)` parameter
 # structure (or `NULL`) for one scenario. Layers, in order
 # (last-write-wins): scenario `modelParameterSets` -> species defaults
 # -> individual `parameterSets` -> application `parameterSets` ->
-# caller-supplied `customParams`. Each `*ParameterSets` field is a
-# list of set ids, iterated in listed order; ids are looked up in
-# the matching project-level bag (`modelParameterSets`,
-# `individualParameterSets`, `applicationParameterSets`). Unknown
-# ids are silently skipped (consistent across all three layers).
+# caller-supplied `customParams`. Each of those reference fields is a
+# list of set ids, iterated in listed order; every id is looked up in
+# the project's single `parameterSets` section. Unknown ids are silently
+# skipped (consistent across all three layers).
 # @keywords internal
 # @noRd
 .mergeScenarioParameters <- function(scenario, project, customParams = NULL) {
@@ -45,7 +110,7 @@
   if (!is.null(scenario$modelParameterSets)) {
     for (setId in scenario$modelParameterSets) {
       setParams <- .parameterSetToStructure(
-        project$modelParameterSets[[setId]]
+        project$parameterSets[[setId]]
       )
       if (!is.null(setParams)) {
         params <- extendParameterStructure(
@@ -69,7 +134,7 @@
       }
       for (setId in unlist(indivData$parameterSets)) {
         setParams <- .parameterSetToStructure(
-          project$individualParameterSets[[setId]]
+          project$parameterSets[[setId]]
         )
         if (!is.null(setParams)) {
           params <- extendParameterStructure(
@@ -95,7 +160,7 @@
     }
     for (setId in unlist(appData$parameterSets)) {
       setParams <- .parameterSetToStructure(
-        project$applicationParameterSets[[setId]]
+        project$parameterSets[[setId]]
       )
       if (!is.null(setParams)) {
         params <- extendParameterStructure(
@@ -179,6 +244,9 @@
   # 2. Build merged parameter structure
   params <- .mergeScenarioParameters(scenario, project, customParams)
 
+  # 2a. Build merged initial-condition (molecule start value) structure
+  initialConditions <- .mergeScenarioInitialConditions(scenario, project)
+
   # 2b. IndividualCharacteristics
   individualCharacteristics <- NULL
   if (!is.null(scenario$individualId) && !is.na(scenario$individualId)) {
@@ -254,6 +322,7 @@
     simulation = simulation,
     individualCharacteristics = individualCharacteristics,
     additionalParams = params,
+    additionalInitialConditions = initialConditions,
     stopIfParameterNotFound = stopIfParameterNotFound
   )
 
@@ -415,6 +484,15 @@
     argumentName = "customParams",
     nullAllowed = TRUE
   )
+  # When the caller does not pass run options, fall back to the project-level
+  # `defaultSimulationRunOptions` (a reproducible run from the shared artifact).
+  # An explicit caller argument always wins; an absent project default leaves
+  # `simulationRunOptions` NULL, i.e. exactly the package defaults as before.
+  if (is.null(simulationRunOptions)) {
+    simulationRunOptions <- .buildSimulationRunOptions(
+      project$defaultSimulationRunOptions
+    )
+  }
   if (isTRUE(validate)) {
     .ensureValid(
       project,
@@ -422,11 +500,9 @@
         "outputPaths",
         "scenarios",
         "individuals",
-        "individualParameterSets",
         "populations",
         "applications",
-        "applicationParameterSets",
-        "modelParameterSets",
+        "parameterSets",
         "crossReferences"
       ),
       opName = "runScenarios"

--- a/R/scenario-from-pkml.R
+++ b/R/scenario-from-pkml.R
@@ -17,29 +17,29 @@
 #'   a vector with the same length as the number of scenarios being created
 #'   (determined by the longest vector argument).
 #' @param project A `Project` object holding base information.
-#' @param scenarioNames Character vector. Optional custom names for the
+#' @param scenarios Character vector. Optional custom names for the
 #'   scenarios. If `NULL` (default), scenario names will be extracted from
 #'   the simulation names in the PKML files. If provided, must have the same
 #'   length as `pkmlFilePaths`.
-#' @param individualId Character vector. Optional individual IDs to use for
+#' @param individual Character vector. Optional individual ids to use for
 #'   scenarios. If `NULL` (default), no individual will be specified. Can be
 #'   a single string (recycled for all scenarios) or a vector with the same
 #'   length as `pkmlFilePaths`.
-#' @param populationId Character vector. Optional population IDs to use for
+#' @param population Character vector. Optional population ids to use for
 #'   scenarios. If `NULL` (default), no population will be specified. If
 #'   provided, sets simulation type to "Population". Can be a single string
 #'   (recycled for all scenarios) or a vector with the same length as
 #'   `pkmlFilePaths`.
-#' @param applicationProtocols Character vector. Optional application protocol
-#'   names to use for scenarios, each referencing `project$applications`. If
+#' @param application Character vector. Optional application protocol
+#'   ids to use for scenarios, each referencing `project$applications`. If
 #'   `NULL` (default), the scenario has no application protocol (the PKML file
 #'   already embeds its own application). Values are used verbatim and are
 #'   validated against `project$applications`. Can be a single string
 #'   (recycled for all scenarios) or a vector with the same length as
 #'   `pkmlFilePaths`.
-#' @param modelParameterSets Character vector. Optional model parameter set
-#'   ids to apply to scenarios (referencing `project$modelParameterSets`).
-#'   If `NULL` (default), no model parameter sets will be applied. Can be a
+#' @param parameterSets Character vector. Optional parameter set
+#'   ids to apply to scenarios (referencing `project$parameterSets`).
+#'   If `NULL` (default), no parameter sets will be applied. Can be a
 #'   single string (recycled for all scenarios) or a vector with the same
 #'   length as `pkmlFilePaths`. If providing multiple set ids per scenario,
 #'   separate them with commas in the string.
@@ -90,7 +90,7 @@
 #'   value (recycled for all scenarios) or a vector with the same length as
 #'   `pkmlFilePaths`.
 #' @param paramSheets `r lifecycle::badge("deprecated")` Use
-#'   `modelParameterSets` instead.
+#'   `parameterSets` instead.
 #'
 #' @details
 #' This function extracts the following information from PKML files:
@@ -143,15 +143,15 @@
 #'   project = project
 #' )
 #'
-#' # The project now holds the new scenarios; run and save them
+#' # The project now holds the new scenarios (already written through to
+#' # their entity files); run them
 #' results <- runScenarios(project)
-#' saveProject(project)
 #'
 #' # Example of vector recycling: single value applied to all scenarios
 #' createScenariosFromPKML(
 #'   pkmlFilePaths = c("sim1.pkml", "sim2.pkml", "sim3.pkml"),
 #'   project = project,
-#'   individualId = "Individual_001",
+#'   individual = "Individual_001",
 #'   steadyState = TRUE,
 #'   steadyStateTime = 1000
 #' )
@@ -160,8 +160,8 @@
 #' createScenariosFromPKML(
 #'   pkmlFilePaths = c("pediatric.pkml", "adult.pkml", "elderly.pkml"),
 #'   project = project,
-#'   scenarioNames = c("Pediatric", "Adult", "Elderly"),
-#'   individualId = c("Child_001", "Adult_001", "Elderly_001"),
+#'   scenarios = c("Pediatric", "Adult", "Elderly"),
+#'   individual = c("Child_001", "Adult_001", "Elderly_001"),
 #'   steadyState = c(FALSE, TRUE, TRUE),
 #'   steadyStateTime = c(NA, 2000, 1500)
 #' )
@@ -169,11 +169,11 @@
 createScenariosFromPKML <- function(
   pkmlFilePaths,
   project,
-  scenarioNames = NULL,
-  individualId = NULL,
-  populationId = NULL,
-  applicationProtocols = NULL,
-  modelParameterSets = NULL,
+  scenarios = NULL,
+  individual = NULL,
+  population = NULL,
+  application = NULL,
+  parameterSets = NULL,
   outputPaths = NULL,
   simulationTime = NULL,
   simulationTimeUnit = NULL,
@@ -188,29 +188,29 @@ createScenariosFromPKML <- function(
   if (lifecycle::is_present(paramSheets)) {
     lifecycle::deprecate_soft(
       what = "createScenariosFromPKML(paramSheets)",
-      with = "createScenariosFromPKML(modelParameterSets)",
+      with = "createScenariosFromPKML(parameterSets)",
       when = "6.0.0"
     )
-    modelParameterSets <- modelParameterSets %||% paramSheets
+    parameterSets <- parameterSets %||% paramSheets
   }
 
   # Validate inputs
   validateIsCharacter(pkmlFilePaths)
   validateIsOfType(project, "Project")
-  if (!is.null(scenarioNames)) {
-    validateIsCharacter(scenarioNames)
+  if (!is.null(scenarios)) {
+    validateIsCharacter(scenarios)
   }
-  if (!is.null(individualId)) {
-    validateIsCharacter(individualId)
+  if (!is.null(individual)) {
+    validateIsCharacter(individual)
   }
-  if (!is.null(populationId)) {
-    validateIsCharacter(populationId)
+  if (!is.null(population)) {
+    validateIsCharacter(population)
   }
-  if (!is.null(applicationProtocols)) {
-    validateIsCharacter(applicationProtocols)
+  if (!is.null(application)) {
+    validateIsCharacter(application)
   }
-  if (!is.null(modelParameterSets)) {
-    validateIsCharacter(modelParameterSets)
+  if (!is.null(parameterSets)) {
+    validateIsCharacter(parameterSets)
   }
   if (!is.null(outputPaths)) {
     validateIsCharacter(outputPaths)
@@ -235,11 +235,11 @@ createScenariosFromPKML <- function(
   # Note: project is excluded as it should always be a single object.
   nScenarios <- .getScenarioCount(
     pkmlFilePaths,
-    scenarioNames,
-    individualId,
-    populationId,
-    applicationProtocols,
-    modelParameterSets,
+    scenarios,
+    individual,
+    population,
+    application,
+    parameterSets,
     outputPaths,
     simulationTime,
     simulationTimeUnit,
@@ -256,29 +256,29 @@ createScenariosFromPKML <- function(
     "pkmlFilePaths",
     nScenarios
   )
-  scenarioNames <- .recycleOrValidateVector(
-    scenarioNames,
-    "scenarioNames",
+  scenarios <- .recycleOrValidateVector(
+    scenarios,
+    "scenarios",
     nScenarios
   )
-  individualId <- .recycleOrValidateVector(
-    individualId,
-    "individualId",
+  individual <- .recycleOrValidateVector(
+    individual,
+    "individual",
     nScenarios
   )
-  populationId <- .recycleOrValidateVector(
-    populationId,
-    "populationId",
+  population <- .recycleOrValidateVector(
+    population,
+    "population",
     nScenarios
   )
-  applicationProtocols <- .recycleOrValidateVector(
-    applicationProtocols,
-    "applicationProtocols",
+  application <- .recycleOrValidateVector(
+    application,
+    "application",
     nScenarios
   )
-  modelParameterSets <- .recycleOrValidateVector(
-    modelParameterSets,
-    "modelParameterSets",
+  parameterSets <- .recycleOrValidateVector(
+    parameterSets,
+    "parameterSets",
     nScenarios
   )
 
@@ -376,12 +376,24 @@ createScenariosFromPKML <- function(
         loadFromCache = FALSE
       )
     }
-    requestedNames[[i]] <- if (is.null(scenarioNames)) {
+    requestedNames[[i]] <- if (is.null(scenarios)) {
       simulationCache[[pkmlPath]]$name
     } else {
-      scenarioNames[[i]]
+      scenarios[[i]]
     }
   }
+  # Canonicalize each requested id before deduping so collision suffixing
+  # operates in canonical (lowercase, safe) space and the canonical ids the
+  # specs are built with are exactly what `addScenario()` will store, so its
+  # duplicate-name abort can never fire on a case-only or sanitization clash.
+  # Per-element (no within-call collision error): a recycled PKML legitimately
+  # yields identical names that `.dedupeScenarioNames()` then suffixes.
+  requestedNames <- vapply(
+    requestedNames,
+    function(n) suppressWarnings(.canonicalizeOneId(n)),
+    character(1),
+    USE.NAMES = FALSE
+  )
   finalNames <- .dedupeScenarioNames(
     requestedNames,
     names(project$scenarios)
@@ -413,17 +425,17 @@ createScenariosFromPKML <- function(
     # so the default is absent). `NA` means absent and is mapped to NULL for
     # `addScenario()`, whose FK check rejects NA.
     applicationProtocol <- NULL
-    if (!is.null(applicationProtocols)) {
-      candidate <- applicationProtocols[[i]]
+    if (!is.null(application)) {
+      candidate <- application[[i]]
       if (!is.na(candidate)) {
         applicationProtocol <- candidate
       }
     }
 
-    # Model parameter sets: split a single comma-separated string into ids.
+    # Parameter sets: split a single comma-separated string into ids.
     modelParameterSetIds <- NULL
-    if (!is.null(modelParameterSets)) {
-      paramSetIds <- modelParameterSets[[i]]
+    if (!is.null(parameterSets)) {
+      paramSetIds <- parameterSets[[i]]
       if (!is.na(paramSetIds) && nchar(paramSetIds) > 0) {
         modelParameterSetIds <- .splitCommaSeparated(paramSetIds)
       }
@@ -499,11 +511,11 @@ createScenariosFromPKML <- function(
     specs[[i]] <- list(
       scenarioName = scenarioName,
       modelFile = modelFile,
-      individualId = if (!is.null(individualId)) individualId[[i]],
-      populationId = if (!is.null(populationId)) populationId[[i]],
-      applicationProtocol = applicationProtocol,
-      modelParameterSets = modelParameterSetIds,
-      outputPathIds = outputPathIds,
+      individual = if (!is.null(individual)) individual[[i]],
+      population = if (!is.null(population)) population[[i]],
+      application = applicationProtocol,
+      parameterSets = modelParameterSetIds,
+      outputPaths = outputPathIds,
       simulationTime = simulationTimeStr,
       simulationTimeUnit = scenarioSimTimeUnit,
       steadyState = steadyState[[i]],
@@ -515,12 +527,11 @@ createScenariosFromPKML <- function(
   }
 
   # Phase B: apply the specs to the project transactionally. A failing
-  # `addScenario()` (e.g. an unknown individualId) on scenario `i` must not
+  # `addScenario()` (e.g. an unknown individual) on scenario `i` must not
   # leave scenarios 1..i-1 and freshly registered output paths behind, so
   # snapshot the section fields and restore them on error.
-  oldScenarios <- project$scenarios
-  oldOutputPaths <- project$outputPaths
-  wasModified <- project$modified
+  oldScenarios <- project$.getSection("scenarios")
+  oldOutputPaths <- project$.getSection("outputPaths")
   wasValidated <- project$validatedSinceMutation
 
   tryCatch(
@@ -535,13 +546,13 @@ createScenariosFromPKML <- function(
       for (spec in specs) {
         addScenario(
           project,
-          scenarioName = spec$scenarioName,
+          id = spec$scenarioName,
           modelFile = spec$modelFile,
-          individualId = spec$individualId,
-          populationId = spec$populationId,
-          applicationProtocol = spec$applicationProtocol,
-          modelParameterSets = spec$modelParameterSets,
-          outputPathIds = spec$outputPathIds,
+          individual = spec$individual,
+          population = spec$population,
+          application = spec$application,
+          parameterSets = spec$parameterSets,
+          outputPaths = spec$outputPaths,
           simulationTime = spec$simulationTime,
           simulationTimeUnit = spec$simulationTimeUnit,
           steadyState = spec$steadyState,
@@ -553,11 +564,8 @@ createScenariosFromPKML <- function(
       }
     },
     error = function(cnd) {
-      project$scenarios <- oldScenarios
-      project$outputPaths <- oldOutputPaths
-      if (!wasModified) {
-        project$.markSaved()
-      }
+      project$.setSection("scenarios", oldScenarios)
+      project$.setSection("outputPaths", oldOutputPaths)
       if (wasValidated) {
         project$.markValidated()
       }
@@ -690,6 +698,9 @@ createScenariosFromPKML <- function(
   if (nchar(base) == 0) {
     base <- "outputPath"
   }
+  # Generate the id already canonical (lowercase, safe) so `addOutputPath()`
+  # does not warn about canonicalizing an id the package itself created.
+  base <- .canonicalizeOneId(base)
   candidate <- base
   suffix <- 2L
   while (candidate %in% takenIds) {

--- a/R/scenarios.R
+++ b/R/scenarios.R
@@ -25,7 +25,8 @@
   "steadyStateTime",
   "steadyStateTimeUnit",
   "overwriteFormulasInSS",
-  "modelParameterSets"
+  "modelParameterSets",
+  "initialConditions"
 )
 
 #' Create a Scenario
@@ -36,8 +37,10 @@
 #'   [runScenarios()] at execution time.
 #'
 #'   A `Scenario` is a named list with copy semantics: an entry extracted
-#'   from `project$scenarios` is an independent copy, and writing it back
-#'   (e.g. `project$scenarios[[name]] <- sc`) is what mutates the project.
+#'   from `project$scenarios` is an independent copy. The section accessor is
+#'   read-only, so to apply a change you pass the record to an authoring
+#'   function (`addScenario()` / `setScenario()`), which validates and writes
+#'   it through to the project.
 #'
 #' @param scenarioName Character. Name of the scenario.
 #' @param modelFile Character. Name of the `.pkml` model file (relative to
@@ -51,8 +54,8 @@
 #' @param outputPaths Named character vector of literal output paths.
 #'   Names are the ids referencing `project$outputPaths`; values are the
 #'   literal paths. `NULL` when the scenario declares no outputs.
-#'   Round-trip serialization reads `names(outputPaths)` to rebuild
-#'   `outputPathIds`, so the named-vector invariant must be preserved.
+#'   Round-trip serialization reads `names(outputPaths)` to rebuild the
+#'   `outputPaths` id array, so the named-vector invariant must be preserved.
 #' @param simulationType Character. `"Individual"` or `"Population"`.
 #'   Defaults to `"Population"` when `populationId` is set,
 #'   `"Individual"` otherwise.
@@ -69,8 +72,10 @@
 #'   `steadyStateTime`, preserved for round-trip serialization.
 #' @param overwriteFormulasInSS Logical. Overwrite formula parameters
 #'   during steady-state.
-#' @param modelParameterSets Character vector. Parameter-set names
-#'   referencing `project$modelParameterSets`.
+#' @param modelParameterSets Character vector. Parameter-set ids
+#'   referencing `project$parameterSets`.
+#' @param initialConditions Character vector. Initial-condition set ids
+#'   referencing `project$initialConditions`.
 #'
 #' @returns A `Scenario` object: a named list carrying exactly the fields
 #'   above.
@@ -90,7 +95,8 @@ Scenario <- function(
   steadyStateTime = 1000,
   steadyStateTimeUnit = NULL,
   overwriteFormulasInSS = FALSE,
-  modelParameterSets = NULL
+  modelParameterSets = NULL,
+  initialConditions = NULL
 ) {
   rec <- stats::setNames(
     vector("list", length(.scenarioFieldNames)),
@@ -117,38 +123,29 @@ as.list.Scenario <- function(x, ...) {
 #' @exportS3Method
 #' @noRd
 print.Scenario <- function(x, ...) {
-  cat("<Scenario>", "\n")
-  cat("  Name:           ", x$scenarioName %||% "(none)", "\n")
-  cat("  Model:          ", x$modelFile %||% "(none)", "\n")
-  cat("  Type:           ", x$simulationType, "\n")
-  cat("  Individual:     ", x$individualId %||% "(none)", "\n")
-  if (x$simulationType == "Population") {
-    cat("  Population:     ", x$populationId %||% "(none)", "\n")
-    cat("  CSV Population: ", x$readPopulationFromCSV, "\n")
-  }
-  if (
-    !is.null(x$applicationProtocol) &&
-      !is.na(x$applicationProtocol)
+  protocol <- if (
+    !is.null(x$applicationProtocol) && !is.na(x$applicationProtocol)
   ) {
-    cat("  Protocol:       ", x$applicationProtocol, "\n")
+    x$applicationProtocol
+  } else {
+    ""
   }
-  if (!is.null(x$modelParameterSets)) {
-    cat(
-      "  Param groups:   ",
-      paste(x$modelParameterSets, collapse = ", "),
-      "\n"
-    )
-  }
-  if (!is.null(x$outputPaths)) {
-    cat("  Output paths:   ", length(x$outputPaths), "path(s)\n")
-  }
-  if (x$simulateSteadyState) {
-    cat(
-      "  Steady state:    TRUE (time=",
-      x$steadyStateTime,
-      "min)\n"
-    )
-  }
+  ospsuite.utils::ospPrintClass(x)
+  ospsuite.utils::ospPrintItems(
+    list(
+      "Name" = x$scenarioName %||% "",
+      "Model" = x$modelFile %||% "",
+      "Type" = x$simulationType %||% "",
+      "Individual" = x$individualId %||% "",
+      "Population" = x$populationId %||% "",
+      "Protocol" = protocol,
+      "Parameter Sets" = paste(x$modelParameterSets, collapse = ", "),
+      "Initial Conditions" = paste(x$initialConditions, collapse = ", "),
+      "Output Paths" = length(x$outputPaths %||% list()),
+      "Steady State" = x$simulateSteadyState %||% FALSE
+    ),
+    print_empty = TRUE
+  )
   invisible(x)
 }
 
@@ -160,12 +157,13 @@ print.Scenario <- function(x, ...) {
 # `scenariosData` is the raw `simplifyVector = FALSE` shape produced by
 # `jsonlite::fromJSON()`: a list of plain named lists. `outputPaths` is
 # the project-level lookup table (named list or named character vector
-# of `id -> literal path`); used to resolve `outputPathIds`.
+# of `id -> literal path`); used to resolve the scenario's `outputPaths`
+# id array.
 #
 # This helper handles only what's needed at parse time: field copies,
-# `simulationType` derivation from `populationId` presence,
+# `simulationType` derivation from `population` presence,
 # `simulationTime` string parsing, `steadyStateTime` unit conversion,
-# `outputPathIds` -> literal `outputPaths` resolution.
+# the `outputPaths` id array -> literal `outputPaths` resolution.
 #
 # @keywords internal
 # @noRd
@@ -176,6 +174,24 @@ print.Scenario <- function(x, ...) {
 
   result <- list()
   for (entry in scenariosData) {
+    # The scenario name is the entity id and the filename stem; assert it is a
+    # usable scalar that matches the file before anything else, so a file with
+    # no `name` (or one disagreeing with its filename) aborts naming the file
+    # rather than producing an opaque base-R index error or a dangling key.
+    scenarioName <- .keyedTreeRecordId(entry, "name", "scenario")
+    # Reject a malformed scalar field early, with a message naming the
+    # scenario and field. A hand-edited file (e.g. the standard `jsonlite`
+    # round-trip that turns `"population": null` into `{}`) otherwise
+    # produces a non-scalar value that mis-derives `simulationType` and later
+    # crashes validation with an opaque internal error that names nothing.
+    .assertScalarScenarioField(entry, "individual")
+    .assertScalarScenarioField(entry, "population")
+    .assertScalarScenarioField(entry, "application")
+    .assertScalarScenarioField(entry, "modelFile")
+    # Backstop the per-field checks above with the generic empty-object guard,
+    # so any other scalar field corrupted by the `null -> {}` round-trip (e.g.
+    # `steadyStateTime: {}`) also fails fast instead of slipping through.
+    .assertNoEmptyObjectFields(entry, "scenario")
     # Use `[[` rather than `$` throughout: list `$` does partial matching,
     # so `entry$simulationTime` would wrongly resolve to `simulationTimeUnit`
     # (and `steadyStateTime` to `steadyStateTimeUnit`) when only the unit is
@@ -198,36 +214,47 @@ print.Scenario <- function(x, ...) {
           (e.g. {.val min})."
         )
       }
+      # Coerce to double before the unit conversion: `jsonlite::fromJSON`
+      # reads a whole number (e.g. `1000`) as integer, and a same-unit
+      # conversion preserves that integer type, so without this the parsed
+      # record's `steadyStateTime` would be integer while a freshly built
+      # scenario (default `1000`, a double) is double, breaking a round trip.
       steadyStateTime <- ospsuite::toBaseUnit(
         quantityOrDimension = ospDimensions$Time,
-        values = entry[["steadyStateTime"]],
+        values = as.double(entry[["steadyStateTime"]]),
         unit = entry[["steadyStateTimeUnit"]]
       )
       steadyStateTimeUnit <- entry[["steadyStateTimeUnit"]]
     }
 
     scenarioOutputPaths <- NULL
-    if (!is.null(entry[["outputPathIds"]])) {
-      pathIds <- unlist(entry[["outputPathIds"]])
-      unknown <- setdiff(pathIds, names(outputPaths))
-      if (length(unknown) > 0) {
-        cli::cli_abort(
-          "Scenario {.val {entry[['name']]}} references unknown outputPathIds: \\
-          {.val {unknown}}."
-        )
-      }
-      scenarioOutputPaths <- stats::setNames(
-        unlist(outputPaths[pathIds], use.names = FALSE),
-        pathIds
+    # Collapse a repeated id to a single entry (first-seen order) so the same
+    # output path is never resolved, run, or plotted twice; `unique()` keeps
+    # the first occurrence.
+    pathIds <- unique(unlist(entry[["outputPaths"]]))
+    # An absent key and an empty `outputPaths: []` both collapse to NULL
+    # (no resolved paths), matching the serializer's array-shape symmetry.
+    if (length(pathIds) > 0L) {
+      # Referential integrity is lazy: an output-path id that is not in the
+      # project-level `outputPaths` map is kept as a name with an `NA`
+      # literal path, so it round-trips and the cross-reference validator
+      # (which checks `names(sc$outputPaths)`) flags it at validate/run/plot
+      # time rather than aborting the load.
+      resolved <- vapply(
+        pathIds,
+        function(id) outputPaths[[id]] %||% NA_character_,
+        character(1),
+        USE.NAMES = FALSE
       )
+      scenarioOutputPaths <- stats::setNames(resolved, pathIds)
     }
 
-    result[[entry[["name"]]]] <- Scenario(
-      scenarioName = entry[["name"]],
+    result[[scenarioName]] <- Scenario(
+      scenarioName = scenarioName,
       modelFile = entry[["modelFile"]],
-      applicationProtocol = entry[["applicationProtocol"]] %||% NA,
-      individualId = entry[["individualId"]],
-      populationId = entry[["populationId"]],
+      applicationProtocol = entry[["application"]] %||% NA,
+      individualId = entry[["individual"]],
+      populationId = entry[["population"]],
       outputPaths = scenarioOutputPaths,
       readPopulationFromCSV = entry[["readPopulationFromCSV"]] %||% FALSE,
       simulateSteadyState = isTRUE(entry[["steadyState"]]),
@@ -236,12 +263,42 @@ print.Scenario <- function(x, ...) {
       steadyStateTime = steadyStateTime,
       steadyStateTimeUnit = steadyStateTimeUnit,
       overwriteFormulasInSS = entry[["overwriteFormulasInSS"]] %||% FALSE,
-      modelParameterSets = if (!is.null(entry[["modelParameterSets"]])) {
-        unlist(entry[["modelParameterSets"]])
+      modelParameterSets = if (!is.null(entry[["parameterSets"]])) {
+        unlist(entry[["parameterSets"]])
+      },
+      initialConditions = if (!is.null(entry[["initialConditions"]])) {
+        unlist(entry[["initialConditions"]])
       }
     )
   }
   result
+}
+
+# Assert that a scenario JSON field, when present, is a length-1 string (or
+# `NULL`/absent). Catches a hand-edited file that turned a scalar field into
+# an object/array (e.g. `"population": null` round-tripped to `{}`), which
+# would otherwise mis-derive `simulationType` and crash validation with an
+# opaque internal error. The message names the scenario and the field so the
+# user can find the offending file (`definitions/scenarios/<name>.json`).
+#
+# @keywords internal
+# @noRd
+.assertScalarScenarioField <- function(entry, field) {
+  value <- entry[[field]]
+  if (is.null(value)) {
+    return(invisible(NULL))
+  }
+  if (!is.character(value) || length(value) != 1L) {
+    name <- entry[["name"]] %||% "<unnamed>"
+    cli::cli_abort(c(
+      "Scenario {.val {name}} has an invalid {.field {field}}.",
+      "i" = "Expected a single string or {.code null}; check \\
+      {.file definitions/scenarios/{name}.json}.",
+      "i" = "A hand-edit that turned {.code \"{field}\": null} into an empty \\
+      object {.code {{}}} is the usual cause."
+    ))
+  }
+  invisible(NULL)
 }
 
 # Section validation adapters ----
@@ -270,8 +327,8 @@ print.Scenario <- function(x, ...) {
 #' (warning), `simulationType` is one of the supported values, and
 #' population-typed scenarios declare a `populationId`.
 #'
-#' Cross-section reference checks (individualId, modelParameterSets,
-#' applicationProtocol, …) live in `.validateCrossReferences()`.
+#' Cross-section reference checks (individual, parameterSets, application,
+#' …) live in `.validateCrossReferences()`.
 #'
 #' @param scenarios Named list of `Scenario` objects from
 #'   `project$scenarios`.
@@ -325,21 +382,23 @@ print.Scenario <- function(x, ...) {
       )
     }
 
-    if (
-      simType == "Population" &&
-        (is.null(sc$populationId) || sc$populationId == "")
-    ) {
+    # `.parseScenarios` already rejects a non-scalar `populationId` on load, so
+    # `sc$populationId` is a length-1 string or `NULL` here. Use a scalar-safe
+    # emptiness test so a stray non-scalar value can never make the `&&`
+    # operand `NA` and crash with an opaque internal error.
+    hasPopulationId <- !is.null(sc$populationId) &&
+      length(sc$populationId) == 1L &&
+      !is.na(sc$populationId) &&
+      nzchar(sc$populationId)
+
+    if (simType == "Population" && !hasPopulationId) {
       result$add_critical_error(
         "Missing Fields",
         paste0("Population scenario '", name, "' has no populationId")
       )
     }
 
-    if (
-      simType != "Population" &&
-        !is.null(sc$populationId) &&
-        sc$populationId != ""
-    ) {
+    if (simType != "Population" && hasPopulationId) {
       result$add_warning(
         "Validation",
         paste0(
@@ -354,6 +413,162 @@ print.Scenario <- function(x, ...) {
   }
 
   result
+}
+
+#' Structural fail-fast validation for one scenario, run on write-through
+#'
+#' Checks a single scenario's own shape (independent of cross-references)
+#' before it is persisted to its entity file: it must be a `Scenario`
+#' record, carry a name that is a safe single path segment and matches the
+#' list key it is stored under, carry a non-empty `modelFile`, and declare
+#' a supported `simulationType`. Referential checks (does `individual` /
+#' `outputPaths` / ... resolve) stay lazy and live in
+#' `.validateCrossReferences()`; they are not enforced here so a project
+#' can pass through a transiently-inconsistent graph during editing.
+#'
+#' Aborts on the first structural problem so a malformed scenario never
+#' lands on disk.
+#'
+#' @param sc A `Scenario` record.
+#' @param name The scenario's key (the authoritative id; the entity file
+#'   is named after it).
+#' @keywords internal
+#' @noRd
+.validateScenarioStructure <- function(sc, name) {
+  if (!inherits(sc, "Scenario")) {
+    cli::cli_abort(
+      "Scenario {.val {name}} must be a {.cls Scenario} record."
+    )
+  }
+  # The list key is the authoritative scenario id: it names the entity file
+  # and is what removal, cross-reference validation, and `names()` key off.
+  # The authoring API (`addScenario()` / `setScenario()`) canonicalizes the
+  # id before it reaches here, so the key is already safe. This structural
+  # backstop still rejects any key that is not already canonical (mixed case, a
+  # forbidden character, ...) and points the user at the canonical form, so a
+  # non-canonical key reaching the write path (the section accessor is
+  # read-only, so only an internal `.setSection()` write can) is caught here.
+  # This subsumes the old case-insensitive-collision guard: two keys differing
+  # only in case cannot both be canonical, so they can never both reach the
+  # tree.
+  canonical <- suppressWarnings(.canonicalizeId(name))
+  if (!identical(name, canonical)) {
+    cli::cli_abort(c(
+      "Scenario id {.val {name}} is not a canonical entity-file id.",
+      "i" = "Use {.code addScenario(project, {.val {name}}, ...)}, which \\
+      canonicalizes it to {.val {canonical}}, or store the scenario under \\
+      the key {.val {canonical}}."
+    ))
+  }
+  # The record's own `scenarioName` must agree with the key it is stored
+  # under, or the serialized JSON (`name = sc$scenarioName`) would contradict
+  # the filename and the cross-reference key.
+  if (
+    !is.null(sc$scenarioName) &&
+      !identical(sc$scenarioName, name)
+  ) {
+    cli::cli_abort(c(
+      "Scenario {.field scenarioName} {.val {sc$scenarioName}} does not match \\
+      the key {.val {name}} it is stored under.",
+      "i" = "Store a scenario under a key equal to its {.field scenarioName} \\
+      (or leave {.field scenarioName} unset)."
+    ))
+  }
+  if (
+    is.null(sc$modelFile) ||
+      !is.character(sc$modelFile) ||
+      length(sc$modelFile) != 1L ||
+      is.na(sc$modelFile) ||
+      !nzchar(sc$modelFile)
+  ) {
+    cli::cli_abort(
+      "Scenario {.val {name}} has no {.field modelFile}; \\
+      it must be a non-empty string."
+    )
+  }
+  simType <- sc$simulationType %||% ""
+  if (!simType %in% c("Individual", "Population")) {
+    cli::cli_abort(
+      "Scenario {.val {name}} has invalid {.field simulationType} \\
+      {.val {simType}}; expected {.val Individual} or {.val Population}."
+    )
+  }
+  # Structural validation must be a true superset of what the serializer
+  # (`.scenarioToJson`) requires: a record that passes here must always
+  # serialize. The two checks below mirror the serializer's own aborts so a
+  # write-through never validates a scenario the writer then chokes on.
+  if (isTRUE(sc$simulateSteadyState) && is.null(sc$steadyStateTimeUnit)) {
+    cli::cli_abort(c(
+      "Scenario {.val {name}} has {.field simulateSteadyState}=TRUE but \\
+      {.field steadyStateTimeUnit} is NULL.",
+      "i" = "Set {.field steadyStateTimeUnit} (e.g. {.val min}) so the \\
+      steady-state time can round-trip."
+    ))
+  }
+  if (!is.null(sc$outputPaths)) {
+    pathIds <- names(sc$outputPaths)
+    if (
+      !is.character(sc$outputPaths) ||
+        is.null(pathIds) ||
+        any(pathIds == "")
+    ) {
+      cli::cli_abort(c(
+        "Scenario {.val {name}} has {.field outputPaths} without ids.",
+        "i" = "Expected a named character vector: id-as-name, \\
+        literal-path-as-value."
+      ))
+    }
+  }
+  # The scalar reference fields the serializer emits verbatim
+  # (`.scenarioToJson`) must be a length-1 scalar when present, or a wrong-typed
+  # value (e.g. `individualId <- list(...)`) would silently serialize to a
+  # malformed entity file the parser then rejects on the next load. NULL or a
+  # length-1 `NA` is allowed: both are the established "no reference" sentinel
+  # the serializer handles (an Individual scenario has no population; a scenario
+  # may have no application).
+  for (field in c("individualId", "populationId", "applicationProtocol")) {
+    val <- sc[[field]]
+    okScalar <- is.null(val) ||
+      (length(val) == 1L && (is.character(val) || is.na(val)))
+    if (!okScalar) {
+      cli::cli_abort(
+        "Scenario {.val {name}} field {.field {field}} must be a single \\
+        string (or NULL), not {.obj_type_friendly {val}}."
+      )
+    }
+  }
+  # The section accessor is read-only, so the only way a record reaches this
+  # write-through backstop is an authoring function (which sets only known
+  # fields) or an internal `.setSection()` call. Reject any field the
+  # serializer does not know, so a typo'd or stale field cannot be silently
+  # dropped on write and then be absent on the next load. `simulationType` is
+  # the derived discriminant validated above; the rest mirror `.scenarioToJson`.
+  knownScenarioFields <- c(
+    "scenarioName",
+    "simulationType",
+    "individualId",
+    "populationId",
+    "readPopulationFromCSV",
+    "modelParameterSets",
+    "initialConditions",
+    "applicationProtocol",
+    "simulationTime",
+    "simulationTimeUnit",
+    "simulateSteadyState",
+    "steadyStateTime",
+    "steadyStateTimeUnit",
+    "overwriteFormulasInSS",
+    "modelFile",
+    "outputPaths"
+  )
+  unknown <- setdiff(names(sc), knownScenarioFields)
+  if (length(unknown) > 0L) {
+    cli::cli_abort(c(
+      "Scenario {.val {name}} has unknown field{?s} {.field {unknown}}.",
+      "i" = "Allowed fields: {.field {knownScenarioFields}}."
+    ))
+  }
+  invisible(NULL)
 }
 
 #' Validate the `applications` section of a Project
@@ -384,7 +599,7 @@ print.Scenario <- function(x, ...) {
 #'   loaded with [loadProject()].
 #'
 #' @param project A [Project] object loaded from a `Project.json` file.
-#' @param scenarioNames Optional character vector of scenario names to
+#' @param scenarios Optional character vector of scenario names to
 #'   run. `NULL` (default) runs all scenarios in the project.
 #' @param customParams A list with vectors `paths`, `values`, and
 #'   `units` — applied to every selected scenario as the final
@@ -411,7 +626,7 @@ print.Scenario <- function(x, ...) {
 #' @export
 runScenarios <- function(
   project,
-  scenarioNames = NULL,
+  scenarios = NULL,
   customParams = NULL,
   simulationRunOptions = NULL,
   validate = TRUE
@@ -424,7 +639,7 @@ runScenarios <- function(
   }
   .runScenariosFromProject(
     project,
-    scenarioNames,
+    scenarios,
     customParams,
     simulationRunOptions,
     validate
@@ -433,26 +648,42 @@ runScenarios <- function(
 
 # Public CRUD: scenarios ----
 
-#' Add a scenario programmatically to a Project
+#' Add one or more scenarios programmatically to a Project
 #'
-#' Creates a new `Scenario` and adds it to `project$scenarios` after
-#' validating all references.
+#' Creates new `Scenario` records and adds them to `project$scenarios` after
+#' validating all references. The call vectorizes over a vector of ids (see
+#' the recycling rule under Details). Scalar-per-entity fields (`modelFile`,
+#' `individual`, `population`, `application`, `simulationTime`,
+#' `simulationTimeUnit`, `steadyState`, `steadyStateTime`,
+#' `steadyStateTimeUnit`, `overwriteFormulasInSS`, `readPopulationFromCSV`)
+#' follow the recycle/align rule. The vector-valued-per-entity fields
+#' `parameterSets` and `outputPaths` are applied whole to every
+#' scenario; to give a different set per scenario, pass a list of the same
+#' length as `id` (one character vector per scenario). `initialConditions`
+#' follows the same whole-vector rule.
+#'
+#' @inherit vectorizedAuthoring details
 #'
 #' @param project A `Project` object.
-#' @param scenarioName Character. Name for the new scenario. Must not
-#'   already exist in `project$scenarios`.
+#' @param id Character vector of ids (names) for the new scenarios (the number
+#'   of scenarios to add). Each is canonicalized to a safe, lowercase,
+#'   single-path-segment id (a warning names the result if it changed); each
+#'   canonical id must not already exist in `project$scenarios`.
 #' @param modelFile Character. Name of the `.pkml` model file (relative
 #'   to model folder).
-#' @param individualId Character or `NULL`. ID referencing
+#' @param individual Character or `NULL`. Id referencing
 #'   `project$individuals`.
-#' @param populationId Character or `NULL`. ID referencing
+#' @param population Character or `NULL`. Id referencing
 #'   `project$populations`.
-#' @param applicationProtocol Character or `NULL`. Protocol name
+#' @param application Character or `NULL`. Id of the application protocol
 #'   referencing `project$applications`.
-#' @param modelParameterSets Character vector or `NULL`. Set names
-#'   referencing `project$modelParameterSets`.
-#' @param outputPathIds Character vector or `NULL`. IDs referencing
-#'   `project$outputPaths`.
+#' @param parameterSets Character vector or `NULL`. Parameter-set ids
+#'   referencing `project$parameterSets`. Applied whole to every scenario.
+#' @param initialConditions Character vector or `NULL`. Initial-condition set
+#'   ids referencing `project$initialConditions`. Applied whole to every
+#'   scenario.
+#' @param outputPaths Character vector or `NULL`. Output-path ids referencing
+#'   `project$outputPaths`. Applied whole to every scenario.
 #' @param simulationTime Character or `NULL`. Format
 #'   `"start, end, resolution"` or
 #'   `"start, end, resolution; start, end, resolution"` for multiple
@@ -474,13 +705,14 @@ runScenarios <- function(
 #' @family scenario
 addScenario <- function(
   project,
-  scenarioName,
+  id,
   modelFile,
-  individualId = NULL,
-  populationId = NULL,
-  applicationProtocol = NULL,
-  modelParameterSets = NULL,
-  outputPathIds = NULL,
+  individual = NULL,
+  population = NULL,
+  application = NULL,
+  parameterSets = NULL,
+  initialConditions = NULL,
+  outputPaths = NULL,
   simulationTime = NULL,
   simulationTimeUnit = "h",
   steadyState = FALSE,
@@ -490,22 +722,64 @@ addScenario <- function(
   readPopulationFromCSV = FALSE
 ) {
   validateIsOfType(project, "Project")
-  errors <- character()
+  .assertIdVector(id)
+  id <- .canonicalizeId(id)
+  n <- length(id)
 
-  if (
-    !is.character(scenarioName) ||
-      length(scenarioName) != 1L ||
-      is.na(scenarioName) ||
-      nchar(scenarioName) == 0
-  ) {
-    errors <- c(errors, "scenarioName must be a non-empty string")
-  } else if (scenarioName %in% names(project$scenarios)) {
-    errors <- c(
-      errors,
-      paste0("scenario '", scenarioName, "' already exists")
+  perEntity <- .alignAuthoringArgs(
+    id,
+    scalarFields = list(
+      modelFile = modelFile,
+      individual = individual,
+      population = population,
+      application = application,
+      simulationTime = simulationTime,
+      simulationTimeUnit = simulationTimeUnit,
+      steadyState = steadyState,
+      steadyStateTime = steadyStateTime,
+      steadyStateTimeUnit = steadyStateTimeUnit,
+      overwriteFormulasInSS = overwriteFormulasInSS,
+      readPopulationFromCSV = readPopulationFromCSV
+    ),
+    wholeFields = list(
+      parameterSets = parameterSets,
+      initialConditions = initialConditions,
+      outputPaths = outputPaths
     )
-  }
+  )
 
+  clash <- intersect(id, names(project$scenarios))
+  if (length(clash) > 0L) {
+    cli::cli_abort("scenario {.val {clash}} already exists")
+  }
+  call <- rlang::current_env()
+  scenarios <- .collectCanonicalizedRefs(lapply(seq_len(n), function(i) {
+    .buildScenarioEntry(project, id[[i]], perEntity[[i]], call = call)
+  }))
+
+  newScenarios <- project$.getSection("scenarios") %||% list()
+  for (i in seq_len(n)) {
+    newScenarios[[id[[i]]]] <- scenarios[[i]]
+  }
+  project$.setSection("scenarios", newScenarios)
+  invisible(project)
+}
+
+# Build one `Scenario` record from its id and per-entity field list, running
+# the same foreign-key + structural checks `addScenario()` always has. Aborts
+# naming the scenario on a problem. `call` attributes the abort to the public
+# caller.
+#
+# @keywords internal
+# @noRd
+.buildScenarioEntry <- function(
+  project,
+  id,
+  fields,
+  call = rlang::caller_env()
+) {
+  errors <- character()
+  modelFile <- fields$modelFile
   if (
     !is.character(modelFile) ||
       length(modelFile) != 1L ||
@@ -515,148 +789,731 @@ addScenario <- function(
     errors <- c(errors, "modelFile must be a non-empty string")
   }
 
-  checkScalarFK <- function(value, argName, lookup, lookupLabel) {
-    if (is.null(value)) {
-      return(character())
-    }
-    if (
-      !is.character(value) ||
-        length(value) != 1L ||
-        is.na(value) ||
-        nchar(value) == 0
-    ) {
-      return(paste0(argName, " must be a non-empty string or NULL"))
-    }
-    if (!(value %in% names(lookup))) {
-      return(paste0(argName, " '", value, "' not found in ", lookupLabel))
-    }
-    character()
-  }
-  checkVectorFK <- function(value, argName, lookup, lookupLabel) {
-    if (is.null(value)) {
-      return(character())
-    }
-    if (
-      !is.character(value) ||
-        length(value) == 0L ||
-        any(is.na(value)) ||
-        any(nchar(value) == 0)
-    ) {
-      return(paste0(
-        argName,
-        " must be a non-empty character vector with no NA or empty entries"
-      ))
-    }
-    bad <- setdiff(value, names(lookup))
-    if (length(bad) > 0L) {
-      return(paste0(
-        argName,
-        " not found in ",
-        lookupLabel,
-        ": ",
-        paste(bad, collapse = ", ")
-      ))
-    }
-    character()
+  # Canonicalize the foreign-key references the moment they enter the API, so a
+  # definition and any later reference made from the same typed string land on
+  # the same canonical id.
+  individual <- .canonicalizeIdRef(fields$individual)
+  population <- .canonicalizeIdRef(fields$population)
+  application <- .canonicalizeIdRef(fields$application)
+  parameterSets <- .canonicalizeIdRef(fields$parameterSets)
+  initialConditions <- .canonicalizeIdRef(fields$initialConditions)
+  outputPaths <- .canonicalizeIdRef(fields$outputPaths)
+  # Collapse a repeated id (first-seen order) so the same output path is never
+  # resolved, run, or plotted twice. A repeat is not an error, just redundant.
+  if (!is.null(outputPaths)) {
+    outputPaths <- unique(outputPaths)
   }
 
   errors <- c(
     errors,
-    checkScalarFK(
-      individualId,
-      "individualId",
+    .checkScalarScenarioFK(
+      individual,
+      "individual",
       project$individuals,
       "individuals"
     ),
-    checkScalarFK(
-      populationId,
-      "populationId",
+    .checkScalarScenarioFK(
+      population,
+      "population",
       project$populations,
       "populations"
     ),
-    checkScalarFK(
-      applicationProtocol,
-      "applicationProtocol",
+    .checkScalarScenarioFK(
+      application,
+      "application",
       project$applications,
       "applications"
     ),
-    checkVectorFK(
-      modelParameterSets,
-      "modelParameterSets",
-      project$modelParameterSets,
-      "project$modelParameterSets"
+    .checkVectorScenarioFK(
+      parameterSets,
+      "parameterSets",
+      project$parameterSets,
+      "project$parameterSets"
     ),
-    checkVectorFK(
-      outputPathIds,
-      "outputPathIds",
+    .checkVectorScenarioFK(
+      initialConditions,
+      "initialConditions",
+      project$initialConditions,
+      "project$initialConditions"
+    ),
+    .checkVectorScenarioFK(
+      outputPaths,
+      "outputPaths",
       project$outputPaths,
       "outputPaths"
     )
   )
 
   if (length(errors) > 0L) {
-    cli::cli_abort(c(
-      "Cannot add scenario {.val {scenarioName}}:",
-      stats::setNames(errors, rep("x", length(errors)))
-    ))
+    cli::cli_abort(
+      c(
+        "Cannot add scenario {.val {id}}:",
+        stats::setNames(errors, rep("x", length(errors)))
+      ),
+      call = call
+    )
   }
 
-  sc <- Scenario(
-    scenarioName = scenarioName,
+  steadyStateTimeUnit <- fields$steadyStateTimeUnit
+  Scenario(
+    scenarioName = id,
     modelFile = modelFile,
-    applicationProtocol = applicationProtocol %||% NA,
-    individualId = individualId,
-    populationId = populationId,
-    outputPaths = if (!is.null(outputPathIds)) {
+    applicationProtocol = application %||% NA,
+    individualId = individual,
+    populationId = population,
+    outputPaths = if (!is.null(outputPaths)) {
       stats::setNames(
-        unlist(project$outputPaths[outputPathIds], use.names = FALSE),
-        outputPathIds
+        unlist(project$outputPaths[outputPaths], use.names = FALSE),
+        outputPaths
       )
     },
-    readPopulationFromCSV = readPopulationFromCSV,
-    simulateSteadyState = steadyState,
-    simulationTime = if (!is.null(simulationTime)) {
-      .parseSimulationTimeIntervals(simulationTime)
+    readPopulationFromCSV = fields$readPopulationFromCSV,
+    simulateSteadyState = fields$steadyState,
+    simulationTime = if (!is.null(fields$simulationTime)) {
+      .parseSimulationTimeIntervals(fields$simulationTime)
     },
-    simulationTimeUnit = simulationTimeUnit,
+    simulationTimeUnit = fields$simulationTimeUnit,
     # The field contract stores steadyStateTime in the base unit (minutes);
     # convert from the user-declared unit so a non-minute unit round-trips
     # correctly (the serializer converts back to steadyStateTimeUnit).
     steadyStateTime = ospsuite::toBaseUnit(
       quantityOrDimension = ospDimensions$Time,
-      values = steadyStateTime,
+      values = fields$steadyStateTime,
       unit = steadyStateTimeUnit
     ),
     steadyStateTimeUnit = steadyStateTimeUnit,
-    overwriteFormulasInSS = overwriteFormulasInSS,
-    modelParameterSets = modelParameterSets
+    overwriteFormulasInSS = fields$overwriteFormulasInSS,
+    modelParameterSets = parameterSets,
+    initialConditions = initialConditions
   )
+}
 
-  project$scenarios[[scenarioName]] <- sc
+#' Remove one or more scenarios from a Project
+#' @param project A `Project` object.
+#' @param id Character vector of scenario ids to remove in one write-through.
+#'   Each is canonicalized the same way [addScenario()] canonicalizes it, so
+#'   the same typed id removes what it created. A not-found id warns and is
+#'   skipped.
+#' @returns The `project` object, invisibly.
+#' @export
+#' @family scenario
+removeScenario <- function(project, id) {
+  validateIsOfType(project, "Project")
+  .assertIdVector(id)
+  id <- .canonicalizeId(id)
+
+  missingIds <- setdiff(id, names(project$scenarios))
+  if (length(missingIds) > 0L) {
+    cli::cli_warn("scenario {.val {missingIds}} not found; no-op.")
+  }
+  toRemove <- intersect(id, names(project$scenarios))
+  for (one in toRemove) {
+    .warnIfReferenced(project, "scenario", one)
+  }
+  if (length(toRemove) == 0L) {
+    return(invisible(project))
+  }
+  scenarios <- project$.getSection("scenarios")
+  scenarios[toRemove] <- NULL
+  project$.setSection("scenarios", scenarios)
+  invisible(project)
+}
+
+#' Modify fields of an existing scenario
+#'
+#' @description Changes one or more fields of the scenario identified by
+#'   `id` and persists the change the same way [addScenario()]
+#'   does (write-through to the scenario definition). The section accessor
+#'   `project$scenarios` is read-only, so this is the way to revise an
+#'   existing scenario: read it if you need the current values
+#'   (`sc <- project$scenarios[[name]]`), then pass the changes here
+#'   (`setScenario(project, name, ...)`).
+#'
+#'   Only the arguments you pass are changed; every other field keeps its
+#'   current value (partial update). For an optional field, passing `NULL`
+#'   clears it (e.g. `individual = NULL` detaches the individual), whereas
+#'   omitting the argument leaves it untouched. The required `modelFile`
+#'   cannot be cleared.
+#'
+#'   References are validated exactly as in [addScenario()]: every supplied
+#'   foreign-key argument (`individual`, `population`, `application`,
+#'   `parameterSets`, `initialConditions`, `outputPaths`) must resolve in the
+#'   project, and the changed scenario must pass structural validation before it
+#'   is written, so an invalid change touches neither memory nor disk. A
+#'   dangling reference is rejected eagerly with an immediate error, not
+#'   deferred to [validateProject()].
+#'
+#'   The call vectorizes over a vector of ids (see the recycling rule under
+#'   Details): a supplied scalar-per-entity field is recycled or aligned
+#'   across `id`, and the whole-vector fields `parameterSets` /
+#'   `initialConditions` / `outputPaths` are applied whole to every scenario. A
+#'   field left unsupplied is untouched on every scenario.
+#'
+#' @inherit vectorizedAuthoring details
+#' @inheritParams addScenario
+#' @param id Character vector. Ids of the scenarios to modify. Each is
+#'   canonicalized the same way [addScenario()] canonicalizes it, and must
+#'   already exist in `project$scenarios`.
+#' @param simulationTimeUnit Character time-unit string. Omitting the argument
+#'   leaves the current value untouched (there is no default; this is a
+#'   partial update).
+#' @param steadyState Logical, whether to simulate steady state. Omitting the
+#'   argument leaves the current value untouched (there is no default; this is
+#'   a partial update).
+#' @param steadyStateTime Numeric steady-state time in `steadyStateTimeUnit`.
+#'   Omitting the argument leaves the current value untouched (there is no
+#'   default; this is a partial update).
+#' @param steadyStateTimeUnit Character unit for `steadyStateTime`. Omitting
+#'   the argument leaves the current value untouched (there is no default; this
+#'   is a partial update).
+#' @param overwriteFormulasInSS Logical, whether to overwrite formulas during
+#'   steady state. Omitting the argument leaves the current value untouched
+#'   (there is no default; this is a partial update).
+#' @param readPopulationFromCSV Logical, whether to load the population from
+#'   CSV. Omitting the argument leaves the current value untouched (there is no
+#'   default; this is a partial update).
+#'
+#' @returns The `project` object, invisibly.
+#' @export
+#' @family scenario
+setScenario <- function(
+  project,
+  id,
+  modelFile,
+  individual,
+  population,
+  application,
+  parameterSets,
+  initialConditions,
+  outputPaths,
+  simulationTime,
+  simulationTimeUnit,
+  steadyState,
+  steadyStateTime,
+  steadyStateTimeUnit,
+  overwriteFormulasInSS,
+  readPopulationFromCSV
+) {
+  validateIsOfType(project, "Project")
+  .assertIdVector(id)
+  id <- .canonicalizeId(id)
+  n <- length(id)
+  missingIds <- setdiff(id, names(project$scenarios))
+  if (length(missingIds) > 0L) {
+    cli::cli_abort(c(
+      "Cannot modify scenario {.val {missingIds}}: it does not exist.",
+      "i" = "Use {.fn addScenario} to create it first."
+    ))
+  }
+
+  # Capture only the fields the caller actually supplied (partial update). A
+  # supplied `NULL` (e.g. `individual = NULL`) clears the field, distinct
+  # from an unsupplied argument; the `x[name] <- list(value)` form preserves a
+  # NULL-valued supplied field as a present-but-NULL list element (a plain
+  # `x$name <- NULL` would instead drop the name).
+  scalarSupplied <- list()
+  wholeSupplied <- list()
+  if (!missing(modelFile)) {
+    scalarSupplied["modelFile"] <- list(modelFile)
+  }
+  if (!missing(individual)) {
+    scalarSupplied["individual"] <- list(individual)
+  }
+  if (!missing(population)) {
+    scalarSupplied["population"] <- list(population)
+  }
+  if (!missing(application)) {
+    scalarSupplied["application"] <- list(application)
+  }
+  if (!missing(simulationTime)) {
+    scalarSupplied["simulationTime"] <- list(simulationTime)
+  }
+  if (!missing(simulationTimeUnit)) {
+    scalarSupplied["simulationTimeUnit"] <- list(simulationTimeUnit)
+  }
+  if (!missing(steadyState)) {
+    scalarSupplied["steadyState"] <- list(steadyState)
+  }
+  if (!missing(steadyStateTime)) {
+    scalarSupplied["steadyStateTime"] <- list(steadyStateTime)
+  }
+  if (!missing(steadyStateTimeUnit)) {
+    scalarSupplied["steadyStateTimeUnit"] <- list(steadyStateTimeUnit)
+  }
+  if (!missing(overwriteFormulasInSS)) {
+    scalarSupplied["overwriteFormulasInSS"] <- list(overwriteFormulasInSS)
+  }
+  if (!missing(readPopulationFromCSV)) {
+    scalarSupplied["readPopulationFromCSV"] <- list(readPopulationFromCSV)
+  }
+  if (!missing(parameterSets)) {
+    wholeSupplied["parameterSets"] <- list(parameterSets)
+  }
+  if (!missing(initialConditions)) {
+    wholeSupplied["initialConditions"] <- list(initialConditions)
+  }
+  if (!missing(outputPaths)) {
+    wholeSupplied["outputPaths"] <- list(outputPaths)
+  }
+
+  perEntity <- .alignAuthoringArgs(
+    id,
+    scalarFields = scalarSupplied,
+    wholeFields = wholeSupplied
+  )
+  suppliedNames <- c(names(scalarSupplied), names(wholeSupplied))
+
+  call <- rlang::current_env()
+  updated <- .collectCanonicalizedRefs(lapply(seq_len(n), function(i) {
+    .setOneScenario(
+      project,
+      id[[i]],
+      perEntity[[i]][suppliedNames],
+      call = call
+    )
+  }))
+
+  scenarios <- project$.getSection("scenarios")
+  for (i in seq_len(n)) {
+    scenarios[[id[[i]]]] <- updated[[i]]
+  }
+  project$.setSection("scenarios", scenarios)
+  invisible(project)
+}
+
+# Apply a partial-update field set to one existing scenario, returning the
+# updated `Scenario` record. `fields` carries only the names the caller
+# supplied (a present-but-NULL field clears it). Runs the same FK + apply
+# logic the scalar `setScenario()` always has. Aborts naming the scenario.
+#
+# @keywords internal
+# @noRd
+.setOneScenario <- function(project, id, fields, call = rlang::caller_env()) {
+  sc <- project$scenarios[[id]]
+  errors <- character()
+  supplied <- names(fields)
+
+  # Canonicalize the supplied foreign-key references (matching the definition
+  # side) before validating, so a reference resolves to its definition.
+  if ("individual" %in% supplied) {
+    fields$individual <- .canonicalizeIdRef(fields$individual)
+  }
+  if ("population" %in% supplied) {
+    fields$population <- .canonicalizeIdRef(fields$population)
+  }
+  if ("application" %in% supplied) {
+    fields$application <- .canonicalizeIdRef(fields$application)
+  }
+  if ("parameterSets" %in% supplied) {
+    fields$parameterSets <- .canonicalizeIdRef(fields$parameterSets)
+  }
+  if ("initialConditions" %in% supplied) {
+    fields$initialConditions <- .canonicalizeIdRef(fields$initialConditions)
+  }
+  if ("outputPaths" %in% supplied) {
+    fields$outputPaths <- .canonicalizeIdRef(fields$outputPaths)
+    # Collapse a repeated id (first-seen order) so the same output path is
+    # never resolved, run, or plotted twice; a repeat is redundant, not an
+    # error.
+    if (!is.null(fields$outputPaths)) {
+      fields$outputPaths <- unique(fields$outputPaths)
+    }
+  }
+
+  # Validate only the foreign-key arguments the caller actually supplied,
+  # reusing the exact checks `addScenario()` runs.
+  if ("individual" %in% supplied) {
+    errors <- c(
+      errors,
+      .checkScalarScenarioFK(
+        fields$individual,
+        "individual",
+        project$individuals,
+        "individuals"
+      )
+    )
+  }
+  if ("population" %in% supplied) {
+    errors <- c(
+      errors,
+      .checkScalarScenarioFK(
+        fields$population,
+        "population",
+        project$populations,
+        "populations"
+      )
+    )
+  }
+  if ("application" %in% supplied) {
+    errors <- c(
+      errors,
+      .checkScalarScenarioFK(
+        fields$application,
+        "application",
+        project$applications,
+        "applications"
+      )
+    )
+  }
+  if ("parameterSets" %in% supplied) {
+    errors <- c(
+      errors,
+      .checkVectorScenarioFK(
+        fields$parameterSets,
+        "parameterSets",
+        project$parameterSets,
+        "project$parameterSets"
+      )
+    )
+  }
+  if ("initialConditions" %in% supplied) {
+    errors <- c(
+      errors,
+      .checkVectorScenarioFK(
+        fields$initialConditions,
+        "initialConditions",
+        project$initialConditions,
+        "project$initialConditions"
+      )
+    )
+  }
+  if ("outputPaths" %in% supplied) {
+    errors <- c(
+      errors,
+      .checkVectorScenarioFK(
+        fields$outputPaths,
+        "outputPaths",
+        project$outputPaths,
+        "outputPaths"
+      )
+    )
+  }
+
+  if (length(errors) > 0L) {
+    cli::cli_abort(
+      c(
+        "Cannot modify scenario {.val {id}}:",
+        stats::setNames(errors, rep("x", length(errors)))
+      ),
+      call = call
+    )
+  }
+
+  # Apply each supplied field to the working record. The record's
+  # `applicationProtocol` field carries `NA` (not `NULL`) when absent,
+  # matching the Scenario() contract.
+  if ("modelFile" %in% supplied) {
+    sc$modelFile <- fields$modelFile
+  }
+  if ("individual" %in% supplied) {
+    sc$individualId <- fields$individual
+  }
+  if ("population" %in% supplied) {
+    sc$populationId <- fields$population
+    sc$simulationType <- if (is.null(fields$population)) {
+      "Individual"
+    } else {
+      "Population"
+    }
+  }
+  if ("application" %in% supplied) {
+    sc$applicationProtocol <- fields$application %||% NA
+  }
+  if ("parameterSets" %in% supplied) {
+    sc$modelParameterSets <- fields$parameterSets
+  }
+  if ("initialConditions" %in% supplied) {
+    sc$initialConditions <- fields$initialConditions
+  }
+  if ("outputPaths" %in% supplied) {
+    sc$outputPaths <- if (is.null(fields$outputPaths)) {
+      NULL
+    } else {
+      stats::setNames(
+        unlist(project$outputPaths[fields$outputPaths], use.names = FALSE),
+        fields$outputPaths
+      )
+    }
+  }
+  if ("simulationTime" %in% supplied) {
+    sc$simulationTime <- if (is.null(fields$simulationTime)) {
+      NULL
+    } else {
+      .parseSimulationTimeIntervals(fields$simulationTime)
+    }
+  }
+  if ("simulationTimeUnit" %in% supplied) {
+    sc$simulationTimeUnit <- fields$simulationTimeUnit
+  }
+  if ("steadyState" %in% supplied) {
+    sc$simulateSteadyState <- fields$steadyState
+  }
+  if ("steadyStateTime" %in% supplied || "steadyStateTimeUnit" %in% supplied) {
+    # steadyStateTime is stored in the base unit (minutes); convert from the
+    # declared unit so a non-minute unit round-trips. Both arguments interact,
+    # so recompute the stored base value whenever either is supplied, falling
+    # back to the record's current unit/value for the one not given.
+    newUnit <- if ("steadyStateTimeUnit" %in% supplied) {
+      fields$steadyStateTimeUnit
+    } else {
+      sc$steadyStateTimeUnit
+    }
+    newTime <- if ("steadyStateTime" %in% supplied) {
+      fields$steadyStateTime
+    } else if (!is.null(sc$steadyStateTimeUnit)) {
+      ospsuite::toUnit(
+        quantityOrDimension = ospDimensions$Time,
+        values = sc$steadyStateTime,
+        targetUnit = sc$steadyStateTimeUnit
+      )
+    } else {
+      sc$steadyStateTime
+    }
+    sc$steadyStateTimeUnit <- newUnit
+    sc$steadyStateTime <- if (is.null(newUnit)) {
+      newTime
+    } else {
+      ospsuite::toBaseUnit(
+        quantityOrDimension = ospDimensions$Time,
+        values = newTime,
+        unit = newUnit
+      )
+    }
+  }
+  if ("overwriteFormulasInSS" %in% supplied) {
+    sc$overwriteFormulasInSS <- fields$overwriteFormulasInSS
+  }
+  if ("readPopulationFromCSV" %in% supplied) {
+    sc$readPopulationFromCSV <- fields$readPopulationFromCSV
+  }
+  sc
+}
+
+#' Rename an existing scenario
+#'
+#' @description Renames the scenario currently keyed `id` to `newId`,
+#'   preserving its configuration. The change is write-through: the scenario's
+#'   old definition is removed and a new one written under `newId`, the
+#'   in-memory key changes, and the record's stored name is updated to match
+#'   the new key so a reload round-trips (the name-equals-key invariant the
+#'   project relies on).
+#'
+#'   Both `id` and `newId` are canonicalized the same way [addScenario()]
+#'   canonicalizes an id (lowercased, made a safe single-path-segment id, with
+#'   a warning when the value changed), so the same typed strings used to
+#'   create and reference a scenario resolve consistently.
+#'
+#' @param project A `Project` object.
+#' @param id Character. Id of the scenario to rename; must exist in
+#'   `project$scenarios` (after canonicalization).
+#' @param newId Character. New id for the scenario; its canonical form must
+#'   not already belong to a different scenario.
+#'
+#' @returns The `project` object, invisibly.
+#' @export
+#' @family scenario
+renameScenario <- function(project, id, newId) {
+  validateIsOfType(project, "Project")
+  id <- .assertScenarioIdArg(id, "id")
+  newId <- .assertScenarioIdArg(newId, "newId")
+
+  id <- .canonicalizeId(id)
+  .assertScenarioExists(project, id, "rename")
+  newId <- .canonicalizeId(newId)
+
+  if (identical(id, newId)) {
+    return(invisible(project))
+  }
+  .assertScenarioTargetFree(project, newId)
+
+  sc <- project$scenarios[[id]]
+  # Keep the record's stored name in step with its new key so the entity file
+  # the write-through emits (`name = sc$scenarioName`) and the key agree, which
+  # is what `.validateScenarioStructure()` enforces.
+  sc$scenarioName <- newId
+
+  # Rebuild the whole section in one write so the write-through diff sees the
+  # new key (written through to `newId`'s file) and the gone key (its file
+  # removed) together.
+  scenarios <- project$.getSection("scenarios")
+  scenarios[[id]] <- NULL
+  scenarios[[newId]] <- sc
+  project$.setSection("scenarios", scenarios)
 
   invisible(project)
 }
 
-#' Remove a scenario from a Project
+#' Duplicate an existing scenario
+#'
+#' @description Creates a deep copy of the scenario currently keyed `id` under
+#'   `newId`, leaving the original untouched. The copy is a new definition
+#'   written through to `newId` (the in-memory store and the on-disk project
+#'   both gain an independent scenario).
+#'
+#'   Both `id` and `newId` are canonicalized the same way [addScenario()]
+#'   canonicalizes an id (lowercased, made a safe single-path-segment id, with
+#'   a warning when the value changed).
+#'
 #' @param project A `Project` object.
-#' @param scenarioName Character scalar, scenario name.
+#' @param id Character. Id of the scenario to copy; must exist in
+#'   `project$scenarios` (after canonicalization).
+#' @param newId Character. Id for the new copy; its canonical form must not
+#'   already belong to an existing scenario.
+#'
 #' @returns The `project` object, invisibly.
 #' @export
 #' @family scenario
-removeScenario <- function(project, scenarioName) {
+duplicateScenario <- function(project, id, newId) {
   validateIsOfType(project, "Project")
-  if (
-    !is.character(scenarioName) ||
-      length(scenarioName) != 1L ||
-      is.na(scenarioName) ||
-      nchar(scenarioName) == 0
-  ) {
-    cli::cli_abort("{.arg scenarioName} must be a non-empty string")
-  }
-  if (!(scenarioName %in% names(project$scenarios))) {
-    cli::cli_warn("scenario {.val {scenarioName}} not found; no-op.")
-    return(invisible(project))
-  }
-  project$scenarios[[scenarioName]] <- NULL
+  id <- .assertScenarioIdArg(id, "id")
+  newId <- .assertScenarioIdArg(newId, "newId")
+
+  id <- .canonicalizeId(id)
+  .assertScenarioExists(project, id, "duplicate")
+  newId <- .canonicalizeId(newId)
+  .assertScenarioTargetFree(project, newId)
+
+  # A `Scenario` is a plain-data list with copy semantics, so this is already a
+  # deep, independent copy; only its stored name has to follow the new key.
+  copy <- project$.getSection("scenarios")[[id]]
+  copy$scenarioName <- newId
+
+  scenarios <- project$.getSection("scenarios")
+  scenarios[[newId]] <- copy
+  project$.setSection("scenarios", scenarios)
+
   invisible(project)
+}
+
+# Validate that a scenario id argument (`id` / `newId` of `renameScenario()` /
+# `duplicateScenario()`) is a non-empty string, aborting with the argument
+# name when it is not. Returns the value unchanged so callers can write
+# `id <- .assertScenarioIdArg(id, "id")`. `call` attributes the abort to the
+# public caller.
+#
+# @keywords internal
+# @noRd
+.assertScenarioIdArg <- function(value, argName, call = rlang::caller_env()) {
+  if (
+    !is.character(value) ||
+      length(value) != 1L ||
+      is.na(value) ||
+      nchar(value) == 0
+  ) {
+    cli::cli_abort("{.arg {argName}} must be a non-empty string", call = call)
+  }
+  value
+}
+
+# Abort when a (canonical) scenario `id` is not in the project, with a
+# "did you mean '...'?" suggestion drawn from the existing scenario ids, the
+# same way the cross-reference validator phrases a dangling reference. `call`
+# attributes the abort to the public caller.
+#
+# @keywords internal
+# @noRd
+.assertScenarioExists <- function(
+  project,
+  id,
+  action,
+  call = rlang::caller_env()
+) {
+  if (id %in% names(project$scenarios)) {
+    return(invisible(NULL))
+  }
+  suggestion <- .suggestSuffix(id, names(project$scenarios))
+  cli::cli_abort(
+    c(
+      "Cannot {action} scenario {.val {id}}: it does not exist.",
+      "i" = paste0(
+        "Available scenarios: ",
+        "{.val {names(project$scenarios)}}",
+        suggestion
+      )
+    ),
+    call = call
+  )
+}
+
+# Abort when a (canonical) target id `newId` already belongs to a scenario, so
+# a rename/duplicate never silently overwrites an existing scenario. `call`
+# attributes the abort to the public caller.
+#
+# @keywords internal
+# @noRd
+.assertScenarioTargetFree <- function(
+  project,
+  newId,
+  call = rlang::caller_env()
+) {
+  if (newId %in% names(project$scenarios)) {
+    cli::cli_abort(
+      "Cannot use {.val {newId}}: a scenario with that id already exists.",
+      call = call
+    )
+  }
+  invisible(NULL)
+}
+
+# Foreign-key validation helpers shared by `addScenario()` and
+# `setScenario()`. Each returns a character vector of error strings (empty
+# when the value is valid or NULL), so the caller can accumulate and report
+# all reference problems at once.
+
+# Validate a scalar foreign-key argument (`individual`, `population`,
+# `application`): NULL is allowed (the reference is absent); a
+# non-empty string must resolve as a name in `lookup`.
+#
+# @keywords internal
+# @noRd
+.checkScalarScenarioFK <- function(value, argName, lookup, lookupLabel) {
+  if (is.null(value)) {
+    return(character())
+  }
+  if (
+    !is.character(value) ||
+      length(value) != 1L ||
+      is.na(value) ||
+      nchar(value) == 0
+  ) {
+    return(paste0(argName, " must be a non-empty string or NULL"))
+  }
+  if (!(value %in% names(lookup))) {
+    return(paste0(argName, " '", value, "' not found in ", lookupLabel))
+  }
+  character()
+}
+
+# Validate a vector foreign-key argument (`parameterSets`,
+# `outputPaths`): NULL is allowed; a non-empty character vector must have
+# no NA/empty entries and every element must resolve in `lookup`.
+#
+# @keywords internal
+# @noRd
+.checkVectorScenarioFK <- function(value, argName, lookup, lookupLabel) {
+  if (is.null(value)) {
+    return(character())
+  }
+  if (
+    !is.character(value) ||
+      length(value) == 0L ||
+      any(is.na(value)) ||
+      any(nchar(value) == 0)
+  ) {
+    return(paste0(
+      argName,
+      " must be a non-empty character vector with no NA or empty entries"
+    ))
+  }
+  bad <- setdiff(value, names(lookup))
+  if (length(bad) > 0L) {
+    return(paste0(
+      argName,
+      " not found in ",
+      lookupLabel,
+      ": ",
+      paste(bad, collapse = ", ")
+    ))
+  }
+  character()
 }

--- a/R/simulation.R
+++ b/R/simulation.R
@@ -58,6 +58,9 @@ applyIndividualParameters <- function(individualCharacteristics, simulation) {
 #'   describing an individual.
 #' @param additionalParams Optional named list with lists 'paths', 'values', and
 #'   'units'.
+#' @param additionalInitialConditions Optional named list with lists 'paths',
+#'   'values', and 'units', giving molecule start values to apply via
+#'   `ospsuite::setQuantityValuesByPath()` after the parameters.
 #' @param stopIfParameterNotFound Logical. If `TRUE` (default), an error is
 #'   thrown if any of the `additionalParams` does not exist. If `FALSE`,
 #'   non-existent parameters are  ignored.
@@ -78,6 +81,7 @@ initializeSimulation <- function(
   simulation,
   individualCharacteristics = NULL,
   additionalParams = NULL,
+  additionalInitialConditions = NULL,
   stopIfParameterNotFound = TRUE
 ) {
   validateIsOfType(simulation, "Simulation", nullAllowed = FALSE)
@@ -89,6 +93,11 @@ initializeSimulation <- function(
   .validateParametersStructure(
     additionalParams,
     "additionalParams",
+    nullAllowed = TRUE
+  )
+  .validateParametersStructure(
+    additionalInitialConditions,
+    "additionalInitialConditions",
     nullAllowed = TRUE
   )
 
@@ -134,6 +143,21 @@ initializeSimulation <- function(
         values = additionalParams$values,
         simulation = simulation,
         units = additionalParams$units,
+        stopIfNotFound = stopIfParameterNotFound
+      )
+    }
+  }
+
+  # Apply additional initial conditions (molecule start values), after the
+  # parameters so a start value overrides any parameter-driven default.
+  if (!is.null(additionalInitialConditions)) {
+    # Skip if the correct structure is supplied, but no entries are defined
+    if (!isEmpty(additionalInitialConditions$paths)) {
+      ospsuite::setQuantityValuesByPath(
+        quantityPaths = additionalInitialConditions$paths,
+        values = additionalInitialConditions$values,
+        simulation = simulation,
+        units = additionalInitialConditions$units,
         stopIfNotFound = stopIfParameterNotFound
       )
     }

--- a/tests/testthat/_snaps/applications.md
+++ b/tests/testthat/_snaps/applications.md
@@ -1,0 +1,38 @@
+# removeApplication warns when still referenced by a scenario, removes anyway
+
+    Code
+      removeApplication(project, "aciclovir_iv_250mg")
+    Condition
+      Warning:
+      Removed application "aciclovir_iv_250mg" is still referenced by 4 scenarios:
+      * populationscenario, populationscenariofromcsv, testscenario, and testscenario_steadystate
+      i These scenarios now have a dangling reference. Update or remove them.
+
+# setApplicationParameterSets aborts on an undefined parameter set
+
+    Code
+      setApplicationParameterSets(project, "aciclovir_iv_250mg", "Ghost")
+    Condition
+      Warning:
+      Canonicalized 1 referenced id to a safe form:
+      * "Ghost" -> "ghost"
+      Error in `setApplicationParameterSets()`:
+      ! `parameterSets` references undefined parameter sets:
+      x "ghost"
+
+# print.Application renders its parameter-set references
+
+    Code
+      print(project$applications[["aciclovir_iv_250mg"]])
+    Output
+      <Application>
+        * Parameter Sets: aciclovir_iv_250mg_default
+
+# print.Application renders an empty protocol
+
+    Code
+      print(project$applications[["empty"]])
+    Output
+      <Application>
+        * Parameter Sets: <empty string>
+

--- a/tests/testthat/_snaps/authoring-vectorize.md
+++ b/tests/testthat/_snaps/authoring-vectorize.md
@@ -1,0 +1,51 @@
+# .assertIdVector rejects empty, NA, or non-character ids
+
+    Code
+      .assertIdVector(character(0))
+    Condition
+      Error:
+      ! `id` must be a non-empty character vector with no NA or empty element.
+
+---
+
+    Code
+      .assertIdVector(c("a", NA))
+    Condition
+      Error:
+      ! `id` must be a non-empty character vector with no NA or empty element.
+
+---
+
+    Code
+      .assertIdVector(c("a", ""))
+    Condition
+      Error:
+      ! `id` must be a non-empty character vector with no NA or empty element.
+
+---
+
+    Code
+      .assertIdVector(1:3)
+    Condition
+      Error:
+      ! `id` must be a non-empty character vector with no NA or empty element.
+
+# .recycleField aborts on a length that is neither 1 nor N
+
+    Code
+      .recycleField(c("a", "b"), 3L, "weight")
+    Condition
+      Error:
+      ! `weight` must be length 1 or length 3 (the number of ids).
+      x It is length 2.
+
+# .alignAuthoringArgs propagates a length error naming the field
+
+    Code
+      .alignAuthoringArgs(id = c("a", "b", "c"), scalarFields = list(weight = c(60,
+        70)))
+    Condition
+      Error:
+      ! `weight` must be length 1 or length 3 (the number of ids).
+      x It is length 2.
+

--- a/tests/testthat/_snaps/entity-files-sections.md
+++ b/tests/testthat/_snaps/entity-files-sections.md
@@ -1,0 +1,61 @@
+# a definitions/<kind>/ path that is a file aborts the load
+
+    Code
+      loadProject(jsonPath)
+    Condition
+      Error in `.assertEntityTreePathIsDir()`:
+      ! Project entity path '<project>/definitions/individuals' exists but is not a directory.
+      x 'definitions/individuals' must be a directory of entity files.
+      i A regular file here is a corrupted or mis-synced project tree.
+
+# a definitions/ root that is a file aborts the load
+
+    Code
+      loadProject(jsonPath)
+    Condition
+      Error in `.assertEntityTreePathIsDir()`:
+      ! Project entity path '<project>/definitions' exists but is not a directory.
+      x 'definitions' must be a directory of entity files.
+      i A regular file here is a corrupted or mis-synced project tree.
+
+# a keyed file missing its id field aborts naming the file
+
+    Code
+      loadProject(jsonPath)
+    Condition
+      Error in `.keyedTreeRecordId()`:
+      ! An entity file for kind individual has no usable individualId.
+      x individualId must be a single non-empty string (it names the entity and its file).
+      i Check '<project>/definitions/individuals/adult_male.json'.
+
+# a keyed file whose inner id disagrees with its filename aborts
+
+    Code
+      loadProject(jsonPath)
+    Condition
+      Error in `.keyedTreeRecordId()`:
+      ! An entity file for kind outputPath has a stored id that disagrees with its filename.
+      x id is "different" but the file is "aciclovir_fat_cell".json.
+      i The filename stem is the entity's id; rename the file or the id so they match. Check '<project>/definitions/output-paths/aciclovir_fat_cell.json'.
+
+# two files with the same inner id cannot silently collapse
+
+    Code
+      loadProject(jsonPath)
+    Condition
+      Error in `.keyedTreeRecordId()`:
+      ! An entity file for kind outputPath has a stored id that disagrees with its filename.
+      x id is "aciclovir_fat_cell" but the file is "duplicate".json.
+      i The filename stem is the entity's id; rename the file or the id so they match. Check '<project>/definitions/output-paths/duplicate.json'.
+
+# an empty-object scalar field on a non-scenario kind aborts the load
+
+    Code
+      loadProject(jsonPath)
+    Condition
+      Error in `.assertNoEmptyObjectFields()`:
+      ! An entity of kind individual has an invalid species.
+      x species is an empty object `{}` where a single value or `null` was expected.
+      i A hand-edit that turned `"species": null` into `{}` (the usual jsonlite round-trip) is the usual cause; restore the value or remove the field.
+      i Check '<project>/definitions/individuals/adult_male.json'.
+

--- a/tests/testthat/_snaps/entity-files.md
+++ b/tests/testthat/_snaps/entity-files.md
@@ -1,0 +1,138 @@
+# addScenario canonicalizes its id to a safe, lowercase form
+
+    Code
+      addScenario(project, "My/Scenario", modelFile = "Aciclovir.pkml")
+    Condition
+      Warning:
+      Canonicalized 1 id to a safe form:
+      * "My/Scenario" -> "my_scenario"
+
+# a scenarioName that disagrees with its list key aborts the write
+
+    Code
+      project$.setSection("scenarios", scenarios)
+    Condition
+      Error in `.validateScenarioStructure()`:
+      ! Scenario scenarioName "testscenario" does not match the key "renamed" it is stored under.
+      i Store a scenario under a key equal to its scenarioName (or leave scenarioName unset).
+
+# a write-back under a non-canonical key aborts the write
+
+    Code
+      project$.setSection("scenarios", scenarios)
+    Condition
+      Error in `.validateScenarioStructure()`:
+      ! Scenario id "Renamed" is not a canonical entity-file id.
+      i Use `addScenario(project, "Renamed", ...)`, which canonicalizes it to "renamed", or store the scenario under the key "renamed".
+
+# a scenario id with path separators is canonicalized, not rejected
+
+    Code
+      addScenario(project, "../escape", modelFile = "Aciclovir.pkml")
+    Condition
+      Warning:
+      Canonicalized 1 id to a safe form:
+      * "../escape" -> "_escape"
+
+---
+
+    Code
+      addScenario(project, "sub/evil", modelFile = "Aciclovir.pkml")
+    Condition
+      Warning:
+      Canonicalized 1 id to a safe form:
+      * "sub/evil" -> "sub_evil"
+
+# saveSnapshot refuses to overwrite the project's own container
+
+    Code
+      saveSnapshot(project)
+    Condition
+      Error in `saveSnapshot()`:
+      ! A snapshot is a derived artifact and must be written to a location other than the project's own jsonPath.
+      i Pass a `path` to a different file. The authoritative 'definitions/' tree and 'Project.json' container are already write-through, so there is nothing to save in place.
+
+---
+
+    Code
+      saveSnapshot(project, project$jsonPath)
+    Condition
+      Error in `saveSnapshot()`:
+      ! A snapshot is a derived artifact and must be written to a location other than the project's own jsonPath.
+      i Pass a `path` to a different file. The authoritative 'definitions/' tree and 'Project.json' container are already write-through, so there is nothing to save in place.
+
+# structural validation rejects a serializer-hostile scenario
+
+    Code
+      .validateScenarioStructure(sc, "ss")
+    Condition
+      Error in `.validateScenarioStructure()`:
+      ! Scenario "ss" has simulateSteadyState=TRUE but steadyStateTimeUnit is NULL.
+      i Set steadyStateTimeUnit (e.g. "min") so the steady-state time can round-trip.
+
+---
+
+    Code
+      .validateScenarioStructure(bad, "op")
+    Condition
+      Error in `.validateScenarioStructure()`:
+      ! Scenario "op" has outputPaths without ids.
+      i Expected a named character vector: id-as-name, literal-path-as-value.
+
+# an id differing only in case canonicalizes to an existing id
+
+    Code
+      addScenario(project, "MyScenario", modelFile = "Aciclovir.pkml")
+    Condition
+      Warning:
+      Canonicalized 1 id to a safe form:
+      * "MyScenario" -> "myscenario"
+
+---
+
+    Code
+      addScenario(project, "myscenario", modelFile = "Aciclovir.pkml")
+    Condition
+      Error in `addScenario()`:
+      ! scenario "myscenario" already exists
+
+# a scenario file missing its name aborts naming the file
+
+    Code
+      loadProject(project$jsonPath)
+    Condition
+      Error in `.keyedTreeRecordId()`:
+      ! An entity file for kind scenario has no usable name.
+      x name must be a single non-empty string (it names the entity and its file).
+      i Check '<project>/definitions/scenarios/populationscenario.json'.
+
+# a scenario file whose name disagrees with its filename aborts
+
+    Code
+      loadProject(project$jsonPath)
+    Condition
+      Error in `.keyedTreeRecordId()`:
+      ! An entity file for kind scenario has a stored name that disagrees with its filename.
+      x name is "differentname" but the file is "populationscenario".json.
+      i The filename stem is the entity's id; rename the file or the name so they match. Check '<project>/definitions/scenarios/populationscenario.json'.
+
+# a non-scalar scalar field fails load naming the scenario and field
+
+    Code
+      loadProject(project$jsonPath)
+    Condition
+      Error in `.assertScalarScenarioField()`:
+      ! Scenario "populationscenario" has an invalid population.
+      i Expected a single string or `null`; check 'definitions/scenarios/populationscenario.json'.
+      i A hand-edit that turned `"population": null` into an empty object `{}` is the usual cause.
+
+# a tree-loaded initialConditions id must match its filename stem
+
+    Code
+      spec$parse(list(rec), NULL)
+    Condition
+      Error in `.keyedTreeRecordId()`:
+      ! An entity file for kind initialConditionSet has a stored id that disagrees with its filename.
+      x id is "myset" but the file is "otherset".json.
+      i The filename stem is the entity's id; rename the file or the id so they match. Check 'somewhere/otherset.json'.
+

--- a/tests/testthat/_snaps/entity-id.md
+++ b/tests/testthat/_snaps/entity-id.md
@@ -1,0 +1,59 @@
+# .canonicalizeId warns naming each changed id
+
+    Code
+      out <- .canonicalizeId("My ID*")
+    Condition
+      Warning:
+      Canonicalized 1 id to a safe form:
+      * "My ID*" -> "my id_"
+
+# .canonicalizeId errors on a post-canonicalization collision
+
+    Code
+      .canonicalizeId(c("ID", "id"))
+    Condition
+      Warning:
+      Canonicalized 1 id to a safe form:
+      * "ID" -> "id"
+      Error in `.canonicalizeId()`:
+      ! Ids collide after canonicalization:
+      x "ID" and "id" -> "id"
+      i Two distinct ids that canonicalize to the same id are ambiguous; rename so they differ by more than case or forbidden characters.
+
+---
+
+    Code
+      .canonicalizeId(c("a/b", "a:b"))
+    Condition
+      Warning:
+      Canonicalized 2 ids to a safe form:
+      * "a/b" -> "a_b"
+      * "a:b" -> "a_b"
+      Error in `.canonicalizeId()`:
+      ! Ids collide after canonicalization:
+      x "a/b" and "a:b" -> "a_b"
+      i Two distinct ids that canonicalize to the same id are ambiguous; rename so they differ by more than case or forbidden characters.
+
+# a public authoring call aborts on a case-differing id collision
+
+    Code
+      addIndividual(project, c("Foo", "foo"), species = "Human", gender = "MALE")
+    Condition
+      Warning:
+      Canonicalized 1 id to a safe form:
+      * "Foo" -> "foo"
+      Error in `.canonicalizeId()`:
+      ! Ids collide after canonicalization:
+      x "Foo" and "foo" -> "foo"
+      i Two distinct ids that canonicalize to the same id are ambiguous; rename so they differ by more than case or forbidden characters.
+
+# .canonicalizeId errors on an id too long to be a filename
+
+    Code
+      .canonicalizeId(longId)
+    Condition
+      Error in `FUN()`:
+      ! Entity id is too long to be a safe filename: 300 bytes (limit 250).
+      x "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      i An id becomes the file '<id>.json'; shorten it to at most 250 bytes.
+

--- a/tests/testthat/_snaps/individuals.md
+++ b/tests/testthat/_snaps/individuals.md
@@ -1,18 +1,109 @@
 # addIndividual aborts when individualId already exists
 
     Code
-      addIndividual(project, "Indiv1", species = "Human", gender = "MALE")
+      addIndividual(project, "indiv1", species = "Human", gender = "MALE")
     Condition
       Error in `addIndividual()`:
-      ! Cannot add individual "Indiv1":
-      x individual 'Indiv1' already exists
+      ! individual "indiv1" already exists
 
 # addIndividual aborts when gender is missing
 
     Code
-      addIndividual(project, "NewI", species = "Human")
+      addIndividual(project, "newi", species = "Human")
     Condition
       Error in `addIndividual()`:
-      ! Cannot add individual "NewI":
+      ! Cannot add individual "newi":
       x gender must be a non-empty string
+
+# setIndividual aborts on a non-existent individual
+
+    Code
+      setIndividual(project, "Ghost", weight = 80)
+    Condition
+      Warning:
+      Canonicalized 1 id to a safe form:
+      * "Ghost" -> "ghost"
+      Error in `setIndividual()`:
+      ! Cannot modify individual "ghost": it does not exist.
+      i Use `addIndividual()` to create it first.
+
+# setIndividual rejects an empty gender like addIndividual
+
+    Code
+      setIndividual(project, "indiv1", gender = "")
+    Condition
+      Error in `setIndividual()`:
+      ! `gender` must be a non-empty string
+
+# setIndividual rejects parameterSets that do not resolve
+
+    Code
+      setIndividual(project, "indiv1", parameterSets = "Ghost")
+    Condition
+      Warning:
+      Canonicalized 1 referenced id to a safe form:
+      * "Ghost" -> "ghost"
+      Error in `setIndividual()`:
+      ! `parameterSets` references undefined parameter sets:
+      x "ghost"
+
+# setIndividualParameterSets aborts on an undefined parameter set
+
+    Code
+      setIndividualParameterSets(project, "indiv1", "Ghost")
+    Condition
+      Warning:
+      Canonicalized 1 referenced id to a safe form:
+      * "Ghost" -> "ghost"
+      Error in `setIndividual()`:
+      ! `parameterSets` references undefined parameter sets:
+      x "ghost"
+
+# addIndividual aborts on a mismatched scalar field length
+
+    Code
+      addIndividual(project, c("a", "b", "c"), species = "Human", gender = c("MALE",
+        "FEMALE"))
+    Condition
+      Error in `addIndividual()`:
+      ! `gender` must be length 1 or length 3 (the number of ids).
+      x It is length 2.
+
+# addIndividual aborts on a duplicate id in the batch
+
+    Code
+      addIndividual(project, c("a", "a"), species = "Human", gender = "MALE")
+    Condition
+      Error in `.canonicalizeId()`:
+      ! Ids collide after canonicalization:
+      x "a" -> "a"
+      i Two distinct ids that canonicalize to the same id are ambiguous; rename so they differ by more than case or forbidden characters.
+
+# print.Individual renders the configured fields
+
+    Code
+      print(project$individuals[["indiv1"]])
+    Output
+      <Individual>
+        * Species: Human
+        * Population: European_ICRP_2002
+        * Gender: MALE
+        * Weight: 73
+        * Height: 176
+        * Age: 30
+        * Parameter Sets: indiv1_default
+
+# print.Individual renders a minimal individual
+
+    Code
+      print(project$individuals[["minimal"]])
+    Output
+      <Individual>
+        * Species: Human
+        * Population: <empty string>
+        * Gender: MALE
+        * Weight: <empty string>
+        * Height: <empty string>
+        * Age: <empty string>
+        * Parameter Sets: <empty string>
 

--- a/tests/testthat/_snaps/observed-data.md
+++ b/tests/testthat/_snaps/observed-data.md
@@ -40,3 +40,25 @@
       Error in `addObservedData()`:
       ! observedData entry with file "Aciclovir_TimeValuesData.xlsx" already exists
 
+# observedData declarations sharing a basename fail the write-through
+
+    Code
+      project$.setSection("observedData", colliding)
+    Condition
+      Error in `.serializeObservedDataSet()`:
+      ! Two observedData declarations map to the same entity file 'obs.pkml.json'.
+      x The on-disk id is the file basename (or the programmatic name), so two sources sharing a basename collide.
+      i Rename one source so the basenames differ.
+
+# print.ObservedDataSource renders the source declaration
+
+    Code
+      print(project$observedData[[1]])
+    Output
+      <ObservedDataSource>
+        * Type: excel
+        * File: Aciclovir_TimeValuesData.xlsx
+        * Name: <empty string>
+        * Importer Configuration: esqlabs_dataImporter_configuration.xml
+        * Sheets: Laskin 1982.Group A
+

--- a/tests/testthat/_snaps/output-paths.md
+++ b/tests/testthat/_snaps/output-paths.md
@@ -4,6 +4,34 @@
       addOutputPath(project, existing, "Organism|other|Concentration in container")
     Condition
       Error in `addOutputPath()`:
+      ! outputPath "aciclovir_fat_cell" already exists
+
+# setOutputPath aborts on a non-existent id
+
+    Code
+      setOutputPath(project, "Ghost", "Organism|A|Concentration in container")
+    Condition
+      Warning:
+      Canonicalized 1 id to a safe form:
+      * "Ghost" -> "ghost"
+      Error in `setOutputPath()`:
+      ! Cannot modify output path "ghost": it does not exist.
+      i Use `addOutputPath()` to create it first.
+
+# setOutputPath rejects an empty path
+
+    Code
+      setOutputPath(project, id, "")
+    Condition
+      Error in `setOutputPath()`:
+      ! `path` must contain non-empty strings
+
+# addOutputPath aborts on a path length that is neither 1 nor N
+
+    Code
+      addOutputPath(project, c("a", "b", "c"), c("X", "Y"))
+    Condition
+      Error in `addOutputPath()`:
       ! Cannot add outputPath:
-      x outputPath id already exists: Aciclovir_PVB
+      x path must be a character vector of length 1 or the same length as id
 

--- a/tests/testthat/_snaps/parameters.md
+++ b/tests/testthat/_snaps/parameters.md
@@ -1,0 +1,211 @@
+# addParameterSet canonicalizes its id
+
+    Code
+      addParameterSet(project, "New Set")
+    Condition
+      Warning:
+      Canonicalized 1 id to a safe form:
+      * "New Set" -> "new set"
+
+# addParameterSet aborts on a duplicate id
+
+    Code
+      addParameterSet(project, "global")
+    Condition
+      Error in `addParameterSet()`:
+      ! parameter set "global" already exists
+
+# addParameterEntry creates the set on demand and appends entries
+
+    Code
+      addParameterEntry(project, "tempset", "Organism|A", "K", 1.5, "1/h")
+    Message
+      Created parameter set "tempset" on demand to hold the new entry.
+
+# addParameterEntry aborts on mismatched vector lengths
+
+    Code
+      addParameterEntry(project, "set", containerPath = c("Organism|A", "Organism|B"),
+      parameterName = "K", value = c(1, 2), units = "1/h")
+    Condition
+      Error in `.assertParameterEntryVectorLengths()`:
+      ! `containerPath`, `parameterName`, `value`, and `units` must be vectors of the same length.
+      x Got lengths 2, 1, 2, and 1.
+
+# removeParameterSet warns when still referenced by a scenario, removes anyway
+
+    Code
+      removeParameterSet(project, "global")
+    Condition
+      Warning:
+      Removed parameterSet "global" is still referenced by 4 entities:
+      * scenario 'populationscenario', scenario 'populationscenariofromcsv', scenario 'testscenario', and scenario 'testscenario_steadystate'
+      i These now have a dangling reference. Update or remove them.
+
+# removeParameterSet warns when still referenced by an individual, removes anyway
+
+    Code
+      removeParameterSet(project, "indiv1_default")
+    Condition
+      Warning:
+      Removed parameterSet "indiv1_default" is still referenced by 1 entity:
+      * individual 'indiv1'
+      i These now have a dangling reference. Update or remove them.
+
+# print.ParameterSet renders the entry count and a compact table
+
+    Code
+      print(project$parameterSets[["global"]])
+    Output
+      <ParameterSet>
+        * Number of Entries: 1
+        * Organism|Liver|EHC continuous fraction = 1
+
+# print.ParameterSet renders an empty set
+
+    Code
+      print(project$parameterSets[["emptyset"]])
+    Output
+      <ParameterSet>
+        * Number of Entries: 0
+
+# addInitialConditions canonicalizes its id
+
+    Code
+      addInitialConditions(project, "New Set")
+    Condition
+      Warning:
+      Canonicalized 1 id to a safe form:
+      * "New Set" -> "new set"
+
+# addInitialConditions aborts on a duplicate id
+
+    Code
+      addInitialConditions(project, "dupset")
+    Condition
+      Error in `addInitialConditions()`:
+      ! initial-condition set "dupset" already exists
+
+# addInitialConditionEntry creates the set on demand and appends
+
+    Code
+      addInitialConditionEntry(project, "tempset", "Organism|A", 1.5, "mg/l")
+    Message
+      Created initial-condition set "tempset" on demand to hold the new entry.
+
+# addInitialConditionEntry aborts on mismatched vector lengths
+
+    Code
+      addInitialConditionEntry(project, "set", path = c("Organism|A", "Organism|B"),
+      value = 1, unit = "mg/l")
+    Condition
+      Error in `.assertInitialConditionEntryVectorLengths()`:
+      ! `path`, `value`, and `unit` must be vectors of the same length.
+      x Got lengths 2, 1, and 1.
+
+# addInitialConditionEntry aborts on a blank unit (units are mandatory)
+
+    Code
+      addInitialConditionEntry(project, "set", "Organism|A", 1.5, "")
+    Message
+      Created initial-condition set "set" on demand to hold the new entry.
+    Condition
+      Error in `.addInitialConditionEntry()`:
+      ! Invalid initial-condition entry:
+      x unit must be a non-empty string
+
+# removeInitialConditions warns when still referenced by a scenario, removes anyway
+
+    Code
+      removeInitialConditions(project, "refset")
+    Condition
+      Warning:
+      Removed initialConditions "refset" is still referenced by 1 scenario:
+      * scenario 'testscenario'
+      i These now have a dangling reference. Update or remove them.
+
+# print.InitialConditionSet renders the entry count and a compact table
+
+    Code
+      print(project$initialConditions[["printset"]])
+    Output
+      <InitialConditionSet>
+        * Number of Entries: 2
+        * Organism|A = 1.5 [mg/l]
+        * Organism|B = 0.5 [µmol/l]
+
+# print.InitialConditionSet renders a unit-less entry
+
+    Code
+      print(set)
+    Output
+      <InitialConditionSet>
+        * Number of Entries: 1
+        * Organism|A = 1.5
+
+# print.InitialConditionSet renders an empty set
+
+    Code
+      print(project$initialConditions[["emptyset"]])
+    Output
+      <InitialConditionSet>
+        * Number of Entries: 0
+
+# `readInitialConditionsFromXLS()` warns and overwrites a path repeated across sheets
+
+    Code
+      initialValues <- readInitialConditionsFromXLS(filePath = initialConditionsXLSpath,
+        sheets = c("ValidSheet", "SecondSheet"))
+    Condition
+      Warning in `readInitialConditionsFromXLS()`:
+      ! Duplicate molecule path(s) in initial values file 'data/InitialConditions.xlsx': "Organism|Liver|A". Only the last value defined for each path is used.
+
+# `readInitialConditionsFromXLS()` errors when units are missing for a present molecule
+
+    Code
+      readInitialConditionsFromXLS(filePath = initialConditionsXLSpath, sheets = "MissingUnits")
+    Condition
+      Error in `readInitialConditionsFromXLS()`:
+      x Missing units in initial values file 'data/InitialConditions.xlsx' for molecule(s): "Organism|Liver|A". Units must be specified for all molecule initial values.
+
+# `readInitialConditionsFromXLS()` errors when a value is missing for a present molecule
+
+    Code
+      readInitialConditionsFromXLS(filePath = initialConditionsXLSpath, sheets = "MissingValue")
+    Condition
+      Error in `readInitialConditionsFromXLS()`:
+      x Missing or non-numeric values in initial values file 'data/InitialConditions.xlsx' for molecule(s): "Organism|Liver|A". A numeric value must be specified for all present molecules.
+
+# `readInitialConditionsFromXLS()` errors on a non-logical 'Is Present' value
+
+    Code
+      readInitialConditionsFromXLS(filePath = initialConditionsXLSpath, sheets = "BadIsPresent")
+    Condition
+      Error in `readInitialConditionsFromXLS()`:
+      x Invalid 'Is Present' values in initial values file 'data/InitialConditions.xlsx' for molecule(s): "Organism|Liver|A". 'Is Present' must be a logical value (TRUE/FALSE), numeric 1/0 (present/not present), or empty.
+
+# `readInitialConditionsFromXLS()` warns and keeps the last value for a duplicate path
+
+    Code
+      initialValues <- readInitialConditionsFromXLS(filePath = initialConditionsXLSpath,
+        sheets = "DuplicatePath")
+    Condition
+      Warning in `readInitialConditionsFromXLS()`:
+      ! Duplicate molecule path(s) in initial values file 'data/InitialConditions.xlsx': "Organism|Liver|A". Only the last value defined for each path is used.
+
+# `readInitialConditionsFromXLS()` errors when a present row has a blank container path
+
+    Code
+      readInitialConditionsFromXLS(filePath = initialConditionsXLSpath, sheets = "BlankPath")
+    Condition
+      Error in `readInitialConditionsFromXLS()`:
+      x Missing Container Path or Molecule Name in initial values file 'data/InitialConditions.xlsx', sheet "BlankPath", data row(s): "1".
+
+# `readInitialConditionsFromXLS()` errors when a sheet has the wrong structure
+
+    Code
+      readInitialConditionsFromXLS(filePath = initialConditionsXLSpath, sheets = "InvalidSheet")
+    Condition
+      Error in `readInitialConditionsFromXLS()`:
+      x Loading from XLS failed, the file 'data/InitialConditions.xlsx' has wrong structure!  The file should contain columns "Container Path, Molecule Name, Is Present, Value, Units, Scale Divisor, Neg. Values Allowed".
+

--- a/tests/testthat/_snaps/populations.md
+++ b/tests/testthat/_snaps/populations.md
@@ -263,3 +263,69 @@
       Error in `extendPopulationFromXLS()`:
       ! x The specified excel sheet does not contain any complete row * Please fill all the columns and try again.
 
+# setPopulation aborts on a non-existent population
+
+    Code
+      setPopulation(project, "Ghost", numberOfIndividuals = 10)
+    Condition
+      Warning:
+      Canonicalized 1 id to a safe form:
+      * "Ghost" -> "ghost"
+      Error in `setPopulation()`:
+      ! Cannot modify population "ghost": it does not exist.
+      i Use `addPopulation()` to create it first.
+
+# setPopulation rejects a non-positive numberOfIndividuals
+
+    Code
+      setPopulation(project, "testpopulation", numberOfIndividuals = 0)
+    Condition
+      Error in `setPopulation()`:
+      ! `numberOfIndividuals` must be a positive number
+
+# addPopulation aborts on a mismatched scalar field length
+
+    Code
+      addPopulation(project, c("a", "b", "c"), species = "Human",
+      numberOfIndividuals = c(5, 7))
+    Condition
+      Error in `addPopulation()`:
+      ! `numberOfIndividuals` must be length 1 or length 3 (the number of ids).
+      x It is length 2.
+
+# removePopulation warns when still referenced by a scenario, removes anyway
+
+    Code
+      removePopulation(project, "testpopulation")
+    Condition
+      Warning:
+      Removed population "testpopulation" is still referenced by 2 scenarios:
+      * populationscenario and populationscenariofromcsv
+      i These scenarios now have a dangling reference. Update or remove them.
+
+# print.Population renders the configured fields
+
+    Code
+      print(project$populations[["testpopulation"]])
+    Output
+      <Population>
+        * Species: Human
+        * Number of Individuals: 2
+        * Proportion of Females: 0
+        * Age Range: 18 - 65
+        * Weight Range: <empty string>
+        * Height Range: <empty string>
+
+# print.Population renders a minimal population
+
+    Code
+      print(project$populations[["minimal"]])
+    Output
+      <Population>
+        * Species: Human
+        * Number of Individuals: 10
+        * Proportion of Females: <empty string>
+        * Age Range: <empty string>
+        * Weight Range: <empty string>
+        * Height Range: <empty string>
+

--- a/tests/testthat/_snaps/project-lifecycle.md
+++ b/tests/testthat/_snaps/project-lifecycle.md
@@ -1,11 +1,3 @@
-# saveProject errors when project has no jsonPath and path is NULL
-
-    Code
-      saveProject(project)
-    Condition
-      Error in `saveProject()`:
-      ! No `path` specified and the project has no jsonPath. Provide a `path` to save the project for the first time.
-
 # initProject aborts non-interactively when a project exists and overwrite = FALSE
 
     Code

--- a/tests/testthat/_snaps/project.md
+++ b/tests/testthat/_snaps/project.md
@@ -1,3 +1,44 @@
+# a whole-section assignment through a section accessor is rejected
+
+    Code
+      project$scenarios <- list()
+    Condition
+      Error:
+      ! scenarios is read-only and cannot be assigned into.
+      i To change a definition, edit its '.json' file or use an authoring function (e.g. `addScenario()` / `setScenario()` / `removeScenario()` and their per-section siblings).
+      i To edit one record, read it, change the copy, then re-submit it with an authoring function: `sc <- project$scenarios[["id"]]; sc$field <- value; setScenario(project, "id", ...)`.
+
+# a subscript assignment through a section accessor is rejected
+
+    Code
+      project$scenarios[["aciclovir_iv"]] <- Scenario(scenarioName = "aciclovir_iv",
+        modelFile = "m.pkml")
+    Condition
+      Error in `[[<-`:
+      ! scenarios is read-only and cannot be assigned into.
+      i To change a definition, edit its '.json' file or use an authoring function (e.g. `addScenario()` / `setScenario()` / `removeScenario()` and their per-section siblings).
+      i To edit one record, read it, change the copy, then re-submit it with an authoring function: `sc <- project$scenarios[["id"]]; sc$field <- value; setScenario(project, "id", ...)`.
+
+# a nested field assignment through a section accessor is rejected
+
+    Code
+      project$scenarios[["testscenario"]]$individualId <- "indiv1"
+    Condition
+      Error in `[[<-`:
+      ! scenarios is read-only and cannot be assigned into.
+      i To change a definition, edit its '.json' file or use an authoring function (e.g. `addScenario()` / `setScenario()` / `removeScenario()` and their per-section siblings).
+      i To edit one record, read it, change the copy, then re-submit it with an authoring function: `sc <- project$scenarios[["id"]]; sc$field <- value; setScenario(project, "id", ...)`.
+
+# a negative-index assignment through a section accessor is rejected
+
+    Code
+      project$scenarios[-1] <- list()
+    Condition
+      Error in `[<-`:
+      ! scenarios is read-only and cannot be assigned into.
+      i To change a definition, edit its '.json' file or use an authoring function (e.g. `addScenario()` / `setScenario()` / `removeScenario()` and their per-section siblings).
+      i To edit one record, read it, change the copy, then re-submit it with an authoring function: `sc <- project$scenarios[["id"]]; sc$field <- value; setScenario(project, "id", ...)`.
+
 # jsonPath is read-only and aliases projectFilePath
 
     Code
@@ -5,4 +46,60 @@
     Condition
       Error:
       ! jsonPath is readonly
+
+# a section accessor prints a count and the definition names
+
+    Code
+      print(project$individuals)
+    Output
+      <DefinitionList>
+      individuals (1 definition):
+        * indiv1
+
+---
+
+    Code
+      print(project$parameterSets)
+    Output
+      <DefinitionList>
+      parameterSets (4 definitions):
+        * aciclovir
+        * aciclovir_iv_250mg_default
+        * global
+        * indiv1_default
+
+# an empty section accessor prints zero definitions
+
+    Code
+      print(project$individuals)
+    Output
+      <DefinitionList>
+      individuals (0 definitions):
+
+# the three plots sections each print a count and ids
+
+    Code
+      print(project$plots)
+    Output
+      <DefinitionList>
+      plots (1 definition):
+        * p1
+
+---
+
+    Code
+      print(project$plotGrids)
+    Output
+      <DefinitionList>
+      plotGrids (1 definition):
+        * individual_diagnostics
+
+---
+
+    Code
+      print(project$dataCombined)
+    Output
+      <DefinitionList>
+      dataCombined (1 definition):
+        * aciclovir_individual
 

--- a/tests/testthat/_snaps/scenario-execution.md
+++ b/tests/testthat/_snaps/scenario-execution.md
@@ -1,9 +1,9 @@
 # a relative modelFile with NULL modelFolder aborts with a clear message
 
     Code
-      esqlabsR:::.runScenariosFromProject(project, scenarioNames = "TestScenario",
+      esqlabsR:::.runScenariosFromProject(project, scenarioNames = "testscenario",
         validate = FALSE)
     Condition
       Error in `.prepareScenario()`:
-      ! x Cannot resolve the model file for scenario "TestScenario". i modelFile "Aciclovir.pkml" is relative but the project has no modelFolder to resolve it against.
+      ! x Cannot resolve the model file for scenario "testscenario". i modelFile "Aciclovir.pkml" is relative but the project has no modelFolder to resolve it against.
 

--- a/tests/testthat/_snaps/scenario-from-pkml.md
+++ b/tests/testthat/_snaps/scenario-from-pkml.md
@@ -1,65 +1,70 @@
-# createScenariosFromPKML adds scenarios in place, marks the project modified, and returns it invisibly
+# createScenariosFromPKML adds scenarios in place and returns the project invisibly
 
     Code
-      result <- createScenariosFromPKML(pkmlFixture, project = project,
-        scenarioNames = "Seeded")
+      result <- createScenariosFromPKML(pkmlFixture, project = project, scenarios = "seeded")
     Message
-      i Added 1 scenario: "Seeded"
+      i Added 1 scenario: "seeded"
 
 # user alias ignored in favour of registered id emits an inform
 
     Code
-      createScenariosFromPKML(pkmlFixture, project = project, scenarioNames = "Seeded",
+      createScenariosFromPKML(pkmlFixture, project = project, scenarios = "seeded",
         outputPaths = stats::setNames(existingPath, "myAlias"))
     Message
-      i Output path alias "myAlias" ignored: path "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)" is already registered as "Aciclovir_PVB".
-      i Added 1 scenario: "Seeded"
+      i Output path alias "myAlias" ignored: path "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)" is already registered as "aciclovir_pvb".
+      i Added 1 scenario: "seeded"
 
 # named outputPaths colliding with an existing id mapped to a different path abort and leave the project unchanged
 
     Code
-      createScenariosFromPKML(pkmlFixture, project = project, scenarioNames = "Seeded",
-        outputPaths = c(Aciclovir_PVB = "Organism|Some|Other|Path"))
+      createScenariosFromPKML(pkmlFixture, project = project, scenarios = "seeded",
+        outputPaths = c(aciclovir_pvb = "Organism|Some|Other|Path"))
     Condition
       Error in `.resolveScenarioOutputPaths()`:
-      ! x Output path id "Aciclovir_PVB" already maps to a different path. i Existing: "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)" i Requested: "Organism|Some|Other|Path"
+      ! x Output path id "aciclovir_pvb" already maps to a different path. i Existing: "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)" i Requested: "Organism|Some|Other|Path"
 
-# unknown modelParameterSets abort and leave the project unchanged
-
-    Code
-      createScenariosFromPKML(pkmlFixture, project = project, scenarioNames = "Seeded",
-        modelParameterSets = "DoesNotExist")
-    Condition
-      Error in `addScenario()`:
-      ! Cannot add scenario "Seeded":
-      x modelParameterSets not found in project$modelParameterSets: DoesNotExist
-
-# unknown applicationProtocols abort
+# unknown parameterSets abort and leave the project unchanged
 
     Code
-      createScenariosFromPKML(pkmlFixture, project = project, scenarioNames = "Seeded",
-        applicationProtocols = "NoSuchProtocol")
+      createScenariosFromPKML(pkmlFixture, project = project, scenarios = "seeded",
+        parameterSets = "DoesNotExist")
     Condition
+      Warning:
+      Canonicalized 1 referenced id to a safe form:
+      * "DoesNotExist" -> "doesnotexist"
       Error in `addScenario()`:
-      ! Cannot add scenario "Seeded":
-      x applicationProtocol 'NoSuchProtocol' not found in applications
+      ! Cannot add scenario "seeded":
+      x parameterSets not found in project$parameterSets: doesnotexist
+
+# an unknown application aborts
+
+    Code
+      createScenariosFromPKML(pkmlFixture, project = project, scenarios = "seeded",
+        application = "NoSuchProtocol")
+    Condition
+      Warning:
+      Canonicalized 1 referenced id to a safe form:
+      * "NoSuchProtocol" -> "nosuchprotocol"
+      Error in `addScenario()`:
+      ! Cannot add scenario "seeded":
+      x application 'nosuchprotocol' not found in applications
 
 # duplicate scenario names are expanded with numeric suffixes
 
     Code
       createScenariosFromPKML(c(pkmlFixture, pkmlFixture), project = project,
-      scenarioNames = c("S", "S"))
+      scenarios = c("s", "s"))
     Condition
       Warning:
-      Duplicate scenario names found and made unique by adding indices: i Duplicated names: "S", renamed to "S_2"
+      Duplicate scenario names found and made unique by adding indices: i Duplicated names: "s", renamed to "s_2"
     Message
-      i Added 2 scenarios: "S" and "S_2"
+      i Added 2 scenarios: "s" and "s_2"
 
 # NULL modelFolder falls back to the absolute pkml path with a warning
 
     Code
       suppressMessages(createScenariosFromPKML(pkmlFixture, project = project,
-        scenarioNames = "Seeded"))
+        scenarios = "seeded"))
     Condition
       Warning:
       ! The project has no modelFolder; storing an absolute model file path. i Set a modelFolder on the project so the scenario stores a portable relative path ('data/TestProject/Models/Simulations/Aciclovir.pkml').
@@ -67,7 +72,7 @@
 # inconsistent vector argument lengths abort
 
     Code
-      createScenariosFromPKML(rep(pkmlFixture, 2), project = project, scenarioNames = c(
+      createScenariosFromPKML(rep(pkmlFixture, 2), project = project, scenarios = c(
         "A", "B", "C"))
     Condition
       Error in `.getScenarioCount()`:

--- a/tests/testthat/_snaps/scenarios.md
+++ b/tests/testthat/_snaps/scenarios.md
@@ -1,30 +1,168 @@
-# addScenario aborts when a referenced individualId is unknown
+# addScenario aborts when a referenced individual is unknown
 
     Code
-      addScenario(project, scenarioName = "Bad", modelFile = "Aciclovir.pkml",
-        individualId = "Ghost")
+      addScenario(project, id = "bad", modelFile = "Aciclovir.pkml", individual = "Ghost")
+    Condition
+      Warning:
+      Canonicalized 1 referenced id to a safe form:
+      * "Ghost" -> "ghost"
+      Error in `addScenario()`:
+      ! Cannot add scenario "bad":
+      x individual 'ghost' not found in individuals
+
+# addScenario aborts eagerly on a dangling initialConditions ref
+
+    Code
+      addScenario(project, id = "bad", modelFile = "Aciclovir.pkml",
+        initialConditions = "ghostset")
     Condition
       Error in `addScenario()`:
-      ! Cannot add scenario "Bad":
-      x individualId 'Ghost' not found in individuals
+      ! Cannot add scenario "bad":
+      x initialConditions not found in project$initialConditions: ghostset
+
+# setScenario aborts eagerly on a dangling initialConditions ref
+
+    Code
+      setScenario(project, "sc", initialConditions = "ghostset")
+    Condition
+      Error in `setScenario()`:
+      ! Cannot modify scenario "sc":
+      x initialConditions not found in project$initialConditions: ghostset
 
 # addScenario rejects NA-valued FK args
 
     Code
-      addScenario(project, scenarioName = "S", modelFile = "Aciclovir.pkml",
-        individualId = NA_character_)
+      addScenario(project, id = "S", modelFile = "Aciclovir.pkml", individual = NA_character_)
     Condition
+      Warning:
+      Canonicalized 1 id to a safe form:
+      * "S" -> "s"
       Error in `addScenario()`:
-      ! Cannot add scenario "S":
-      x individualId must be a non-empty string or NULL
+      ! Cannot add scenario "s":
+      x individual must be a non-empty string or NULL
 
 ---
 
     Code
-      addScenario(project, scenarioName = "S", modelFile = "Aciclovir.pkml",
-        outputPathIds = c("Output1", NA_character_))
+      addScenario(project, id = "S", modelFile = "Aciclovir.pkml", outputPaths = c(
+        "Output1", NA_character_))
+    Condition
+      Warning:
+      Canonicalized 1 id to a safe form:
+      * "S" -> "s"
+      Warning:
+      Canonicalized 1 referenced id to a safe form:
+      * "Output1" -> "output1"
+      Error in `addScenario()`:
+      ! Cannot add scenario "s":
+      x outputPaths must be a non-empty character vector with no NA or empty entries
+
+# setScenario aborts on a non-existent scenario, no file written
+
+    Code
+      setScenario(project, "Ghost", simulationTimeUnit = "min")
+    Condition
+      Warning:
+      Canonicalized 1 id to a safe form:
+      * "Ghost" -> "ghost"
+      Error in `setScenario()`:
+      ! Cannot modify scenario "ghost": it does not exist.
+      i Use `addScenario()` to create it first.
+
+# setScenario rejects an unknown foreign key like addScenario
+
+    Code
+      setScenario(project, "testscenario", individual = "Ghost")
+    Condition
+      Warning:
+      Canonicalized 1 referenced id to a safe form:
+      * "Ghost" -> "ghost"
+      Error in `setScenario()`:
+      ! Cannot modify scenario "testscenario":
+      x individual 'ghost' not found in individuals
+
+# renameScenario errors clearly on a non-existent id
+
+    Code
+      renameScenario(project, "Ghost", "renamed")
+    Condition
+      Warning:
+      Canonicalized 1 id to a safe form:
+      * "Ghost" -> "ghost"
+      Error in `renameScenario()`:
+      ! Cannot rename scenario "ghost": it does not exist.
+      i Available scenarios: "populationscenario", "populationscenariofromcsv", "testscenario", and "testscenario_steadystate"
+
+# renameScenario errors when the target id already exists
+
+    Code
+      renameScenario(project, "testscenario", "populationscenario")
+    Condition
+      Error in `renameScenario()`:
+      ! Cannot use "populationscenario": a scenario with that id already exists.
+
+# renameScenario canonicalizes newId, warning and landing on the canonical form
+
+    Code
+      renameScenario(project, "testscenario", "New Name")
+    Condition
+      Warning:
+      Canonicalized 1 id to a safe form:
+      * "New Name" -> "new name"
+
+# duplicateScenario errors on a non-existent source id
+
+    Code
+      duplicateScenario(project, "Ghost", "copy")
+    Condition
+      Warning:
+      Canonicalized 1 id to a safe form:
+      * "Ghost" -> "ghost"
+      Error in `duplicateScenario()`:
+      ! Cannot duplicate scenario "ghost": it does not exist.
+      i Available scenarios: "populationscenario", "populationscenariofromcsv", "testscenario", and "testscenario_steadystate"
+
+# duplicateScenario errors when the target id already exists
+
+    Code
+      duplicateScenario(project, "testscenario", "populationscenario")
+    Condition
+      Error in `duplicateScenario()`:
+      ! Cannot use "populationscenario": a scenario with that id already exists.
+
+# removeScenario warns when a dataCombined still references it
+
+    Code
+      removeScenario(project, "testscenario")
+    Condition
+      Warning:
+      Removed scenario "testscenario" is still referenced by 1 dataCombined definition:
+      * dc_ref
+      i These now have a dangling reference. Update or remove them.
+
+# addScenario aborts on a mismatched scalar field length
+
+    Code
+      addScenario(project, c("s1", "s2", "s3"), modelFile = c("A.pkml", "B.pkml"))
     Condition
       Error in `addScenario()`:
-      ! Cannot add scenario "S":
-      x outputPathIds must be a non-empty character vector with no NA or empty entries
+      ! `modelFile` must be length 1 or length 3 (the number of ids).
+      x It is length 2.
+
+# print.Scenario renders the configured fields
+
+    Code
+      print(project$scenarios[["testscenario"]])
+    Output
+      <Scenario>
+        * Name: testscenario
+        * Model: Aciclovir.pkml
+        * Type: Individual
+        * Individual: indiv1
+        * Population: <empty string>
+        * Protocol: aciclovir_iv_250mg
+        * Parameter Sets: global
+        * Initial Conditions: testinitialset
+        * Output Paths: 1
+        * Steady State: FALSE
 

--- a/tests/testthat/_snaps/snapshot.md
+++ b/tests/testthat/_snaps/snapshot.md
@@ -1,0 +1,9 @@
+# saveSnapshot refuses the own container path
+
+    Code
+      saveSnapshot(project, project$jsonPath)
+    Condition
+      Error in `saveSnapshot()`:
+      ! A snapshot is a derived artifact and must be written to a location other than the project's own jsonPath.
+      i Pass a `path` to a different file. The authoritative 'definitions/' tree and 'Project.json' container are already write-through, so there is nothing to save in place.
+

--- a/tests/testthat/test-applications.R
+++ b/tests/testthat/test-applications.R
@@ -2,14 +2,137 @@ test_that("addApplication + removeApplication round-trip leaves the section unch
   project <- testProject()
   before <- project$applications
 
-  addApplication(project, "NewApp")
-  expect_true("NewApp" %in% names(project$applications))
+  addApplication(project, "newapp")
+  expect_true("newapp" %in% names(project$applications))
 
-  removeApplication(project, "NewApp")
+  removeApplication(project, "newapp")
   expect_identical(project$applications, before)
 })
 
 test_that("removeApplication warns on missing key and is a no-op", {
   project <- testProject()
   expect_warning(removeApplication(project, "Ghost"), "not found")
+})
+
+test_that("removeApplication warns when still referenced by a scenario, removes anyway", {
+  project <- testProject()
+  withr::local_options(cli.unicode = FALSE)
+  # `aciclovir_iv_250mg` is the application referenced by every scenario in
+  # the fixture, so removing it leaves those scenarios with a dangling ref.
+  expect_snapshot(removeApplication(project, "aciclovir_iv_250mg"))
+  expect_false("aciclovir_iv_250mg" %in% names(project$applications))
+})
+
+# setApplicationParameterSets ----
+
+test_that("setApplicationParameterSets replaces the refs and persists to file", {
+  project <- testProject()
+  # The fixture application references one set; point it at a different
+  # existing set instead.
+  setApplicationParameterSets(project, "aciclovir_iv_250mg", "global")
+  expect_identical(
+    project$applications[["aciclovir_iv_250mg"]]$parameterSets,
+    "global"
+  )
+
+  # The write-through must reach disk.
+  reloaded <- loadProject(project$jsonPath)
+  expect_identical(
+    reloaded$applications[["aciclovir_iv_250mg"]]$parameterSets,
+    "global"
+  )
+})
+
+test_that("setApplicationParameterSets aborts on an undefined parameter set", {
+  project <- testProject()
+  before <- project$applications[["aciclovir_iv_250mg"]]
+  expect_snapshot(
+    error = TRUE,
+    setApplicationParameterSets(project, "aciclovir_iv_250mg", "Ghost")
+  )
+  expect_identical(project$applications[["aciclovir_iv_250mg"]], before)
+})
+
+# Vectorized authoring ----
+
+test_that("addApplication adds N protocols in one call equal to N scalar adds", {
+  vectorized <- testProject()
+  addApplication(vectorized, c("p1", "p2"), parameterSets = "global")
+
+  scalar <- testProject()
+  addApplication(scalar, "p1", parameterSets = "global")
+  addApplication(scalar, "p2", parameterSets = "global")
+
+  expect_identical(
+    vectorized$applications[c("p1", "p2")],
+    scalar$applications[c("p1", "p2")]
+  )
+})
+
+test_that("addApplication applies parameterSets whole to every protocol", {
+  project <- testProject()
+  addApplication(
+    project,
+    c("p1", "p2"),
+    parameterSets = c("global", "aciclovir")
+  )
+  expect_identical(
+    project$applications$p1$parameterSets,
+    c("global", "aciclovir")
+  )
+  expect_identical(
+    project$applications$p2$parameterSets,
+    c("global", "aciclovir")
+  )
+})
+
+test_that("addApplication aborts the whole batch and writes nothing on a bad reference", {
+  project <- testProject()
+  before <- names(project$applications)
+  expect_error(
+    addApplication(project, c("p1", "p2"), parameterSets = "ghost")
+  )
+  expect_identical(names(project$applications), before)
+  reloaded <- loadProject(project$jsonPath)
+  expect_identical(names(reloaded$applications), before)
+})
+
+test_that("removeApplication removes a vector of ids in one write-through", {
+  project <- testProject()
+  addApplication(project, c("p1", "p2"))
+  removeApplication(project, c("p1", "p2"))
+  expect_false(any(c("p1", "p2") %in% names(project$applications)))
+  reloaded <- loadProject(project$jsonPath)
+  expect_false(any(c("p1", "p2") %in% names(reloaded$applications)))
+})
+
+test_that("setApplicationParameterSets vectorizes whole across N ids", {
+  project <- testProject()
+  addApplication(project, c("p1", "p2"))
+  setApplicationParameterSets(project, c("p1", "p2"), c("global", "aciclovir"))
+  expect_identical(
+    project$applications$p1$parameterSets,
+    c("global", "aciclovir")
+  )
+  expect_identical(
+    project$applications$p2$parameterSets,
+    c("global", "aciclovir")
+  )
+})
+
+# Print method ----
+
+test_that("print.Application renders its parameter-set references", {
+  project <- testProject()
+  withr::local_options(cli.unicode = FALSE)
+  local_reproducible_output()
+  expect_snapshot(print(project$applications[["aciclovir_iv_250mg"]]))
+})
+
+test_that("print.Application renders an empty protocol", {
+  project <- testProject()
+  addApplication(project, "empty")
+  withr::local_options(cli.unicode = FALSE)
+  local_reproducible_output()
+  expect_snapshot(print(project$applications[["empty"]]))
 })

--- a/tests/testthat/test-authoring-vectorize.R
+++ b/tests/testthat/test-authoring-vectorize.R
@@ -1,0 +1,86 @@
+test_that(".assertIdVector accepts a non-empty character vector", {
+  expect_identical(.assertIdVector(c("a", "b")), c("a", "b"))
+})
+
+test_that(".assertIdVector rejects empty, NA, or non-character ids", {
+  expect_snapshot(error = TRUE, .assertIdVector(character(0)))
+  expect_snapshot(error = TRUE, .assertIdVector(c("a", NA)))
+  expect_snapshot(error = TRUE, .assertIdVector(c("a", "")))
+  expect_snapshot(error = TRUE, .assertIdVector(1:3))
+})
+
+test_that(".recycleField recycles a length-1 value to all N", {
+  expect_identical(
+    .recycleField("x", 3L, "f"),
+    list("x", "x", "x")
+  )
+})
+
+test_that(".recycleField aligns a length-N value by position", {
+  expect_identical(
+    .recycleField(c("a", "b", "c"), 3L, "f"),
+    list("a", "b", "c")
+  )
+})
+
+test_that(".recycleField passes NULL through as N NULLs", {
+  expect_identical(.recycleField(NULL, 2L, "f"), list(NULL, NULL))
+})
+
+test_that(".recycleField aborts on a length that is neither 1 nor N", {
+  expect_snapshot(error = TRUE, .recycleField(c("a", "b"), 3L, "weight"))
+})
+
+test_that(".wholeField applies a vector whole to every entity", {
+  expect_identical(
+    .wholeField(c("global", "def"), 2L),
+    list(c("global", "def"), c("global", "def"))
+  )
+})
+
+test_that(".wholeField aligns a length-N list of vectors per entity", {
+  expect_identical(
+    .wholeField(list(c("a", "b"), "c"), 2L),
+    list(c("a", "b"), "c")
+  )
+})
+
+test_that(".alignAuthoringArgs builds N per-entity field sets", {
+  out <- .alignAuthoringArgs(
+    id = c("a", "b"),
+    scalarFields = list(species = "Human", gender = c("FEMALE", "MALE")),
+    wholeFields = list(parameterSets = c("global", "def"))
+  )
+  expect_length(out, 2L)
+  expect_identical(
+    out[[1]],
+    list(
+      species = "Human",
+      gender = "FEMALE",
+      parameterSets = c("global", "def")
+    )
+  )
+  expect_identical(
+    out[[2]],
+    list(species = "Human", gender = "MALE", parameterSets = c("global", "def"))
+  )
+})
+
+test_that(".alignAuthoringArgs preserves NULL fields as present-but-NULL", {
+  out <- .alignAuthoringArgs(
+    id = "a",
+    scalarFields = list(species = "Human", population = NULL)
+  )
+  expect_true("population" %in% names(out[[1]]))
+  expect_null(out[[1]]$population)
+})
+
+test_that(".alignAuthoringArgs propagates a length error naming the field", {
+  expect_snapshot(
+    error = TRUE,
+    .alignAuthoringArgs(
+      id = c("a", "b", "c"),
+      scalarFields = list(weight = c(60, 70))
+    )
+  )
+})

--- a/tests/testthat/test-entity-files-sections.R
+++ b/tests/testthat/test-entity-files-sections.R
@@ -1,0 +1,546 @@
+# Tests for the entity-files write-through generalization (Phase 2b):
+# every Project section, not only scenarios, is persisted as a per-entity
+# tree under `definitions/<kind>/`. Mirrors test-entity-files.R but exercises
+# the other eight sections. The scenarios slice keeps its own dedicated tests.
+
+test_that("loadProject reads every section from its definitions/<kind>/ tree", {
+  project <- exampleProject()
+  defs <- file.path(project$projectDirPath, "definitions")
+
+  # The example fixture materializes each non-empty section as a tree, and
+  # Project.json carries no inline copy of it.
+  raw <- jsonlite::fromJSON(project$jsonPath, simplifyVector = FALSE)
+
+  expect_true(dir.exists(file.path(defs, "individuals")))
+  expect_setequal(
+    list.files(file.path(defs, "individuals"), pattern = "\\.json$"),
+    paste0(names(project$individuals), ".json")
+  )
+  expect_length(raw$individuals, 0L)
+
+  expect_true(dir.exists(file.path(defs, "parameter-sets")))
+  expect_setequal(
+    list.files(file.path(defs, "parameter-sets"), pattern = "\\.json$"),
+    paste0(names(project$parameterSets), ".json")
+  )
+  expect_length(raw$parameterSets, 0L)
+
+  expect_true(dir.exists(file.path(defs, "initial-conditions")))
+  expect_setequal(
+    list.files(file.path(defs, "initial-conditions"), pattern = "\\.json$"),
+    paste0(names(project$initialConditions), ".json")
+  )
+  expect_length(raw$initialConditions, 0L)
+
+  expect_true(dir.exists(file.path(defs, "output-paths")))
+  expect_setequal(
+    list.files(file.path(defs, "output-paths"), pattern = "\\.json$"),
+    paste0(names(project$outputPaths), ".json")
+  )
+  expect_length(raw$outputPaths, 0L)
+})
+
+test_that("addIndividual writes one entity file; removeIndividual deletes it", {
+  project <- exampleProject()
+  dir <- file.path(project$projectDirPath, "definitions", "individuals")
+
+  addIndividual(project, "newindiv", species = "Human", gender = "MALE")
+  expect_true(file.exists(file.path(dir, "newindiv.json")))
+
+  reloaded <- loadProject(project$jsonPath)
+  expect_identical(
+    reloaded$individuals[["newindiv"]]$species,
+    project$individuals[["newindiv"]]$species
+  )
+
+  removeIndividual(project, "newindiv")
+  expect_false(file.exists(file.path(dir, "newindiv.json")))
+})
+
+test_that("addPopulation / addApplication / addOutputPath write entity files", {
+  project <- exampleProject()
+  defs <- file.path(project$projectDirPath, "definitions")
+
+  addPopulation(project, "newpop", species = "Human", numberOfIndividuals = 5)
+  expect_true(file.exists(file.path(defs, "populations", "newpop.json")))
+
+  addApplication(project, "newapp")
+  expect_true(file.exists(file.path(defs, "applications", "newapp.json")))
+
+  addOutputPath(project, "newpath", "Organism|Drug|Concentration")
+  expect_true(file.exists(file.path(defs, "output-paths", "newpath.json")))
+
+  reloaded <- loadProject(project$jsonPath)
+  expect_true("newpop" %in% names(reloaded$populations))
+  expect_true("newapp" %in% names(reloaded$applications))
+  expect_identical(
+    reloaded$outputPaths[["newpath"]],
+    "Organism|Drug|Concentration"
+  )
+})
+
+test_that("addParameterSet / addParameterEntry write the set's entity file", {
+  project <- exampleProject()
+  dir <- file.path(project$projectDirPath, "definitions", "parameter-sets")
+
+  addParameterSet(project, "newset")
+  expect_true(file.exists(file.path(dir, "newset.json")))
+
+  addParameterEntry(project, "newset", "Organism", "Param", 1.5, "mg")
+  reloaded <- loadProject(project$jsonPath)
+  expect_length(reloaded$parameterSets[["newset"]], 1L)
+  expect_identical(reloaded$parameterSets[["newset"]][[1]]$value, 1.5)
+})
+
+# A single mutation must rewrite only the changed entity's file. A full
+# re-serialize of the whole section would rewrite every sibling file too,
+# which is both the O(N^2) cost and a needless churn of unrelated git diffs.
+# Hand-edit a sibling file on disk with content the canonical serializer would
+# never emit, mutate a different entity, then confirm the sibling is untouched.
+test_that("a single mutation rewrites only the changed entity's file", {
+  project <- exampleProject()
+  dir <- file.path(project$projectDirPath, "definitions", "parameter-sets")
+
+  addParameterSet(project, "seta")
+  addParameterSet(project, "setb")
+  siblingFile <- file.path(dir, "seta.json")
+  sentinel <- "NOT-CANONICAL-SENTINEL"
+  writeLines(sentinel, siblingFile)
+
+  # Mutate a different set; the sibling's hand-written content must survive.
+  addParameterEntry(project, "setb", "Organism", "Param", 1.5, "mg")
+  expect_identical(readLines(siblingFile), sentinel)
+  expect_true(file.exists(file.path(dir, "setb.json")))
+})
+
+# Per-mutation write-through must be ~linear in the number of mutations, not
+# quadratic. Adding N entities one at a time serializes only the one changed
+# entity each time, so the cost of adding the Nth entity is independent of how
+# many already exist. The old whole-section-serialize path made each add
+# O(section size), i.e. O(N^2) for N adds (the panel measured ~132x at 10x N).
+test_that("adding many parameter sets one at a time scales linearly", {
+  skip_on_cran()
+
+  timeFor <- function(n) {
+    p <- exampleProject()
+    system.time(
+      for (i in seq_len(n)) {
+        addParameterSet(p, paste0("set", i))
+      }
+    )[["elapsed"]]
+  }
+
+  t100 <- timeFor(100L)
+  t1000 <- timeFor(1000L)
+
+  # 10x the work in O(N) is ~10x the time; the old O(N^2) path was ~100x. A
+  # generous ceiling keeps the test robust to machine noise while still failing
+  # loudly on a quadratic regression.
+  ratio <- t1000 / max(t100, 1e-3)
+  expect_lt(ratio, 40)
+})
+
+test_that("addPITask writes a per-task entity file; removePITask deletes it", {
+  project <- exampleProject()
+  dir <- file.path(
+    project$projectDirPath,
+    "definitions",
+    "parameter-identification"
+  )
+
+  param <- PIParameter(
+    id = "p1",
+    scenarios = "aciclovir_iv",
+    path = "Aciclovir|Lipophilicity",
+    minValue = -2,
+    maxValue = 2,
+    startValue = 0
+  )
+  mapping <- PIOutputMapping(
+    id = "m1",
+    scenarios = "aciclovir_iv",
+    outputPath = "aciclovir_pvb",
+    observedData = "obs"
+  )
+  addPITask(
+    project,
+    "newtask",
+    scenarios = "aciclovir_iv",
+    parameters = list(param),
+    outputMappings = list(mapping)
+  )
+  expect_true(file.exists(file.path(dir, "newtask.json")))
+
+  reloaded <- loadProject(project$jsonPath)
+  expect_true("newtask" %in% names(reloaded$parameterIdentification))
+
+  removePITask(project, "newtask")
+  expect_false(file.exists(file.path(dir, "newtask.json")))
+})
+
+test_that("the three plots parts write to data-combined / plots / plot-grids", {
+  project <- exampleProject()
+  defs <- file.path(project$projectDirPath, "definitions")
+  dcDir <- file.path(defs, "data-combined")
+  plotsDir <- file.path(defs, "plots")
+  gridsDir <- file.path(defs, "plot-grids")
+
+  # Each part persists one file per entity, keyed by its rationalized id.
+  addDataCombined(
+    project,
+    "newdc",
+    simulated = list(list(
+      label = "sim",
+      scenario = "aciclovir_iv",
+      path = "Organism|Drug"
+    ))
+  )
+  expect_true(file.exists(file.path(dcDir, "newdc.json")))
+
+  addPlot(project, "newplot", "newdc", "individual")
+  expect_true(file.exists(file.path(plotsDir, "newplot.json")))
+
+  addPlotGrid(project, "newgrid", plots = "newplot")
+  expect_true(file.exists(file.path(gridsDir, "newgrid.json")))
+
+  # A reload reads each of the three plots sections from its own folder.
+  reloaded <- loadProject(project$jsonPath)
+  expect_true("newdc" %in% names(reloaded$dataCombined))
+  expect_true("newplot" %in% names(reloaded$plots))
+  expect_true("newgrid" %in% names(reloaded$plotGrids))
+})
+
+test_that("removing a plot entity deletes only its file, leaving siblings", {
+  project <- exampleProject()
+  plotsDir <- file.path(project$projectDirPath, "definitions", "plots")
+  dcDir <- file.path(project$projectDirPath, "definitions", "data-combined")
+
+  addPlot(project, "p_extra", "aciclovir_individual", "individual")
+  expect_true(file.exists(file.path(plotsDir, "p_extra.json")))
+  # The pre-existing plot p1 and the dataCombined are untouched by this add.
+  expect_true(file.exists(file.path(plotsDir, "p1.json")))
+  expect_true(file.exists(file.path(dcDir, "aciclovir_individual.json")))
+
+  removePlot(project, "p_extra")
+  expect_false(file.exists(file.path(plotsDir, "p_extra.json")))
+  expect_true(file.exists(file.path(plotsDir, "p1.json")))
+})
+
+test_that("addObservedData (config) writes an observed-data entity file", {
+  project <- exampleProject()
+  dir <- file.path(project$projectDirPath, "definitions", "observed-data")
+
+  addObservedData(
+    project,
+    list(type = "pkml", file = "extra.pkml")
+  )
+  expect_true(file.exists(file.path(dir, "extra.pkml.json")))
+
+  reloaded <- loadProject(project$jsonPath)
+  files <- vapply(
+    reloaded$observedData,
+    function(e) basename(e[["file"]] %||% ""),
+    character(1)
+  )
+  expect_true("extra.pkml" %in% files)
+})
+
+test_that("a section write-through is an in-memory no-op on a clone", {
+  source <- exampleProject()
+  defs <- file.path(source$projectDirPath, "definitions")
+  before <- list.files(file.path(defs, "individuals"))
+
+  clone <- source$clone()
+  addIndividual(clone, "cloneonly", species = "Human", gender = "MALE")
+
+  expect_true("cloneonly" %in% names(clone$individuals))
+  expect_setequal(list.files(file.path(defs, "individuals")), before)
+  reloadedSource <- loadProject(source$jsonPath)
+  expect_false("cloneonly" %in% names(reloadedSource$individuals))
+})
+
+test_that("a snapshot-loaded project materializes the full section tree on first write", {
+  snap <- saveSnapshot(exampleProject(), local_projectPath())
+  # A snapshot has no definitions/ tree; sections come from the inline arrays.
+  expect_false(dir.exists(file.path(
+    dirname(snap),
+    "definitions",
+    "individuals"
+  )))
+
+  project <- loadProject(snap)
+  before <- names(project$individuals)
+  addIndividual(project, "freshindiv", species = "Human", gender = "MALE")
+
+  reloaded <- loadProject(snap)
+  expect_named(
+    reloaded$individuals,
+    c(before, "freshindiv"),
+    ignore.order = TRUE
+  )
+})
+
+# A `definitions/<kind>/` path that is a regular file (not a directory) is a
+# corrupted tree, not an absent section. `dir.exists()` is FALSE for both, so
+# without a guard the project would load as structurally-valid but empty. The
+# load must abort naming the path.
+test_that("a definitions/<kind>/ path that is a file aborts the load", {
+  project <- exampleProject()
+  jsonPath <- project$jsonPath
+  kindDir <- file.path(project$projectDirPath, "definitions", "individuals")
+
+  unlink(kindDir, recursive = TRUE)
+  writeLines("not a directory", kindDir)
+
+  expect_snapshot(
+    loadProject(jsonPath),
+    error = TRUE,
+    transform = .redactTmpPath
+  )
+})
+
+test_that("a definitions/ root that is a file aborts the load", {
+  project <- exampleProject()
+  jsonPath <- project$jsonPath
+  defs <- file.path(project$projectDirPath, "definitions")
+
+  unlink(defs, recursive = TRUE)
+  writeLines("not a directory", defs)
+
+  expect_snapshot(
+    loadProject(jsonPath),
+    error = TRUE,
+    transform = .redactTmpPath
+  )
+})
+
+# A keyed entity file missing its id field used to abort with an opaque base-R
+# `list[[NULL]] <- x` error that named nothing. It must now abort naming the
+# file and the missing field.
+test_that("a keyed file missing its id field aborts naming the file", {
+  project <- exampleProject()
+  jsonPath <- project$jsonPath
+  dir <- file.path(project$projectDirPath, "definitions", "individuals")
+  f <- list.files(dir, pattern = "\\.json$", full.names = TRUE)[[1]]
+
+  obj <- jsonlite::fromJSON(f, simplifyVector = FALSE)
+  obj$individualId <- NULL
+  jsonlite::write_json(obj, f, auto_unbox = TRUE, null = "null", pretty = TRUE)
+
+  expect_snapshot(
+    loadProject(jsonPath),
+    error = TRUE,
+    transform = .redactTmpPath
+  )
+})
+
+# A keyed file whose inner id disagrees with its filename used to load keyed by
+# the inner id, contradicting the "id is the filename" contract and breaking
+# canonicalized references. It must now abort naming the file and the mismatch.
+test_that("a keyed file whose inner id disagrees with its filename aborts", {
+  project <- exampleProject()
+  jsonPath <- project$jsonPath
+  dir <- file.path(project$projectDirPath, "definitions", "output-paths")
+  f <- list.files(dir, pattern = "\\.json$", full.names = TRUE)[[1]]
+
+  obj <- jsonlite::fromJSON(f, simplifyVector = FALSE)
+  obj$id <- "different"
+  jsonlite::write_json(obj, f, auto_unbox = TRUE, null = "null", pretty = TRUE)
+
+  expect_snapshot(
+    loadProject(jsonPath),
+    error = TRUE,
+    transform = .redactTmpPath
+  )
+})
+
+# Two output-path files declaring the same inner id used to silently collapse
+# to one on load (silent loss). The filename-stem check makes that impossible:
+# the file whose stem disagrees with its inner id aborts.
+test_that("two files with the same inner id cannot silently collapse", {
+  project <- exampleProject()
+  jsonPath <- project$jsonPath
+  dir <- file.path(project$projectDirPath, "definitions", "output-paths")
+  f <- list.files(dir, pattern = "\\.json$", full.names = TRUE)[[1]]
+
+  obj <- jsonlite::fromJSON(f, simplifyVector = FALSE)
+  # A second file under a different name but carrying the first file's inner id.
+  jsonlite::write_json(
+    obj,
+    file.path(dir, "duplicate.json"),
+    auto_unbox = TRUE,
+    null = "null",
+    pretty = TRUE
+  )
+
+  expect_snapshot(
+    loadProject(jsonPath),
+    error = TRUE,
+    transform = .redactTmpPath
+  )
+})
+
+# The natural jsonlite hand-edit round-trip re-emits a JSON `null` as `{}`. A
+# scalar field that became an empty object on a non-scenario kind used to slip
+# through with no guard; it must now fail the load with a clear message.
+test_that("an empty-object scalar field on a non-scenario kind aborts the load", {
+  project <- exampleProject()
+  jsonPath <- project$jsonPath
+  dir <- file.path(project$projectDirPath, "definitions", "individuals")
+  f <- list.files(dir, pattern = "\\.json$", full.names = TRUE)[[1]]
+
+  obj <- jsonlite::fromJSON(f, simplifyVector = FALSE)
+  # `"species": null` round-tripped the standard jsonlite way becomes {}.
+  obj$species <- structure(list(), names = character(0))
+  jsonlite::write_json(obj, f, auto_unbox = TRUE, null = "null", pretty = TRUE)
+
+  expect_snapshot(
+    loadProject(jsonPath),
+    error = TRUE,
+    transform = .redactTmpPath
+  )
+})
+
+test_that("an inline-section snapshot loads identically to its tree source", {
+  source <- exampleProject()
+  snap <- saveSnapshot(source, local_projectPath())
+  reloaded <- loadProject(snap)
+
+  expect_named(
+    reloaded$individuals,
+    names(source$individuals),
+    ignore.order = TRUE
+  )
+  expect_named(
+    reloaded$parameterSets,
+    names(source$parameterSets),
+    ignore.order = TRUE
+  )
+  expect_named(
+    reloaded$outputPaths,
+    names(source$outputPaths),
+    ignore.order = TRUE
+  )
+  expect_named(
+    reloaded$applications,
+    names(source$applications),
+    ignore.order = TRUE
+  )
+})
+
+# Plots split into three kinds ----
+#
+# The plots concern is three independent top-level keyed sections
+# (`dataCombined`, `plots`, `plotGrids`), each its own `definitions/<kind>/`
+# tree. These exercise loading each section from its folder, the lazy
+# referential contract across the three files, and the snapshot fixed-point
+# over the tree.
+
+test_that("loadProject reads each plots section from its own folder", {
+  project <- exampleProject()
+  defs <- file.path(project$projectDirPath, "definitions")
+
+  # The example fixture materializes each plots part as its own keyed tree.
+  expect_setequal(
+    list.files(file.path(defs, "data-combined"), pattern = "\\.json$"),
+    paste0(names(project$dataCombined), ".json")
+  )
+  expect_setequal(
+    list.files(file.path(defs, "plots"), pattern = "\\.json$"),
+    paste0(names(project$plots), ".json")
+  )
+  expect_setequal(
+    list.files(file.path(defs, "plot-grids"), pattern = "\\.json$"),
+    paste0(names(project$plotGrids), ".json")
+  )
+  # Project.json carries no inline copy of the plots section.
+  raw <- jsonlite::fromJSON(project$jsonPath, simplifyVector = FALSE)
+  expect_null(raw$plots)
+})
+
+test_that("a dangling cross-file plot ref is a lazy error, not a write abort", {
+  project <- exampleProject()
+  plotsDir <- file.path(project$projectDirPath, "definitions", "plots")
+
+  # A plot referencing a non-existent dataCombined: the write itself is
+  # structural-only (the plot's own shape), so it does not abort. The dangling
+  # ref is caught lazily by validateProject(), exactly as before the split.
+  pc <- project$.getSection("plots")
+  pc$p1$dataCombinedId <- "ghost_dc"
+  project$.setSection("plots", pc)
+  expect_true(file.exists(file.path(plotsDir, "p1.json")))
+
+  reloaded <- loadProject(project$jsonPath)
+  results <- suppressWarnings(validateProject(reloaded))
+  msgs <- vapply(
+    results$plots$critical_errors,
+    \(e) e$message,
+    character(1)
+  )
+  expect_true(any(grepl("ghost_dc", msgs)))
+})
+
+test_that("a grid pointing at a missing plot stays a lazy error after reload", {
+  project <- exampleProject()
+  gridsDir <- file.path(project$projectDirPath, "definitions", "plot-grids")
+
+  # Repoint the grid at a plot id that does not exist; the grid write succeeds
+  # (its own structure is valid), the dangling plotIds ref is lazy.
+  pg <- project$.getSection("plotGrids")
+  pg$individual_diagnostics$plotIds <- "ghost_plot"
+  project$.setSection("plotGrids", pg)
+  expect_true(file.exists(file.path(gridsDir, "individual_diagnostics.json")))
+
+  reloaded <- loadProject(project$jsonPath)
+  results <- suppressWarnings(validateProject(reloaded))
+  msgs <- vapply(
+    results$plots$critical_errors,
+    \(e) e$message,
+    character(1)
+  )
+  expect_true(any(grepl("ghost_plot", msgs)))
+})
+
+test_that("an emptied plots part clears its folder's files", {
+  project <- exampleProject()
+  gridsDir <- file.path(project$projectDirPath, "definitions", "plot-grids")
+  expect_true(file.exists(file.path(gridsDir, "individual_diagnostics.json")))
+
+  removePlotGrid(project, "individual_diagnostics")
+  expect_false(file.exists(file.path(gridsDir, "individual_diagnostics.json")))
+
+  reloaded <- loadProject(project$jsonPath)
+  expect_length(reloaded$plotGrids %||% list(), 0L)
+})
+
+test_that("snapshot then load is a fixed point over the three plots folders", {
+  source <- exampleProject()
+  snap <- saveSnapshot(source, local_projectPath())
+  reloaded <- loadSnapshot(snap, dirname(local_projectPath()))
+
+  # Each plots section is identical (same ids) and the three folders
+  # materialized on the loaded snapshot.
+  defs <- file.path(reloaded$projectDirPath, "definitions")
+  expect_setequal(
+    names(reloaded$dataCombined),
+    names(source$dataCombined)
+  )
+  expect_true(file.exists(file.path(
+    defs,
+    "data-combined",
+    "aciclovir_individual.json"
+  )))
+  expect_true(file.exists(file.path(defs, "plots", "p1.json")))
+  expect_true(file.exists(file.path(
+    defs,
+    "plot-grids",
+    "individual_diagnostics.json"
+  )))
+  # The inlined plots JSON (all three top-level sections) is a fixed point
+  # across the round-trip.
+  reloadedJson <- esqlabsR:::.projectToJson(reloaded)
+  sourceJson <- esqlabsR:::.projectToJson(source)
+  expect_identical(reloadedJson$dataCombined, sourceJson$dataCombined)
+  expect_identical(reloadedJson$plots, sourceJson$plots)
+  expect_identical(reloadedJson$plotGrids, sourceJson$plotGrids)
+})

--- a/tests/testthat/test-entity-files.R
+++ b/tests/testthat/test-entity-files.R
@@ -1,0 +1,545 @@
+# Tests for the scenarios entity-files format layer (R/entity-files.R):
+# the per-scenario JSON tree loader, write-through mutators, lazy
+# referential validation, and the derived single-file snapshot.
+
+test_that("loadProject reads scenarios from the definitions/scenarios/ tree", {
+  project <- testProject()
+
+  # The fixture stores scenarios as definitions/scenarios/*.json, and
+  # Project.json carries no inline scenarios array.
+  dir <- file.path(project$projectDirPath, "definitions", "scenarios")
+  expect_true(dir.exists(dir))
+  expect_setequal(
+    list.files(dir, pattern = "\\.json$"),
+    paste0(names(project$scenarios), ".json")
+  )
+  raw <- jsonlite::fromJSON(project$jsonPath, simplifyVector = FALSE)
+  expect_length(raw$scenarios, 0L)
+})
+
+test_that("addScenario writes one entity file; removeScenario deletes it", {
+  project <- testProject()
+  dir <- file.path(project$projectDirPath, "definitions", "scenarios")
+
+  addScenario(project, "added", modelFile = "Aciclovir.pkml")
+  expect_true(file.exists(file.path(dir, "added.json")))
+
+  # The file on disk reloads to the same scenario record.
+  reloaded <- loadProject(project$jsonPath)
+  expect_identical(
+    reloaded$scenarios[["added"]]$modelFile,
+    project$scenarios[["added"]]$modelFile
+  )
+
+  removeScenario(project, "added")
+  expect_false(file.exists(file.path(dir, "added.json")))
+})
+
+test_that("addScenario canonicalizes its id to a safe, lowercase form", {
+  project <- testProject()
+  dir <- file.path(project$projectDirPath, "definitions", "scenarios")
+
+  # A mixed-case id with a forbidden character is canonicalized (with a
+  # warning) rather than rejected; the canonical id names the file and key.
+  expect_snapshot(addScenario(
+    project,
+    "My/Scenario",
+    modelFile = "Aciclovir.pkml"
+  ))
+  expect_true("my_scenario" %in% names(project$scenarios))
+  expect_true(file.exists(file.path(dir, "my_scenario.json")))
+  expect_false("My/Scenario" %in% names(project$scenarios))
+})
+
+test_that("write-through structurally fail-fasts and leaves disk unchanged", {
+  project <- testProject()
+  dir <- file.path(project$projectDirPath, "definitions", "scenarios")
+  before <- list.files(dir)
+
+  # A scenario with no modelFile is structurally invalid; the write-through
+  # entry point (`.setSection()`, what the authoring functions call) must abort
+  # and write no file.
+  scenarios <- c(
+    project$.getSection("scenarios"),
+    list(bad = Scenario(scenarioName = "bad"))
+  )
+  expect_error(
+    project$.setSection("scenarios", scenarios),
+    "bad.*modelFile"
+  )
+  expect_false(file.exists(file.path(dir, "bad.json")))
+  expect_setequal(list.files(dir), before)
+})
+
+test_that("an unknown outputPathId is a lazy referential finding, not a load error", {
+  project <- testProject()
+  # Point an existing scenario at an output-path id that does not exist. The
+  # authoring functions check this reference eagerly, so the only way a dangling
+  # ref reaches the project is a hand-edited file or a raw `.setSection()`
+  # write; both leave the structurally-valid record in place for the lazy
+  # referential check at validateProject().
+  scenarios <- project$.getSection("scenarios")
+  sc <- scenarios[["testscenario"]]
+  sc$outputPaths <- c(sc$outputPaths, Ghost = NA_character_)
+  scenarios[["testscenario"]] <- sc
+  # Write-through accepts it (structurally valid); referential check is lazy.
+  expect_no_error(project$.setSection("scenarios", scenarios))
+
+  results <- suppressWarnings(validateProject(project))
+  msgs <- vapply(
+    results$crossReferences$critical_errors,
+    \(e) e$message,
+    character(1)
+  )
+  expect_true(any(grepl("Ghost", msgs)))
+})
+
+test_that("saveSnapshot writes a self-contained single file with scenarios inlined", {
+  project <- testProject()
+  # saveSnapshot normalizes the output to a `.esqlabsR` file and returns it.
+  snap <- saveSnapshot(project, local_projectPath())
+  expect_identical(fs::path_ext(snap), "esqlabsR")
+
+  raw <- jsonlite::fromJSON(snap, simplifyVector = FALSE)
+  expect_length(raw$scenarios, length(project$scenarios))
+  # The snapshot directory has no definitions/ tree; the inline array suffices.
+  expect_false(dir.exists(file.path(dirname(snap), "definitions", "scenarios")))
+
+  reloaded <- loadProject(snap)
+  expect_named(
+    reloaded$scenarios,
+    names(project$scenarios),
+    ignore.order = TRUE
+  )
+})
+
+test_that("snapshot -> load -> snapshot is a fixed point", {
+  project <- testProject()
+
+  snap1 <- saveSnapshot(project, local_projectPath())
+  reloaded <- loadProject(snap1)
+
+  snap2 <- saveSnapshot(reloaded, local_projectPath())
+
+  expect_identical(
+    jsonlite::fromJSON(snap1, simplifyVector = FALSE),
+    jsonlite::fromJSON(snap2, simplifyVector = FALSE)
+  )
+})
+
+test_that("snapshot -> load -> snapshot is a fixed point for the plots trio", {
+  # testProject()'s fixture has no dataCombined/plots/plotGrids, so the fixed
+  # point above never exercises the three sections reshaped most by this
+  # refactor. exampleProject() populates all three.
+  project <- exampleProject()
+  expect_gt(length(project$dataCombined), 0)
+  expect_gt(length(project$plots), 0)
+  expect_gt(length(project$plotGrids), 0)
+
+  snap1 <- saveSnapshot(project, local_projectPath())
+  reloaded <- loadProject(snap1)
+  snap2 <- saveSnapshot(reloaded, local_projectPath())
+
+  json1 <- jsonlite::fromJSON(snap1, simplifyVector = FALSE)
+  json2 <- jsonlite::fromJSON(snap2, simplifyVector = FALSE)
+  expect_identical(json1, json2)
+  # The three sections must actually be inlined, not silently dropped to NULL.
+  expect_length(json1$dataCombined, length(project$dataCombined))
+  expect_length(json1$plots, length(project$plots))
+  expect_length(json1$plotGrids, length(project$plotGrids))
+})
+
+test_that("bare mutation of a snapshot-loaded project preserves siblings on reload", {
+  snap <- saveSnapshot(testProject(), local_projectPath())
+
+  # A snapshot has no definitions/ tree; loading falls back to the inline array.
+  expect_false(dir.exists(file.path(dirname(snap), "definitions", "scenarios")))
+  project <- loadProject(snap)
+  before <- names(project$scenarios)
+
+  # The first write-through must materialize the whole set to the tree, not
+  # just the one new scenario, or the inline siblings are lost on reload.
+  addScenario(project, "newlyadded", modelFile = "Aciclovir.pkml")
+  reloaded <- loadProject(snap)
+  expect_named(
+    reloaded$scenarios,
+    c(before, "newlyadded"),
+    ignore.order = TRUE
+  )
+})
+
+test_that("write-back on a snapshot-loaded project preserves siblings on reload", {
+  snap <- saveSnapshot(testProject(), local_projectPath())
+  project <- loadProject(snap)
+  before <- names(project$scenarios)
+
+  existing <- before[[1]]
+  setScenario(project, existing, simulationTimeUnit = "min")
+
+  reloaded <- loadProject(snap)
+  expect_named(reloaded$scenarios, before, ignore.order = TRUE)
+})
+
+test_that("mutating a clone leaves the source's on-disk tree untouched", {
+  source <- testProject()
+  sourceDir <- file.path(source$projectDirPath, "definitions", "scenarios")
+  before <- list.files(sourceDir)
+
+  clone <- source$clone()
+  addScenario(clone, "cloneonly", modelFile = "Aciclovir.pkml")
+
+  # The clone holds the new scenario in memory, but its write-through is a
+  # no-op: it does not own the source's tree.
+  expect_true("cloneonly" %in% names(clone$scenarios))
+  expect_setequal(list.files(sourceDir), before)
+  reloadedSource <- loadProject(source$jsonPath)
+  expect_false("cloneonly" %in% names(reloadedSource$scenarios))
+})
+
+test_that("saveSnapshot persists a clone's in-memory edits to a single file", {
+  clone <- testProject()$clone()
+  addScenario(clone, "cloneonly", modelFile = "Aciclovir.pkml")
+
+  newPath <- saveSnapshot(clone, local_projectPath())
+
+  # The snapshot is a single self-contained file (no definitions/ tree), and
+  # reloading it yields the clone's edits including the new scenario.
+  expect_false(dir.exists(file.path(dirname(newPath), "definitions")))
+  expect_true("cloneonly" %in% names(loadProject(newPath)$scenarios))
+})
+
+test_that("a scenarioName that disagrees with its list key aborts the write", {
+  project <- testProject()
+  dir <- file.path(project$projectDirPath, "definitions", "scenarios")
+  before <- list.files(dir)
+
+  # Store an existing scenario under a different key without updating its
+  # scenarioName. The structural backstop in the write path (`.setSection()`)
+  # rejects the key/name disagreement before any file is written.
+  scenarios <- project$.getSection("scenarios")
+  scenarios[["renamed"]] <- scenarios[["testscenario"]]
+  expect_snapshot(
+    project$.setSection("scenarios", scenarios),
+    error = TRUE
+  )
+  expect_false(file.exists(file.path(dir, "renamed.json")))
+  expect_setequal(list.files(dir), before)
+})
+
+test_that("a write-back under a non-canonical key aborts the write", {
+  project <- testProject()
+  dir <- file.path(project$projectDirPath, "definitions", "scenarios")
+  before <- list.files(dir)
+
+  # The section accessor is read-only and addScenario() canonicalizes ids, so a
+  # non-canonical key can only reach the tree through a raw `.setSection()`
+  # write. The structural validator is the backstop: a non-canonical key (mixed
+  # case or a forbidden character) aborts, pointing the user at addScenario().
+  scenarios <- project$.getSection("scenarios")
+  sc <- scenarios[["testscenario"]]
+  sc$scenarioName <- "Renamed"
+  scenarios[["Renamed"]] <- sc
+  expect_snapshot(
+    project$.setSection("scenarios", scenarios),
+    error = TRUE
+  )
+  expect_false(file.exists(file.path(dir, "Renamed.json")))
+  expect_setequal(list.files(dir), before)
+})
+
+test_that("a correctly-keyed rename round-trips through the tree", {
+  project <- testProject()
+  dir <- file.path(project$projectDirPath, "definitions", "scenarios")
+
+  renameScenario(project, "testscenario", "renamed")
+
+  expect_true(file.exists(file.path(dir, "renamed.json")))
+  expect_false(file.exists(file.path(dir, "testscenario.json")))
+  # Reload warns about cross-references that still point at the old name
+  # (lazy referential check); the rename itself round-trips.
+  reloaded <- suppressWarnings(loadProject(project$jsonPath))
+  expect_true("renamed" %in% names(reloaded$scenarios))
+  expect_false("testscenario" %in% names(reloaded$scenarios))
+})
+
+test_that("a scenario id with path separators is canonicalized, not rejected", {
+  project <- testProject()
+  parentDir <- project$projectDirPath
+  scenariosDir <- file.path(parentDir, "definitions", "scenarios")
+
+  # Forbidden path characters are replaced (with a warning); the canonical id
+  # is a single safe path segment that cannot escape the scenarios directory.
+  expect_snapshot(
+    addScenario(project, "../escape", modelFile = "Aciclovir.pkml")
+  )
+  expect_snapshot(
+    addScenario(project, "sub/evil", modelFile = "Aciclovir.pkml")
+  )
+  expect_true("_escape" %in% names(project$scenarios))
+  expect_true("sub_evil" %in% names(project$scenarios))
+  # Nothing escaped the definitions/scenarios/ directory.
+  expect_false(file.exists(file.path(parentDir, "escape.json")))
+  expect_true(file.exists(file.path(scenariosDir, "_escape.json")))
+  expect_true(file.exists(file.path(scenariosDir, "sub_evil.json")))
+})
+
+test_that("saveSnapshot refuses to overwrite the project's own container", {
+  project <- testProject()
+  containerBefore <- jsonlite::fromJSON(
+    project$jsonPath,
+    simplifyVector = FALSE
+  )
+
+  # No path defaults to the container; an explicit container path is the same.
+  expect_snapshot(saveSnapshot(project), error = TRUE)
+  expect_snapshot(saveSnapshot(project, project$jsonPath), error = TRUE)
+
+  # The container is untouched (still scenarios: []) and the tree intact.
+  containerAfter <- jsonlite::fromJSON(project$jsonPath, simplifyVector = FALSE)
+  expect_length(containerAfter$scenarios, 0L)
+  expect_identical(containerAfter, containerBefore)
+  expect_true(dir.exists(file.path(
+    project$projectDirPath,
+    "definitions",
+    "scenarios"
+  )))
+})
+
+# A bulk tree write must be all-or-nothing, and structural
+# validation must be a true superset of what the serializer requires (a
+# scenario that passes `.validateScenarioStructure` must always serialize).
+test_that("structural validation rejects a serializer-hostile scenario", {
+  # simulateSteadyState = TRUE with no steadyStateTimeUnit is what
+  # `.scenarioToJson` aborts on; the structural validator must catch it first.
+  sc <- Scenario(
+    scenarioName = "ss",
+    modelFile = "m.pkml",
+    simulateSteadyState = TRUE,
+    steadyStateTimeUnit = NULL
+  )
+  expect_snapshot(.validateScenarioStructure(sc, "ss"), error = TRUE)
+
+  # outputPaths present but unnamed is the other serializer abort.
+  bad <- Scenario(scenarioName = "op", modelFile = "m.pkml")
+  bad$outputPaths <- "Organism|Drug"
+  expect_snapshot(.validateScenarioStructure(bad, "op"), error = TRUE)
+})
+
+test_that("a bulk write aborting on one scenario leaves the tree intact", {
+  snap <- saveSnapshot(testProject(), local_projectPath())
+  project <- loadProject(snap)
+  before <- names(project$scenarios)
+
+  # Make one already-loaded scenario serializer-hostile, in the backing store
+  # so it bypasses write-through, then trigger a full materialize by adding a
+  # new scenario. The materialize must abort before writing any file, so the
+  # reload still yields the original full set (no partial tree).
+  poke <- project$.__enclos_env__$private
+  hostile <- poke$.scenarios[[before[[1]]]]
+  hostile$simulateSteadyState <- TRUE
+  hostile$steadyStateTimeUnit <- NULL
+  poke$.scenarios[[before[[1]]]] <- hostile
+
+  expect_error(
+    addScenario(project, "BrandNew", modelFile = "Aciclovir.pkml"),
+    "steadyStateTimeUnit"
+  )
+  expect_false(dir.exists(file.path(dirname(snap), "definitions", "scenarios")))
+  reloaded <- loadProject(snap)
+  expect_named(reloaded$scenarios, before, ignore.order = TRUE)
+})
+
+# The diff path (a project whose `definitions/scenarios/` already exists on
+# disk) serializes every changed entity before writing any file, so a
+# whole-section assignment carrying one valid plus one serializer-hostile
+# entity must abort with neither landing on disk and memory unchanged. The
+# materialize branch is covered above; this covers the common diff branch.
+test_that("a multi-entity diff-path write aborting on one entity is atomic", {
+  project <- testProject()
+  dir <- file.path(project$projectDirPath, "definitions", "scenarios")
+  beforeFiles <- list.files(dir)
+  beforeMem <- project$scenarios
+
+  # Build a whole-section map: one brand-new valid scenario plus one new
+  # serializer-hostile scenario (steadyState without a unit). Assigning the
+  # whole map exercises the diff path (both are "added" keys it must serialize).
+  valid <- Scenario(modelFile = "Aciclovir.pkml", scenarioName = "fresh_ok")
+  hostile <- Scenario(modelFile = "Aciclovir.pkml", scenarioName = "fresh_bad")
+  hostile$simulateSteadyState <- TRUE
+  hostile$steadyStateTimeUnit <- NULL
+
+  newSection <- c(
+    beforeMem,
+    list(fresh_ok = valid, fresh_bad = hostile)
+  )
+  expect_error(
+    project$.setSection("scenarios", newSection),
+    "steadyStateTimeUnit"
+  )
+
+  # Neither new entity reached disk, and the in-memory section is unchanged.
+  expect_setequal(list.files(dir), beforeFiles)
+  expect_identical(project$scenarios, beforeMem)
+})
+
+# Two ids differing only in case canonicalize to the same lowercase id, so
+# the case-insensitive-filesystem collision dissolves: the second add lands
+# on the same id and is rejected as a duplicate.
+test_that("an id differing only in case canonicalizes to an existing id", {
+  project <- testProject()
+  dir <- file.path(project$projectDirPath, "definitions", "scenarios")
+  before <- list.files(dir)
+
+  expect_snapshot(addScenario(
+    project,
+    "MyScenario",
+    modelFile = "Aciclovir.pkml"
+  ))
+  # "myscenario" canonicalizes to the same id, which already exists.
+  expect_snapshot(
+    addScenario(project, "myscenario", modelFile = "Aciclovir.pkml"),
+    error = TRUE
+  )
+  # Only the one (lowercased) file was written.
+  expect_setequal(list.files(dir), c(before, "myscenario.json"))
+})
+
+# A non-ASCII scenario filename must round-trip; `list.files()`
+# returns native-encoding paths that an un-normalized radix sort can reject.
+# (The accented letter is not a forbidden character, only lowercased.)
+test_that("a non-ASCII scenario name round-trips through the tree", {
+  project <- testProject()
+  dir <- file.path(project$projectDirPath, "definitions", "scenarios")
+
+  addScenario(project, "scénario", modelFile = "Aciclovir.pkml")
+  expect_true(file.exists(file.path(dir, "scénario.json")))
+
+  reloaded <- loadProject(project$jsonPath)
+  expect_true("scénario" %in% names(reloaded$scenarios))
+  expect_identical(
+    reloaded$scenarios[["scénario"]]$modelFile,
+    project$scenarios[["scénario"]]$modelFile
+  )
+})
+
+# A scenario file with no `name` field used to abort with an opaque base-R
+# index error naming nothing; it must now abort naming the file.
+test_that("a scenario file missing its name aborts naming the file", {
+  project <- testProject()
+  dir <- file.path(project$projectDirPath, "definitions", "scenarios")
+  f <- file.path(dir, paste0(names(project$scenarios)[[1]], ".json"))
+
+  obj <- jsonlite::fromJSON(f, simplifyVector = FALSE)
+  obj$name <- NULL
+  jsonlite::write_json(obj, f, auto_unbox = TRUE, null = "null", pretty = TRUE)
+
+  expect_snapshot(
+    loadProject(project$jsonPath),
+    error = TRUE,
+    transform = .redactTmpPath
+  )
+})
+
+# A scenario file whose inner `name` disagrees with its filename used to load
+# keyed by the inner name, so a canonicalized reference would dangle. It must
+# now abort naming the file and the mismatch.
+test_that("a scenario file whose name disagrees with its filename aborts", {
+  project <- testProject()
+  dir <- file.path(project$projectDirPath, "definitions", "scenarios")
+  f <- file.path(dir, paste0(names(project$scenarios)[[1]], ".json"))
+
+  obj <- jsonlite::fromJSON(f, simplifyVector = FALSE)
+  obj$name <- "differentname"
+  jsonlite::write_json(obj, f, auto_unbox = TRUE, null = "null", pretty = TRUE)
+
+  expect_snapshot(
+    loadProject(project$jsonPath),
+    error = TRUE,
+    transform = .redactTmpPath
+  )
+})
+
+# A hand-edited scenario file whose scalar field became an empty
+# object (the standard jsonlite round-trip of `null`) must fail load with a
+# message naming the scenario and field, not an opaque internal error.
+test_that("a non-scalar scalar field fails load naming the scenario and field", {
+  project <- testProject()
+  dir <- file.path(project$projectDirPath, "definitions", "scenarios")
+  f <- file.path(dir, paste0(names(project$scenarios)[[1]], ".json"))
+
+  obj <- jsonlite::fromJSON(f, simplifyVector = FALSE)
+  # `"population": null` round-tripped the standard jsonlite way becomes {}.
+  obj$population <- structure(list(), names = character(0))
+  jsonlite::write_json(obj, f, auto_unbox = TRUE, null = "null", pretty = TRUE)
+
+  expect_snapshot(loadProject(project$jsonPath), error = TRUE)
+})
+
+# Every section is write-through, so after a mutation the entity files are
+# already on disk and there is nothing for syncStatus() to flag (no Excel
+# side-car here, so it reports NA).
+test_that("a mutation lands on disk immediately; syncStatus has nothing to flag", {
+  project <- testProject()
+  dir <- file.path(project$projectDirPath, "definitions", "scenarios")
+
+  addScenario(project, "fresh", modelFile = "Aciclovir.pkml")
+  # The scenario file is already on disk right after the mutation.
+  expect_true(file.exists(file.path(dir, "fresh.json")))
+
+  status <- project$syncStatus(silent = TRUE)
+  expect_identical(status$excel_in_sync, NA)
+})
+
+# initialConditions tree kind ----
+
+test_that("the initialConditions spec serializes and parses a set round-trip", {
+  spec <- .entityTreeSpec("initialConditions")
+  section <- list(
+    myset = .asInitialConditionSet(list(
+      list(path = "Organism|A|Concentration", value = 1.5, unit = "mg/l"),
+      list(path = "Organism|B|Concentration", value = 0.5, unit = "µmol/l")
+    ))
+  )
+
+  serialized <- spec$serialize(section, NULL)
+  expect_named(serialized, "myset")
+  expect_identical(serialized$myset$id, "myset")
+  expect_length(serialized$myset$initialConditions, 2L)
+  expect_identical(
+    serialized$myset$initialConditions[[1]]$path,
+    "Organism|A|Concentration"
+  )
+
+  # Feeding the serialized per-file records back through the parser (the load
+  # path reads one `{id, initialConditions}` record per file) reproduces the
+  # in-memory section.
+  records <- unname(serialized)
+  parsed <- spec$parse(records, NULL)
+  expect_named(parsed, "myset")
+  expect_s3_class(parsed$myset, "InitialConditionSet")
+  expect_identical(unclass(parsed$myset), unclass(section$myset))
+})
+
+test_that("the initialConditions spec keeps the empty-vs-absent distinction", {
+  spec <- .entityTreeSpec("initialConditions")
+
+  # A genuinely absent section (NULL) stays a bare list(); a present empty
+  # section ({}) becomes a named-empty list.
+  expect_identical(spec$parse(spec$inline(list()), NULL), list())
+  emptyPresent <- spec$parse(
+    spec$inline(list(
+      initialConditions = structure(list(), names = character(0))
+    )),
+    NULL
+  )
+  expect_length(emptyPresent, 0L)
+  expect_identical(names(emptyPresent), character(0))
+})
+
+test_that("a tree-loaded initialConditions id must match its filename stem", {
+  spec <- .entityTreeSpec("initialConditions")
+  rec <- list(id = "myset", initialConditions = list())
+  attr(rec, ".entityFile") <- "somewhere/otherset.json"
+
+  expect_snapshot(spec$parse(list(rec), NULL), error = TRUE)
+})

--- a/tests/testthat/test-entity-id.R
+++ b/tests/testthat/test-entity-id.R
@@ -1,0 +1,150 @@
+# .canonicalizeId ----
+
+# The result-only assertions below suppress the (intentional) "canonicalized"
+# warning; the warning behavior itself is asserted in its own snapshot test.
+
+test_that(".canonicalizeId lowercases its input", {
+  expect_identical(suppressWarnings(.canonicalizeId("ID")), "id")
+  expect_identical(
+    suppressWarnings(.canonicalizeId("MyScenario")),
+    "myscenario"
+  )
+})
+
+test_that(".canonicalizeId leaves an already-safe id unchanged", {
+  expect_identical(.canonicalizeId("aciclovir_iv"), "aciclovir_iv")
+  expect_identical(.canonicalizeId("global"), "global")
+})
+
+test_that(".canonicalizeId replaces forbidden characters with underscore", {
+  expect_identical(suppressWarnings(.canonicalizeId("a/b")), "a_b")
+  expect_identical(suppressWarnings(.canonicalizeId("a\\b")), "a_b")
+  expect_identical(
+    suppressWarnings(.canonicalizeId("a:b*c?d\"e<f>g|h")),
+    "a_b_c_d_e_f_g_h"
+  )
+})
+
+test_that(".canonicalizeId strips control characters", {
+  expect_identical(suppressWarnings(.canonicalizeId("a\tb\nc")), "a_b_c")
+})
+
+test_that(".canonicalizeId trims leading and trailing dots and spaces", {
+  expect_identical(suppressWarnings(.canonicalizeId(" id ")), "id")
+  expect_identical(suppressWarnings(.canonicalizeId(".id.")), "id")
+  expect_identical(suppressWarnings(.canonicalizeId("..id..")), "id")
+})
+
+test_that(".canonicalizeId maps an empty or all-trimmed id to underscore", {
+  expect_identical(suppressWarnings(.canonicalizeId("")), "_")
+  expect_identical(suppressWarnings(.canonicalizeId("   ")), "_")
+  expect_identical(suppressWarnings(.canonicalizeId("...")), "_")
+})
+
+test_that(".canonicalizeId suffixes a Windows reserved basename", {
+  expect_identical(suppressWarnings(.canonicalizeId("CON")), "con_")
+  expect_identical(suppressWarnings(.canonicalizeId("con")), "con_")
+  expect_identical(suppressWarnings(.canonicalizeId("NUL")), "nul_")
+  expect_identical(suppressWarnings(.canonicalizeId("COM1")), "com1_")
+  expect_identical(suppressWarnings(.canonicalizeId("LPT9")), "lpt9_")
+  # A name that merely starts with a reserved word is fine.
+  expect_identical(.canonicalizeId("console"), "console")
+  expect_identical(.canonicalizeId("com10"), "com10")
+})
+
+test_that(".canonicalizeId is vectorized", {
+  expect_identical(
+    suppressWarnings(.canonicalizeId(c("A", "b/c", "CON"))),
+    c("a", "b_c", "con_")
+  )
+})
+
+test_that(".canonicalizeId warns naming each changed id", {
+  expect_snapshot(out <- .canonicalizeId("My ID*"))
+  expect_identical(out, "my id_")
+})
+
+test_that(".canonicalizeId does not warn when nothing changes", {
+  expect_no_warning(.canonicalizeId("already_safe"))
+})
+
+test_that(".canonicalizeId errors on a post-canonicalization collision", {
+  expect_snapshot(error = TRUE, .canonicalizeId(c("ID", "id")))
+  expect_snapshot(error = TRUE, .canonicalizeId(c("a/b", "a:b")))
+})
+
+# The collision guard must fire through the public authoring API for a
+# case-differing pair (not just literal duplicates): the two ids are distinct
+# on input but canonicalize to the same safe id, and the whole batch aborts
+# writing nothing.
+test_that("a public authoring call aborts on a case-differing id collision", {
+  project <- testProject()
+  before <- names(project$individuals)
+  expect_snapshot(
+    error = TRUE,
+    addIndividual(project, c("Foo", "foo"), species = "Human", gender = "MALE")
+  )
+  expect_identical(names(project$individuals), before)
+})
+
+# An id over the filesystem single-component byte limit becomes an unwritable
+# filename; bound it up front with a clear message rather than letting the
+# eventual file write fail with an opaque `cannot open the connection`.
+test_that(".canonicalizeId errors on an id too long to be a filename", {
+  longId <- strrep("a", 300L)
+  expect_snapshot(error = TRUE, .canonicalizeId(longId))
+})
+
+test_that(".canonicalizeId accepts an id at the byte limit", {
+  atLimit <- strrep("a", 250L)
+  expect_identical(.canonicalizeId(atLimit), atLimit)
+})
+
+# .nearestMatch ----
+
+test_that(".nearestMatch returns the closest candidate within threshold", {
+  expect_identical(
+    .nearestMatch("indiv1", c("Indiv1", "Pop1")),
+    "Indiv1"
+  )
+})
+
+test_that(".nearestMatch is case-insensitive", {
+  expect_identical(
+    .nearestMatch("GLOBAL", c("Global", "somethingFarOff")),
+    "Global"
+  )
+})
+
+test_that(".nearestMatch returns up to three matches ordered by distance", {
+  out <- .nearestMatch(
+    "aci",
+    c("aci1", "aci2", "aci3", "aci4", "totallyDifferent")
+  )
+  expect_length(out, 3L)
+})
+
+test_that(".nearestMatch returns empty when there are no candidates", {
+  expect_identical(.nearestMatch("x", character(0)), character(0))
+})
+
+test_that(".nearestMatch returns empty when nothing is within threshold", {
+  expect_identical(
+    .nearestMatch("abc", c("zzzzzzzzz", "qqqqqqqqq")),
+    character(0)
+  )
+})
+
+# .suggestSuffix ----
+
+test_that(".suggestSuffix builds a 'did you mean' suffix for a near id", {
+  expect_match(
+    .suggestSuffix("indiv1", c("Indiv1", "Pop1")),
+    "did you mean.*Indiv1",
+    ignore.case = TRUE
+  )
+})
+
+test_that(".suggestSuffix is empty when there is no close candidate", {
+  expect_identical(.suggestSuffix("xyz", c("aaaaaaaa", "bbbbbbbb")), "")
+})

--- a/tests/testthat/test-individuals.R
+++ b/tests/testthat/test-individuals.R
@@ -40,10 +40,10 @@ test_that("addIndividual + removeIndividual round-trip leaves the section unchan
   project <- testProject()
   before <- project$individuals
 
-  addIndividual(project, "NewI", species = "Human", gender = "MALE")
-  expect_true("NewI" %in% names(project$individuals))
+  addIndividual(project, "newi", species = "Human", gender = "MALE")
+  expect_true("newi" %in% names(project$individuals))
 
-  removeIndividual(project, "NewI")
+  removeIndividual(project, "newi")
   expect_identical(project$individuals, before)
 })
 
@@ -51,7 +51,7 @@ test_that("addIndividual aborts when individualId already exists", {
   project <- testProject()
   expect_snapshot(
     error = TRUE,
-    addIndividual(project, "Indiv1", species = "Human", gender = "MALE")
+    addIndividual(project, "indiv1", species = "Human", gender = "MALE")
   )
 })
 
@@ -59,14 +59,304 @@ test_that("addIndividual aborts when gender is missing", {
   project <- testProject()
   expect_snapshot(
     error = TRUE,
-    addIndividual(project, "NewI", species = "Human")
+    addIndividual(project, "newi", species = "Human")
   )
-  expect_false("NewI" %in% names(project$individuals))
+  expect_false("newi" %in% names(project$individuals))
 })
 
 test_that("removeIndividual warns when referenced by a scenario", {
   project <- testProject()
-  referenced <- "Indiv1"
+  referenced <- "indiv1"
   expect_warning(removeIndividual(project, referenced), "referenced")
   expect_false(referenced %in% names(project$individuals))
+})
+
+# setIndividual ----
+
+test_that("setIndividual changes a field and persists to file and memory", {
+  project <- testProject()
+  setIndividual(project, "indiv1", weight = 80)
+  expect_equal(project$individuals[["indiv1"]]$weight, 80)
+
+  # The write-through must reach disk: a throwaway reload sees the new value.
+  reloaded <- loadProject(project$jsonPath)
+  expect_equal(reloaded$individuals[["indiv1"]]$weight, 80)
+})
+
+test_that("setIndividual coerces numeric fields like addIndividual", {
+  project <- testProject()
+  setIndividual(project, "indiv1", age = "45")
+  expect_identical(project$individuals[["indiv1"]]$age, 45)
+})
+
+test_that("setIndividual partial update leaves other fields untouched", {
+  project <- testProject()
+  before <- project$individuals[["indiv1"]]
+  setIndividual(project, "indiv1", height = 180)
+
+  after <- project$individuals[["indiv1"]]
+  expect_equal(after$height, 180)
+  for (f in setdiff(names(before), "height")) {
+    expect_equal(after[[f]], before[[f]])
+  }
+})
+
+test_that("setIndividual clears validatedSinceMutation", {
+  project <- testProject()
+  project$.markValidated()
+  setIndividual(project, "indiv1", weight = 80)
+  expect_false(project$validatedSinceMutation)
+})
+
+test_that("setIndividual aborts on a non-existent individual", {
+  project <- testProject()
+  expect_snapshot(
+    error = TRUE,
+    setIndividual(project, "Ghost", weight = 80)
+  )
+})
+
+test_that("setIndividual rejects an empty gender like addIndividual", {
+  project <- testProject()
+  before <- project$individuals[["indiv1"]]
+  expect_snapshot(
+    error = TRUE,
+    setIndividual(project, "indiv1", gender = "")
+  )
+  # Memory unchanged after the rejected write.
+  expect_equal(project$individuals[["indiv1"]], before)
+})
+
+test_that("setIndividual rejects parameterSets that do not resolve", {
+  project <- testProject()
+  expect_snapshot(
+    error = TRUE,
+    setIndividual(project, "indiv1", parameterSets = "Ghost")
+  )
+})
+
+test_that("setIndividual on a clone does not affect the source on disk", {
+  source <- testProject()
+  before <- source$individuals[["indiv1"]]
+  clone <- source$clone()
+  setIndividual(clone, "indiv1", weight = 99)
+
+  expect_equal(clone$individuals[["indiv1"]]$weight, 99)
+  expect_equal(source$individuals[["indiv1"]], before)
+  # The clone's edit must not reach the source's on-disk tree: a fresh load
+  # of the source still sees the original value.
+  reloaded <- loadProject(source$jsonPath)
+  expect_equal(reloaded$individuals[["indiv1"]], before)
+})
+
+# setIndividualParameterSets ----
+
+test_that("setIndividualParameterSets replaces the refs and persists to file", {
+  project <- testProject()
+  # The fixture individual references "indiv1_default"; point it at another
+  # existing set instead.
+  setIndividualParameterSets(project, "indiv1", "global")
+  expect_identical(
+    project$individuals[["indiv1"]]$parameterSets,
+    "global"
+  )
+
+  # The write-through must reach disk.
+  reloaded <- loadProject(project$jsonPath)
+  expect_identical(
+    reloaded$individuals[["indiv1"]]$parameterSets,
+    "global"
+  )
+})
+
+test_that("setIndividualParameterSets aborts on an undefined parameter set", {
+  project <- testProject()
+  before <- project$individuals[["indiv1"]]
+  expect_snapshot(
+    error = TRUE,
+    setIndividualParameterSets(project, "indiv1", "Ghost")
+  )
+  expect_identical(project$individuals[["indiv1"]], before)
+})
+
+# Vectorized authoring ----
+
+test_that("addIndividual adds N individuals in one call equal to N scalar adds", {
+  vectorized <- testProject()
+  addIndividual(
+    vectorized,
+    c("adult_female", "adult_male"),
+    species = "Human",
+    gender = c("FEMALE", "MALE"),
+    weight = 60,
+    height = 165,
+    age = 35,
+    parameterSets = "global"
+  )
+
+  scalar <- testProject()
+  addIndividual(
+    scalar,
+    "adult_female",
+    species = "Human",
+    gender = "FEMALE",
+    weight = 60,
+    height = 165,
+    age = 35,
+    parameterSets = "global"
+  )
+  addIndividual(
+    scalar,
+    "adult_male",
+    species = "Human",
+    gender = "MALE",
+    weight = 60,
+    height = 165,
+    age = 35,
+    parameterSets = "global"
+  )
+
+  expect_identical(
+    vectorized$individuals[c("adult_female", "adult_male")],
+    scalar$individuals[c("adult_female", "adult_male")]
+  )
+})
+
+test_that("addIndividual recycles scalar fields and applies parameterSets whole", {
+  project <- testProject()
+  addIndividual(
+    project,
+    c("a", "b"),
+    species = "Human",
+    gender = c("FEMALE", "MALE"),
+    weight = 60,
+    parameterSets = c("global", "aciclovir")
+  )
+
+  expect_identical(project$individuals$a$species, "Human")
+  expect_identical(project$individuals$a$gender, "FEMALE")
+  expect_identical(project$individuals$b$gender, "MALE")
+  expect_identical(project$individuals$a$weight, 60)
+  expect_identical(project$individuals$b$weight, 60)
+  # parameterSets applied whole to both.
+  expect_identical(
+    project$individuals$a$parameterSets,
+    c("global", "aciclovir")
+  )
+  expect_identical(
+    project$individuals$b$parameterSets,
+    c("global", "aciclovir")
+  )
+})
+
+test_that("addIndividual persists all N to disk in one write-through", {
+  project <- testProject()
+  addIndividual(
+    project,
+    c("a", "b"),
+    species = "Human",
+    gender = "MALE"
+  )
+  reloaded <- loadProject(project$jsonPath)
+  expect_true(all(c("a", "b") %in% names(reloaded$individuals)))
+})
+
+test_that("addIndividual aborts the whole batch and writes nothing on one bad entry", {
+  project <- testProject()
+  before <- names(project$individuals)
+  expect_error(
+    addIndividual(
+      project,
+      c("a", "b"),
+      species = "Human",
+      # b has no gender -> the whole batch must abort.
+      gender = c("MALE", "")
+    )
+  )
+  # Neither memory nor disk gained any individual.
+  expect_identical(names(project$individuals), before)
+  reloaded <- loadProject(project$jsonPath)
+  expect_identical(names(reloaded$individuals), before)
+})
+
+test_that("addIndividual aborts on a mismatched scalar field length", {
+  project <- testProject()
+  expect_snapshot(
+    error = TRUE,
+    addIndividual(
+      project,
+      c("a", "b", "c"),
+      species = "Human",
+      gender = c("MALE", "FEMALE")
+    )
+  )
+})
+
+test_that("addIndividual aborts on a duplicate id in the batch", {
+  project <- testProject()
+  expect_snapshot(
+    error = TRUE,
+    addIndividual(project, c("a", "a"), species = "Human", gender = "MALE")
+  )
+})
+
+test_that("setIndividual vectorizes a partial update across N ids", {
+  project <- testProject()
+  addIndividual(project, c("a", "b"), species = "Human", gender = "MALE")
+  setIndividual(project, c("a", "b"), weight = c(80, 90), age = 40)
+
+  expect_identical(project$individuals$a$weight, 80)
+  expect_identical(project$individuals$b$weight, 90)
+  expect_identical(project$individuals$a$age, 40)
+  expect_identical(project$individuals$b$age, 40)
+  # An unsupplied field is untouched.
+  expect_identical(project$individuals$a$gender, "MALE")
+})
+
+test_that("removeIndividual removes a vector of ids in one write-through", {
+  project <- testProject()
+  addIndividual(project, c("a", "b"), species = "Human", gender = "MALE")
+  removeIndividual(project, c("a", "b"))
+  expect_false(any(c("a", "b") %in% names(project$individuals)))
+  reloaded <- loadProject(project$jsonPath)
+  expect_false(any(c("a", "b") %in% names(reloaded$individuals)))
+})
+
+test_that("setIndividualParameterSets vectorizes whole across N ids", {
+  project <- testProject()
+  addIndividual(project, c("a", "b"), species = "Human", gender = "MALE")
+  setIndividualParameterSets(project, c("a", "b"), c("global", "aciclovir"))
+  expect_identical(
+    project$individuals$a$parameterSets,
+    c("global", "aciclovir")
+  )
+  expect_identical(
+    project$individuals$b$parameterSets,
+    c("global", "aciclovir")
+  )
+})
+
+# Print method ----
+
+test_that("print.Individual renders the configured fields", {
+  project <- testProject()
+  withr::local_options(cli.unicode = FALSE)
+  local_reproducible_output()
+  expect_snapshot(print(project$individuals[["indiv1"]]))
+})
+
+test_that("print.Individual renders a minimal individual", {
+  project <- testProject()
+  addIndividual(project, "minimal", species = "Human", gender = "MALE")
+  withr::local_options(cli.unicode = FALSE)
+  local_reproducible_output()
+  expect_snapshot(print(project$individuals[["minimal"]]))
+})
+
+test_that("a classed Individual still behaves as a list", {
+  project <- testProject()
+  indiv <- project$individuals[["indiv1"]]
+  expect_type(indiv, "list")
+  expect_identical(indiv[["species"]], "Human")
+  expect_true("gender" %in% names(indiv))
 })

--- a/tests/testthat/test-observed-data.R
+++ b/tests/testthat/test-observed-data.R
@@ -232,10 +232,11 @@ test_that("addObservedData appends a valid config entry", {
   before <- length(project$observedData)
   addObservedData(project, list(type = "pkml", file = "extra.pkml"))
   expect_length(project$observedData, before + 1L)
-  expect_equal(
-    project$observedData[[before + 1L]],
-    list(type = "pkml", file = "extra.pkml")
-  )
+  added <- project$observedData[[before + 1L]]
+  # The entry is classed as an ObservedDataSource (a transparent list wrapper
+  # for printing); compare the fields, not the class.
+  expect_s3_class(added, "ObservedDataSource")
+  expect_equal(unclass(added), list(type = "pkml", file = "extra.pkml"))
 })
 
 test_that("addObservedData rejects an under-specified config entry", {
@@ -262,4 +263,91 @@ test_that("addObservedData rejects a duplicate config entry file", {
     )
   )
   expect_length(project$observedData, 1L)
+})
+
+# Two declarations whose `file` differs only by directory derive the same
+# on-disk id (the basename) and would silently overwrite each other (the second
+# lost on reload). The section accessor is read-only, so the only way such a
+# section reaches the write path is a raw `.setSection()` write, which bypasses
+# addObservedData()'s own basename guard; it must fail fast in the
+# serialize/write path naming the collision, leaving disk and memory unchanged.
+test_that("observedData declarations sharing a basename fail the write-through", {
+  project <- testProject()
+  dir <- file.path(project$projectDirPath, "definitions", "observed-data")
+  before <- if (dir.exists(dir)) list.files(dir) else character()
+  beforeMem <- project$observedData
+
+  colliding <- list(
+    list(type = "pkml", file = "dirA/obs.pkml"),
+    list(type = "pkml", file = "dirB/obs.pkml")
+  )
+  expect_snapshot(
+    project$.setSection("observedData", colliding),
+    error = TRUE
+  )
+
+  # Neither the in-memory section nor the on-disk tree changed.
+  expect_identical(project$observedData, beforeMem)
+  if (dir.exists(dir)) {
+    expect_setequal(list.files(dir), before)
+  }
+})
+
+# removeObservedData write-through ----
+
+test_that("removeObservedData deletes the entity file and persists to disk", {
+  project <- testProject()
+  dir <- file.path(project$projectDirPath, "definitions", "observed-data")
+  # The fixture declares one Excel source, filed under its basename.
+  id <- "Aciclovir_TimeValuesData.xlsx"
+  expect_true(file.exists(file.path(dir, paste0(id, ".json"))))
+
+  suppressWarnings(removeObservedData(project, id))
+
+  # In memory the declaration is gone, the entity file is deleted, and a fresh
+  # load no longer sees it.
+  expect_false(any(vapply(
+    project$observedData,
+    function(e) identical(basename(e[["file"]] %||% ""), id),
+    logical(1)
+  )))
+  expect_false(file.exists(file.path(dir, paste0(id, ".json"))))
+  reloaded <- loadProject(project$jsonPath)
+  expect_length(reloaded$observedData, 0L)
+})
+
+test_that("removeObservedData removes a vector of ids in one pass", {
+  project <- testProject()
+  addObservedData(project, list(type = "pkml", file = "one.pkml"))
+  addObservedData(project, list(type = "pkml", file = "two.pkml"))
+  before <- length(project$observedData)
+
+  removeObservedData(project, c("one.pkml", "two.pkml"))
+  expect_length(project$observedData, before - 2L)
+  files <- vapply(
+    project$observedData,
+    function(e) basename(e[["file"]] %||% NA_character_),
+    character(1)
+  )
+  expect_false(any(c("one.pkml", "two.pkml") %in% files))
+})
+
+test_that("removeObservedData warns and skips a not-found id in the batch", {
+  project <- testProject()
+  addObservedData(project, list(type = "pkml", file = "one.pkml"))
+  before <- length(project$observedData)
+  expect_warning(
+    removeObservedData(project, c("one.pkml", "ghost.pkml")),
+    "ghost.pkml"
+  )
+  expect_length(project$observedData, before - 1L)
+})
+
+# Print method ----
+
+test_that("print.ObservedDataSource renders the source declaration", {
+  project <- testProject()
+  withr::local_options(cli.unicode = FALSE)
+  local_reproducible_output()
+  expect_snapshot(print(project$observedData[[1]]))
 })

--- a/tests/testthat/test-output-paths.R
+++ b/tests/testthat/test-output-paths.R
@@ -1,18 +1,19 @@
-test_that("addOutputPath() sets modified and clears validatedSinceMutation", {
+test_that("addOutputPath() clears validatedSinceMutation", {
   project <- testProject()
   project$.markValidated()
   expect_true(project$validatedSinceMutation)
 
   addOutputPath(project, "X", "Organism|A|Concentration in container")
 
-  expect_true(project$modified)
   expect_false(project$validatedSinceMutation)
 })
 
 test_that("removeOutputPath() warns on missing key and is a no-op", {
   project <- testProject()
+  project$.markValidated()
   expect_warning(removeOutputPath(project, "Ghost"), "not found")
-  expect_false(project$modified)
+  # A no-op must not invalidate the validation cache.
+  expect_true(project$validatedSinceMutation)
 })
 
 test_that("addOutputPath aborts on a duplicate id", {
@@ -37,4 +38,136 @@ test_that("removeOutputPath warns when the id is referenced by a scenario, remov
 
   expect_warning(removeOutputPath(project, referenced), "referenced")
   expect_false(referenced %in% names(project$outputPaths))
+})
+
+# setOutputPath ----
+
+test_that("setOutputPath changes the literal path and persists to file and memory", {
+  project <- testProject()
+  id <- names(project$outputPaths)[[1]]
+  setOutputPath(project, id, "Organism|Lung|Concentration in container")
+
+  expect_equal(
+    project$outputPaths[[id]],
+    "Organism|Lung|Concentration in container"
+  )
+
+  # The write-through must reach disk: a throwaway reload sees the new path.
+  reloaded <- loadProject(project$jsonPath)
+  expect_equal(
+    reloaded$outputPaths[[id]],
+    "Organism|Lung|Concentration in container"
+  )
+})
+
+test_that("setOutputPath clears validatedSinceMutation", {
+  project <- testProject()
+  project$.markValidated()
+  id <- names(project$outputPaths)[[1]]
+  setOutputPath(project, id, "Organism|Lung|Concentration in container")
+  expect_false(project$validatedSinceMutation)
+})
+
+test_that("setOutputPath leaves the other ids untouched", {
+  project <- testProject()
+  ids <- names(project$outputPaths)
+  other <- ids[[2]]
+  beforeOther <- project$outputPaths[[other]]
+
+  setOutputPath(project, ids[[1]], "Organism|Lung|Concentration in container")
+  expect_equal(project$outputPaths[[other]], beforeOther)
+})
+
+test_that("setOutputPath aborts on a non-existent id", {
+  project <- testProject()
+  expect_snapshot(
+    error = TRUE,
+    setOutputPath(project, "Ghost", "Organism|A|Concentration in container")
+  )
+})
+
+test_that("setOutputPath rejects an empty path", {
+  project <- testProject()
+  id <- names(project$outputPaths)[[1]]
+  before <- project$outputPaths[[id]]
+  expect_snapshot(
+    error = TRUE,
+    setOutputPath(project, id, "")
+  )
+  expect_equal(project$outputPaths[[id]], before)
+})
+
+test_that("setOutputPath on a clone does not affect the source on disk", {
+  source <- testProject()
+  id <- names(source$outputPaths)[[1]]
+  before <- source$outputPaths[[id]]
+  clone <- source$clone()
+  setOutputPath(clone, id, "Organism|Lung|Concentration in container")
+
+  expect_equal(
+    clone$outputPaths[[id]],
+    "Organism|Lung|Concentration in container"
+  )
+  expect_equal(source$outputPaths[[id]], before)
+  # The clone's edit must not reach the source's on-disk tree.
+  reloaded <- loadProject(source$jsonPath)
+  expect_equal(reloaded$outputPaths[[id]], before)
+})
+
+# Vectorized authoring ----
+
+test_that("addOutputPath recycles a single path to every id", {
+  project <- testProject()
+  addOutputPath(project, c("a", "b"), "Organism|Liver|X")
+  expect_identical(project$outputPaths$a, "Organism|Liver|X")
+  expect_identical(project$outputPaths$b, "Organism|Liver|X")
+})
+
+test_that("addOutputPath aligns a length-N path vector by position", {
+  project <- testProject()
+  addOutputPath(project, c("a", "b"), c("Organism|A", "Organism|B"))
+  expect_identical(project$outputPaths$a, "Organism|A")
+  expect_identical(project$outputPaths$b, "Organism|B")
+  reloaded <- loadProject(project$jsonPath)
+  expect_identical(reloaded$outputPaths$a, "Organism|A")
+  expect_identical(reloaded$outputPaths$b, "Organism|B")
+})
+
+test_that("addOutputPath aborts on a path length that is neither 1 nor N", {
+  project <- testProject()
+  expect_snapshot(
+    error = TRUE,
+    addOutputPath(project, c("a", "b", "c"), c("X", "Y"))
+  )
+})
+
+test_that("setOutputPath vectorizes across N ids", {
+  project <- testProject()
+  addOutputPath(project, c("a", "b"), c("Organism|A", "Organism|B"))
+  setOutputPath(project, c("a", "b"), c("Organism|A2", "Organism|B2"))
+  expect_identical(project$outputPaths$a, "Organism|A2")
+  expect_identical(project$outputPaths$b, "Organism|B2")
+})
+
+test_that("removeOutputPath removes a vector of ids in one write-through", {
+  project <- testProject()
+  addOutputPath(project, c("a", "b"), "Organism|X")
+  removeOutputPath(project, c("a", "b"))
+  expect_false(any(c("a", "b") %in% names(project$outputPaths)))
+  reloaded <- loadProject(project$jsonPath)
+  expect_false(any(c("a", "b") %in% names(reloaded$outputPaths)))
+})
+
+test_that("addOutputPath aborts the whole batch and writes nothing on one bad id", {
+  project <- testProject()
+  before <- names(project$outputPaths)
+  existing <- before[[1]]
+  expect_error(
+    # "a" is new but the second id already exists, so the whole batch aborts.
+    addOutputPath(project, c("a", existing), "Organism|X")
+  )
+  # Neither memory nor disk gained the new id.
+  expect_identical(names(project$outputPaths), before)
+  reloaded <- loadProject(project$jsonPath)
+  expect_identical(names(reloaded$outputPaths), before)
 })

--- a/tests/testthat/test-parameters.R
+++ b/tests/testthat/test-parameters.R
@@ -1,7 +1,5 @@
-dataFolder <- getTestDataFilePath("")
-
 test_that("It can read an empty sheet", {
-  paramsXLSpath <- file.path(dataFolder, "Parameters.xlsx")
+  paramsXLSpath <- getTestDataFilePath("Parameters.xlsx")
   sheets <- c("EmptySheet")
   params <- readParametersFromXLS(
     paramsXLSpath = paramsXLSpath,
@@ -14,7 +12,7 @@ test_that("It can read an empty sheet", {
 })
 
 test_that("It can read a properly defined file", {
-  paramsXLSpath <- file.path(dataFolder, "Parameters.xlsx")
+  paramsXLSpath <- getTestDataFilePath("Parameters.xlsx")
   sheets <- c("ValidSheet")
   params <- readParametersFromXLS(
     paramsXLSpath = paramsXLSpath,
@@ -25,7 +23,7 @@ test_that("It can read a properly defined file", {
 })
 
 test_that("It can read a properly defined file with extra columns", {
-  paramsXLSpath <- file.path(dataFolder, "Parameters.xlsx")
+  paramsXLSpath <- getTestDataFilePath("Parameters.xlsx")
   sheets <- c("ValidSheed_extraColumns")
   params <- readParametersFromXLS(
     paramsXLSpath = paramsXLSpath,
@@ -36,7 +34,7 @@ test_that("It can read a properly defined file with extra columns", {
 })
 
 test_that("It throws an error when a sheet has wrong structure", {
-  paramsXLSpath <- file.path(dataFolder, "Parameters.xlsx")
+  paramsXLSpath <- getTestDataFilePath("Parameters.xlsx")
   sheets <- "InvalidSheet"
   columnNames <- c("Container Path", "Parameter Name", "Value", "Units")
   expect_error(
@@ -46,7 +44,7 @@ test_that("It throws an error when a sheet has wrong structure", {
 })
 
 test_that("It overwrites the value if the path is present in multiple sheets", {
-  paramsXLSpath <- file.path(dataFolder, "Parameters.xlsx")
+  paramsXLSpath <- getTestDataFilePath("Parameters.xlsx")
   sheets <- c("ValidSheet", "SecondSheet")
   params <- readParametersFromXLS(
     paramsXLSpath = paramsXLSpath,
@@ -184,49 +182,733 @@ test_that("It extends a structure by a new structure", {
   expect_equal(extended$units, c("", "", "µmol"))
 })
 
-test_that("removeModelParameterEntry auto-removes empty parameter sets", {
-  project <- testProject()
-  addModelParameterEntry(project, "TempSet", "Organism|A", "K", 1.5, "1/h")
-  expect_true("TempSet" %in% names(project$modelParameterSets))
+# Unified parameterSets section ----
 
-  removeModelParameterEntry(project, "TempSet", "Organism|A", "K")
-  expect_false("TempSet" %in% names(project$modelParameterSets))
+test_that("addParameterSet creates a set; removeParameterSet drops it", {
+  project <- testProject()
+  addParameterSet(project, "newset")
+  expect_true("newset" %in% names(project$parameterSets))
+
+  removeParameterSet(project, "newset")
+  expect_false("newset" %in% names(project$parameterSets))
 })
 
-test_that("remove*ParameterEntry no-op on missing entry does not mark modified", {
+test_that("addParameterSet canonicalizes its id", {
   project <- testProject()
-  addModelParameterEntry(project, "MSet", "Organism|A", "K", 1.5, "1/h")
-  addApplicationParameterEntry(
-    project,
-    "ASet",
-    "Organism|B",
-    "K",
-    2,
-    "1/h"
+  expect_snapshot(addParameterSet(project, "New Set"))
+  expect_true("new set" %in% names(project$parameterSets))
+})
+
+test_that("addParameterSet aborts on a duplicate id", {
+  project <- testProject()
+  expect_snapshot(error = TRUE, addParameterSet(project, "global"))
+})
+
+test_that("addParameterEntry creates the set on demand and appends entries", {
+  project <- testProject()
+  # Creating a set on demand is divergent from the other add* functions, so it
+  # informs the user the first time (and only then).
+  expect_snapshot(
+    addParameterEntry(project, "tempset", "Organism|A", "K", 1.5, "1/h")
   )
-  addIndividualParameterEntry(
+  expect_true("tempset" %in% names(project$parameterSets))
+  expect_length(project$parameterSets$tempset, 1L)
+
+  # Appending to the existing set does not re-inform.
+  expect_no_message(
+    addParameterEntry(project, "tempset", "Organism|B", "L", 2.5, "1/h")
+  )
+  expect_length(project$parameterSets$tempset, 2L)
+})
+
+test_that("addParameterEntry accepts parallel vectors and writes once", {
+  project <- testProject()
+  dir <- file.path(project$projectDirPath, "definitions", "parameter-sets")
+
+  n <- 5L
+  suppressMessages(
+    addParameterEntry(
+      project,
+      "vecset",
+      containerPath = paste0("Organism|A", seq_len(n)),
+      parameterName = paste0("P", seq_len(n)),
+      value = as.double(seq_len(n)),
+      units = rep("1/h", n)
+    )
+  )
+
+  # All N entries land in memory and on disk after one vectorized call.
+  expect_length(project$parameterSets$vecset, n)
+  reloaded <- loadProject(project$jsonPath)
+  expect_length(reloaded$parameterSets$vecset, n)
+  expect_identical(
+    vapply(reloaded$parameterSets$vecset, \(e) e$parameterName, character(1)),
+    paste0("P", seq_len(n))
+  )
+})
+
+test_that("a vectorized addParameterEntry equals three scalar adds", {
+  vectorized <- testProject()
+  suppressMessages(
+    addParameterEntry(
+      vectorized,
+      "set",
+      containerPath = c("Organism|A", "Organism|B", "Organism|C"),
+      parameterName = c("Ka", "Kb", "Kc"),
+      value = c(1, 2, 3),
+      units = c("1/h", "", "mg")
+    )
+  )
+
+  scalar <- testProject()
+  suppressMessages(
+    addParameterEntry(scalar, "set", "Organism|A", "Ka", 1, "1/h")
+  )
+  addParameterEntry(scalar, "set", "Organism|B", "Kb", 2, "")
+  addParameterEntry(scalar, "set", "Organism|C", "Kc", 3, "mg")
+
+  expect_identical(
+    vectorized$parameterSets$set,
+    scalar$parameterSets$set
+  )
+})
+
+test_that("addParameterEntry last-write-wins on an in-batch duplicate", {
+  project <- testProject()
+  suppressMessages(
+    addParameterEntry(
+      project,
+      "dupset",
+      containerPath = c("Organism|A", "Organism|A"),
+      parameterName = c("K", "K"),
+      value = c(1, 9),
+      units = c("1/h", "1/min")
+    )
+  )
+
+  # The duplicate (containerPath, parameterName) collapses to one entry, last
+  # value winning, matching the scalar last-write-wins semantics.
+  expect_length(project$parameterSets$dupset, 1L)
+  expect_identical(project$parameterSets$dupset[[1]]$value, 9)
+  expect_identical(project$parameterSets$dupset[[1]]$units, "1/min")
+})
+
+test_that("addParameterEntry aborts on mismatched vector lengths", {
+  project <- testProject()
+  expect_snapshot(
+    error = TRUE,
+    addParameterEntry(
+      project,
+      "set",
+      containerPath = c("Organism|A", "Organism|B"),
+      parameterName = "K",
+      value = c(1, 2),
+      units = "1/h"
+    )
+  )
+})
+
+test_that("a single scalar addParameterEntry still works (regression)", {
+  project <- testProject()
+  suppressMessages(
+    addParameterEntry(project, "scalarset", "Organism|A", "K", 1.5, "1/h")
+  )
+  expect_length(project$parameterSets$scalarset, 1L)
+  expect_identical(
+    project$parameterSets$scalarset[[1]]$containerPath,
+    "Organism|A"
+  )
+})
+
+# A parameter set with many entries built in ONE vectorized call writes the set
+# file exactly once. The per-call write-through re-encodes the whole growing
+# set file, so an N-call buildup loop is O(N^2); the vectorized call collapses
+# it to a single write. The prior linear-scaling regression test only exercised
+# adding many DISTINCT sets (one entry each), so it never guarded this growing-
+# set buildup case.
+test_that("a vectorized bulk add of many entries is fast (one write)", {
+  skip_on_cran()
+  project <- testProject()
+
+  n <- 1000L
+  elapsed <- system.time(
+    suppressMessages(
+      addParameterEntry(
+        project,
+        "bulk",
+        containerPath = paste0("Organism|A", seq_len(n)),
+        parameterName = paste0("P", seq_len(n)),
+        value = as.double(seq_len(n)),
+        units = rep("1/h", n)
+      )
+    )
+  )[["elapsed"]]
+
+  expect_length(project$parameterSets$bulk, n)
+  # One write of the whole set is well under a second on any machine; the old
+  # per-call loop took ~26s for the same 1000 entries. A generous ceiling keeps
+  # the test robust to machine noise while still failing on a regression back
+  # to per-entry writes.
+  expect_lt(elapsed, 5)
+})
+
+test_that("removeParameterEntry accepts parallel vectors", {
+  project <- testProject()
+  suppressMessages(
+    addParameterEntry(
+      project,
+      "rset",
+      containerPath = c("Organism|A", "Organism|B", "Organism|C"),
+      parameterName = c("Ka", "Kb", "Kc"),
+      value = c(1, 2, 3),
+      units = c("1/h", "1/h", "1/h")
+    )
+  )
+
+  removeParameterEntry(
     project,
-    "ISet",
-    "Organism|C",
-    "K",
-    3,
-    "1/h"
+    "rset",
+    containerPath = c("Organism|A", "Organism|C"),
+    parameterName = c("Ka", "Kc")
+  )
+
+  expect_length(project$parameterSets$rset, 1L)
+  reloaded <- loadProject(project$jsonPath)
+  expect_length(reloaded$parameterSets$rset, 1L)
+  expect_identical(
+    reloaded$parameterSets$rset[[1]]$parameterName,
+    "Kb"
+  )
+})
+
+test_that("removeParameterEntry auto-removes an emptied parameter set", {
+  project <- testProject()
+  suppressMessages(
+    addParameterEntry(project, "tempset", "Organism|A", "K", 1.5, "1/h")
+  )
+  expect_true("tempset" %in% names(project$parameterSets))
+
+  removeParameterEntry(project, "tempset", "Organism|A", "K")
+  expect_false("tempset" %in% names(project$parameterSets))
+})
+
+# On-disk delete / nested-record-update write-through ----
+
+test_that("removeParameterSet deletes the entity file and persists to disk", {
+  project <- testProject()
+  dir <- file.path(project$projectDirPath, "definitions", "parameter-sets")
+  suppressMessages(
+    addParameterEntry(project, "tempset", "Organism|A", "K", 1.5, "1/h")
+  )
+  expect_true(file.exists(file.path(dir, "tempset.json")))
+
+  removeParameterSet(project, "tempset")
+
+  # In memory gone, entity file deleted, and absent from a fresh load.
+  expect_false("tempset" %in% names(project$parameterSets))
+  expect_false(file.exists(file.path(dir, "tempset.json")))
+  reloaded <- loadProject(project$jsonPath)
+  expect_false("tempset" %in% names(reloaded$parameterSets))
+})
+
+test_that("removeParameterEntry updates the on-disk set when entries remain", {
+  project <- testProject()
+  dir <- file.path(project$projectDirPath, "definitions", "parameter-sets")
+  suppressMessages(
+    addParameterEntry(project, "tempset", "Organism|A", "K", 1.5, "1/h")
+  )
+  addParameterEntry(project, "tempset", "Organism|B", "L", 2.5, "1/h")
+
+  removeParameterEntry(project, "tempset", "Organism|A", "K")
+
+  # The set survives with one entry; the on-disk file and a fresh load both
+  # reflect the removal of the single entry.
+  expect_length(project$parameterSets$tempset, 1L)
+  reloaded <- loadProject(project$jsonPath)
+  expect_length(reloaded$parameterSets$tempset, 1L)
+  expect_identical(
+    reloaded$parameterSets$tempset[[1]]$containerPath,
+    "Organism|B"
+  )
+})
+
+test_that("removeParameterEntry no-op on a missing entry does not mark modified", {
+  project <- testProject()
+  suppressMessages(
+    addParameterEntry(project, "mset", "Organism|A", "K", 1.5, "1/h")
   )
   project$.markValidated()
   expect_true(project$validatedSinceMutation)
 
   expect_warning(
-    removeModelParameterEntry(project, "MSet", "Organism|A", "Ghost"),
-    "not found"
-  )
-  expect_warning(
-    removeApplicationParameterEntry(project, "ASet", "Organism|B", "Ghost"),
-    "not found"
-  )
-  expect_warning(
-    removeIndividualParameterEntry(project, "ISet", "Organism|C", "Ghost"),
+    removeParameterEntry(project, "mset", "Organism|A", "Ghost"),
     "not found"
   )
 
   expect_true(project$validatedSinceMutation)
+})
+
+test_that("the three former parameter-set kinds are merged into project$parameterSets", {
+  project <- testProject()
+  # The TestProject fixture has model sets (global, aciclovir), one individual
+  # set (indiv1_default), and one application set (aciclovir_iv_250mg_default);
+  # all live under the single parameterSets section now.
+  expect_setequal(
+    names(project$parameterSets),
+    c("global", "aciclovir", "indiv1_default", "aciclovir_iv_250mg_default")
+  )
+})
+
+# Vectorized addParameterSet / removeParameterSet ----
+
+test_that("addParameterSet adds N sets in one write-through", {
+  project <- testProject()
+  addParameterSet(project, c("setA", "setB"))
+  expect_true(all(c("seta", "setb") %in% names(project$parameterSets)))
+  reloaded <- loadProject(project$jsonPath)
+  expect_true(all(c("seta", "setb") %in% names(reloaded$parameterSets)))
+})
+
+test_that("addParameterSet aborts the whole batch on a clash and writes nothing", {
+  project <- testProject()
+  before <- names(project$parameterSets)
+  expect_error(addParameterSet(project, c("newone", "global")))
+  expect_identical(names(project$parameterSets), before)
+})
+
+test_that("removeParameterSet removes a vector of ids in one write-through", {
+  project <- testProject()
+  addParameterSet(project, c("a", "b"))
+  removeParameterSet(project, c("a", "b"))
+  expect_false(any(c("a", "b") %in% names(project$parameterSets)))
+  reloaded <- loadProject(project$jsonPath)
+  expect_false(any(c("a", "b") %in% names(reloaded$parameterSets)))
+})
+
+test_that("removeParameterSet warns when still referenced by a scenario, removes anyway", {
+  project <- testProject()
+  withr::local_options(cli.unicode = FALSE)
+  # `global` is a `modelParameterSets` entry of every scenario in the fixture.
+  expect_snapshot(removeParameterSet(project, "global"))
+  expect_false("global" %in% names(project$parameterSets))
+})
+
+test_that("removeParameterSet warns when still referenced by an individual, removes anyway", {
+  project <- testProject()
+  withr::local_options(cli.unicode = FALSE)
+  # `indiv1_default` is a `parameterSets` entry of individual `indiv1`, so this
+  # exercises the individual-holder branch of the still-referenced scan.
+  expect_snapshot(removeParameterSet(project, "indiv1_default"))
+  expect_false("indiv1_default" %in% names(project$parameterSets))
+})
+
+# Print method ----
+
+test_that("print.ParameterSet renders the entry count and a compact table", {
+  project <- testProject()
+  withr::local_options(cli.unicode = FALSE)
+  local_reproducible_output()
+  expect_snapshot(print(project$parameterSets[["global"]]))
+})
+
+test_that("print.ParameterSet renders an empty set", {
+  project <- testProject()
+  addParameterSet(project, "emptyset")
+  withr::local_options(cli.unicode = FALSE)
+  local_reproducible_output()
+  expect_snapshot(print(project$parameterSets[["emptyset"]]))
+})
+
+test_that("a classed ParameterSet still behaves as a list", {
+  project <- testProject()
+  set <- project$parameterSets[["global"]]
+  expect_type(set, "list")
+  expect_gt(length(set), 0L)
+  expect_true(is.list(set[[1]]))
+})
+
+# initialConditions CRUD ----
+
+test_that("addInitialConditions creates a set; removeInitialConditions drops it", {
+  project <- testProject()
+  addInitialConditions(project, "newset")
+  expect_true("newset" %in% names(project$initialConditions))
+
+  removeInitialConditions(project, "newset")
+  expect_false("newset" %in% names(project$initialConditions))
+})
+
+test_that("addInitialConditions canonicalizes its id", {
+  project <- testProject()
+  expect_snapshot(addInitialConditions(project, "New Set"))
+  expect_true("new set" %in% names(project$initialConditions))
+})
+
+test_that("addInitialConditions aborts on a duplicate id", {
+  project <- testProject()
+  addInitialConditions(project, "dupset")
+  expect_snapshot(error = TRUE, addInitialConditions(project, "dupset"))
+})
+
+test_that("addInitialConditionEntry creates the set on demand and appends", {
+  project <- testProject()
+  expect_snapshot(
+    addInitialConditionEntry(project, "tempset", "Organism|A", 1.5, "mg/l")
+  )
+  expect_true("tempset" %in% names(project$initialConditions))
+  expect_length(project$initialConditions$tempset, 1L)
+
+  expect_no_message(
+    addInitialConditionEntry(project, "tempset", "Organism|B", 2.5, "mg/l")
+  )
+  expect_length(project$initialConditions$tempset, 2L)
+})
+
+test_that("a vectorized addInitialConditionEntry equals three scalar adds", {
+  project <- testProject()
+  suppressMessages(
+    addInitialConditionEntry(
+      project,
+      "vecset",
+      path = c("Organism|A", "Organism|B", "Organism|C"),
+      value = c(1, 2, 3),
+      unit = c("mg/l", "mg/l", "µmol/l")
+    )
+  )
+
+  scalar <- testProject()
+  suppressMessages(
+    addInitialConditionEntry(scalar, "vecset", "Organism|A", 1, "mg/l")
+  )
+  addInitialConditionEntry(scalar, "vecset", "Organism|B", 2, "mg/l")
+  addInitialConditionEntry(scalar, "vecset", "Organism|C", 3, "µmol/l")
+
+  expect_identical(
+    unclass(project$initialConditions$vecset),
+    unclass(scalar$initialConditions$vecset)
+  )
+})
+
+test_that("addInitialConditionEntry last-write-wins on an in-batch duplicate", {
+  project <- testProject()
+  suppressMessages(
+    addInitialConditionEntry(
+      project,
+      "dset",
+      path = c("Organism|A", "Organism|A"),
+      value = c(1, 9),
+      unit = c("mg/l", "mg/l")
+    )
+  )
+  expect_length(project$initialConditions$dset, 1L)
+  expect_identical(project$initialConditions$dset[[1]]$value, 9)
+})
+
+test_that("addInitialConditionEntry aborts on mismatched vector lengths", {
+  project <- testProject()
+  expect_snapshot(
+    error = TRUE,
+    addInitialConditionEntry(
+      project,
+      "set",
+      path = c("Organism|A", "Organism|B"),
+      value = 1,
+      unit = "mg/l"
+    )
+  )
+})
+
+test_that("addInitialConditionEntry aborts on a blank unit (units are mandatory)", {
+  project <- testProject()
+  expect_snapshot(
+    error = TRUE,
+    addInitialConditionEntry(project, "set", "Organism|A", 1.5, "")
+  )
+})
+
+test_that("addInitialConditionEntry writes the set to disk once", {
+  project <- testProject()
+  dir <- file.path(
+    project$projectDirPath,
+    "definitions",
+    "initial-conditions"
+  )
+  suppressMessages(
+    addInitialConditionEntry(project, "diskset", "Organism|A", 1.5, "mg/l")
+  )
+  expect_true(file.exists(file.path(dir, "diskset.json")))
+  reloaded <- loadProject(project$jsonPath)
+  expect_length(reloaded$initialConditions$diskset, 1L)
+  expect_identical(reloaded$initialConditions$diskset[[1]]$path, "Organism|A")
+})
+
+test_that("removeInitialConditionEntry auto-removes an emptied set", {
+  project <- testProject()
+  suppressMessages(
+    addInitialConditionEntry(project, "tempset", "Organism|A", 1.5, "mg/l")
+  )
+  removeInitialConditionEntry(project, "tempset", "Organism|A")
+  expect_false("tempset" %in% names(project$initialConditions))
+})
+
+test_that("removeInitialConditionEntry updates the on-disk set when entries remain", {
+  project <- testProject()
+  suppressMessages(
+    addInitialConditionEntry(project, "tempset", "Organism|A", 1.5, "mg/l")
+  )
+  addInitialConditionEntry(project, "tempset", "Organism|B", 2.5, "mg/l")
+
+  removeInitialConditionEntry(project, "tempset", "Organism|A")
+
+  expect_length(project$initialConditions$tempset, 1L)
+  reloaded <- loadProject(project$jsonPath)
+  expect_length(reloaded$initialConditions$tempset, 1L)
+  expect_identical(
+    reloaded$initialConditions$tempset[[1]]$path,
+    "Organism|B"
+  )
+})
+
+test_that("addInitialConditions adds N sets in one write-through", {
+  project <- testProject()
+  addInitialConditions(project, c("setA", "setB"))
+  expect_true(all(c("seta", "setb") %in% names(project$initialConditions)))
+  reloaded <- loadProject(project$jsonPath)
+  expect_true(all(c("seta", "setb") %in% names(reloaded$initialConditions)))
+})
+
+test_that("removeInitialConditionEntry no-op on a missing entry warns", {
+  project <- testProject()
+  suppressMessages(
+    addInitialConditionEntry(project, "mset", "Organism|A", 1.5, "mg/l")
+  )
+  expect_warning(
+    removeInitialConditionEntry(project, "mset", "Organism|Ghost"),
+    "not found"
+  )
+  expect_length(project$initialConditions$mset, 1L)
+})
+
+test_that("removeInitialConditions warns when still referenced by a scenario, removes anyway", {
+  project <- testProject()
+  withr::local_options(cli.unicode = FALSE)
+  addInitialConditions(project, "refset")
+  setScenario(project, "testscenario", initialConditions = "refset")
+  expect_snapshot(removeInitialConditions(project, "refset"))
+  expect_false("refset" %in% names(project$initialConditions))
+})
+
+# Print method ----
+
+test_that("print.InitialConditionSet renders the entry count and a compact table", {
+  project <- testProject()
+  suppressMessages(
+    addInitialConditionEntry(
+      project,
+      "printset",
+      path = c("Organism|A", "Organism|B"),
+      value = c(1.5, 0.5),
+      unit = c("mg/l", "µmol/l")
+    )
+  )
+  withr::local_options(cli.unicode = FALSE)
+  local_reproducible_output()
+  expect_snapshot(print(project$initialConditions[["printset"]]))
+})
+
+test_that("print.InitialConditionSet renders a unit-less entry", {
+  # A hand-edited entity file can carry a record with no unit; the print method
+  # must still render it (blank-unit branch). Build the set directly since the
+  # authoring API requires a unit.
+  set <- esqlabsR:::.asInitialConditionSet(list(
+    list(path = "Organism|A", value = 1.5, unit = NULL)
+  ))
+  withr::local_options(cli.unicode = FALSE)
+  local_reproducible_output()
+  expect_snapshot(print(set))
+})
+
+test_that("print.InitialConditionSet renders an empty set", {
+  project <- testProject()
+  addInitialConditions(project, "emptyset")
+  withr::local_options(cli.unicode = FALSE)
+  local_reproducible_output()
+  expect_snapshot(print(project$initialConditions[["emptyset"]]))
+})
+
+# readInitialConditionsFromXLS ----
+
+test_that("`readInitialConditionsFromXLS()` reads a valid sheet and builds molecule paths", {
+  initialConditionsXLSpath <- getTestDataFilePath("InitialConditions.xlsx")
+  initialValues <- readInitialConditionsFromXLS(
+    filePath = initialConditionsXLSpath,
+    sheets = "ValidSheet"
+  )
+
+  expect_true(.validateParametersStructure(initialValues))
+  expect_setequal(
+    initialValues$paths,
+    c("Organism|Liver|A", "Organism|Liver|B")
+  )
+})
+
+test_that("`readInitialConditionsFromXLS()` returns the values and units of present molecules", {
+  initialConditionsXLSpath <- getTestDataFilePath("InitialConditions.xlsx")
+  initialValues <- readInitialConditionsFromXLS(
+    filePath = initialConditionsXLSpath,
+    sheets = "ValidSheet"
+  )
+
+  idxA <- which(initialValues$paths == "Organism|Liver|A")
+  idxB <- which(initialValues$paths == "Organism|Liver|B")
+  expect_equal(initialValues$values[[idxA]], 0.5)
+  expect_equal(initialValues$values[[idxB]], 1.0)
+  expect_equal(initialValues$units[[idxA]], "µmol")
+  expect_equal(initialValues$units[[idxB]], "µmol")
+})
+
+test_that("`readInitialConditionsFromXLS()` ignores rows where 'Is Present' is FALSE but keeps NA", {
+  initialConditionsXLSpath <- getTestDataFilePath("InitialConditions.xlsx")
+  initialValues <- readInitialConditionsFromXLS(
+    filePath = initialConditionsXLSpath,
+    sheets = "ValidSheet"
+  )
+
+  expect_false("Organism|Kidney|A" %in% initialValues$paths)
+  expect_true("Organism|Liver|B" %in% initialValues$paths)
+})
+
+test_that("`readInitialConditionsFromXLS()` uses the first sheet when no sheet is provided", {
+  initialConditionsXLSpath <- getTestDataFilePath("InitialConditions.xlsx")
+  initialValues <- readInitialConditionsFromXLS(
+    filePath = initialConditionsXLSpath
+  )
+
+  expect_setequal(
+    initialValues$paths,
+    c("Organism|Liver|A", "Organism|Liver|B")
+  )
+})
+
+test_that("`readInitialConditionsFromXLS()` warns and overwrites a path repeated across sheets", {
+  initialConditionsXLSpath <- getTestDataFilePath("InitialConditions.xlsx")
+  expect_snapshot(
+    initialValues <- readInitialConditionsFromXLS(
+      filePath = initialConditionsXLSpath,
+      sheets = c("ValidSheet", "SecondSheet")
+    )
+  )
+
+  idxA <- which(initialValues$paths == "Organism|Liver|A")
+  expect_equal(initialValues$values[[idxA]], 2.5)
+  expect_length(idxA, 1)
+})
+
+test_that("`readInitialConditionsFromXLS()` returns empty structure when all molecules are absent", {
+  initialConditionsXLSpath <- getTestDataFilePath("InitialConditions.xlsx")
+  initialValues <- readInitialConditionsFromXLS(
+    filePath = initialConditionsXLSpath,
+    sheets = "AllAbsent"
+  )
+
+  expect_true(.validateParametersStructure(initialValues))
+  expect_length(initialValues$paths, 0)
+  expect_length(initialValues$values, 0)
+  expect_length(initialValues$units, 0)
+})
+
+test_that("`readInitialConditionsFromXLS()` errors when units are missing for a present molecule", {
+  initialConditionsXLSpath <- getTestDataFilePath("InitialConditions.xlsx")
+  expect_snapshot(
+    error = TRUE,
+    readInitialConditionsFromXLS(
+      filePath = initialConditionsXLSpath,
+      sheets = "MissingUnits"
+    )
+  )
+})
+
+test_that("`readInitialConditionsFromXLS()` errors when a value is missing for a present molecule", {
+  initialConditionsXLSpath <- getTestDataFilePath("InitialConditions.xlsx")
+  expect_snapshot(
+    error = TRUE,
+    readInitialConditionsFromXLS(
+      filePath = initialConditionsXLSpath,
+      sheets = "MissingValue"
+    )
+  )
+})
+
+test_that("`readInitialConditionsFromXLS()` errors on a non-logical 'Is Present' value", {
+  initialConditionsXLSpath <- getTestDataFilePath("InitialConditions.xlsx")
+  expect_snapshot(
+    error = TRUE,
+    readInitialConditionsFromXLS(
+      filePath = initialConditionsXLSpath,
+      sheets = "BadIsPresent"
+    )
+  )
+})
+
+test_that("`readInitialConditionsFromXLS()` accepts numeric 0/1 for 'Is Present'", {
+  initialConditionsXLSpath <- getTestDataFilePath("InitialConditions.xlsx")
+  initialValues <- readInitialConditionsFromXLS(
+    filePath = initialConditionsXLSpath,
+    sheets = "NumericIsPresent"
+  )
+
+  expect_setequal(initialValues$paths, "Organism|Liver|A")
+  expect_equal(initialValues$values[[1]], 0.5)
+})
+
+test_that("`readInitialConditionsFromXLS()` warns and keeps the last value for a duplicate path", {
+  initialConditionsXLSpath <- getTestDataFilePath("InitialConditions.xlsx")
+  expect_snapshot(
+    initialValues <- readInitialConditionsFromXLS(
+      filePath = initialConditionsXLSpath,
+      sheets = "DuplicatePath"
+    )
+  )
+
+  expect_setequal(initialValues$paths, "Organism|Liver|A")
+  expect_equal(initialValues$values[[1]], 2.5)
+})
+
+test_that("`readInitialConditionsFromXLS()` errors when a present row has a blank container path", {
+  initialConditionsXLSpath <- getTestDataFilePath("InitialConditions.xlsx")
+  expect_snapshot(
+    error = TRUE,
+    readInitialConditionsFromXLS(
+      filePath = initialConditionsXLSpath,
+      sheets = "BlankPath"
+    )
+  )
+})
+
+test_that("`readInitialConditionsFromXLS()` errors when a sheet has the wrong structure", {
+  initialConditionsXLSpath <- getTestDataFilePath("InitialConditions.xlsx")
+  expect_snapshot(
+    error = TRUE,
+    readInitialConditionsFromXLS(
+      filePath = initialConditionsXLSpath,
+      sheets = "InvalidSheet"
+    )
+  )
+})
+
+test_that("`readInitialConditionsFromXLS()` validates its arguments", {
+  initialConditionsXLSpath <- getTestDataFilePath("InitialConditions.xlsx")
+  expect_error(
+    readInitialConditionsFromXLS(filePath = 123),
+    regexp = 'argument "filePath" is of type <numeric>, but expected <character>!',
+    fixed = TRUE
+  )
+  expect_error(
+    readInitialConditionsFromXLS(
+      filePath = initialConditionsXLSpath,
+      sheets = 123
+    ),
+    regexp = 'argument "sheets" is of type <numeric>, but expected <character>!',
+    fixed = TRUE
+  )
 })

--- a/tests/testthat/test-populations.R
+++ b/tests/testthat/test-populations.R
@@ -226,3 +226,222 @@ test_that("extendPopulationFromXLS throws an error if specified sheet is empty o
     }
   )
 })
+
+# setPopulation ----
+
+test_that("setPopulation changes a field and persists to file and memory", {
+  project <- testProject()
+  setPopulation(project, "testpopulation", numberOfIndividuals = 50)
+  expect_equal(project$populations[["testpopulation"]]$numberOfIndividuals, 50)
+
+  # The write-through must reach disk: a throwaway reload sees the new value.
+  reloaded <- loadProject(project$jsonPath)
+  expect_equal(
+    reloaded$populations[["testpopulation"]]$numberOfIndividuals,
+    50
+  )
+})
+
+test_that("setPopulation coerces numeric fields like addPopulation", {
+  project <- testProject()
+  setPopulation(project, "testpopulation", proportionOfFemales = "75")
+  expect_identical(
+    project$populations[["testpopulation"]]$proportionOfFemales,
+    75
+  )
+})
+
+test_that("setPopulation partial update leaves other fields untouched", {
+  project <- testProject()
+  before <- project$populations[["testpopulation"]]
+  setPopulation(project, "testpopulation", ageMin = 20)
+
+  after <- project$populations[["testpopulation"]]
+  expect_equal(after$ageMin, 20)
+  for (f in setdiff(names(before), "ageMin")) {
+    expect_equal(after[[f]], before[[f]])
+  }
+})
+
+test_that("setPopulation clears validatedSinceMutation", {
+  project <- testProject()
+  project$.markValidated()
+  setPopulation(project, "testpopulation", numberOfIndividuals = 10)
+  expect_false(project$validatedSinceMutation)
+})
+
+test_that("setPopulation aborts on a non-existent population", {
+  project <- testProject()
+  expect_snapshot(
+    error = TRUE,
+    setPopulation(project, "Ghost", numberOfIndividuals = 10)
+  )
+})
+
+test_that("setPopulation rejects a non-positive numberOfIndividuals", {
+  project <- testProject()
+  before <- project$populations[["testpopulation"]]
+  expect_snapshot(
+    error = TRUE,
+    setPopulation(project, "testpopulation", numberOfIndividuals = 0)
+  )
+  expect_equal(project$populations[["testpopulation"]], before)
+})
+
+test_that("setPopulation on a clone does not affect the source on disk", {
+  source <- testProject()
+  before <- source$populations[["testpopulation"]]
+  clone <- source$clone()
+  setPopulation(clone, "testpopulation", numberOfIndividuals = 7)
+
+  expect_equal(clone$populations[["testpopulation"]]$numberOfIndividuals, 7)
+  expect_equal(source$populations[["testpopulation"]], before)
+  # The clone's edit must not reach the source's on-disk tree.
+  reloaded <- loadProject(source$jsonPath)
+  expect_equal(reloaded$populations[["testpopulation"]], before)
+})
+
+# Vectorized authoring ----
+
+test_that("addPopulation adds N populations in one call equal to N scalar adds", {
+  vectorized <- testProject()
+  addPopulation(
+    vectorized,
+    c("young", "old"),
+    species = "Human",
+    numberOfIndividuals = c(10, 20),
+    ageMin = c(18, 65),
+    ageMax = c(40, 90)
+  )
+
+  scalar <- testProject()
+  addPopulation(
+    scalar,
+    "young",
+    species = "Human",
+    numberOfIndividuals = 10,
+    ageMin = 18,
+    ageMax = 40
+  )
+  addPopulation(
+    scalar,
+    "old",
+    species = "Human",
+    numberOfIndividuals = 20,
+    ageMin = 65,
+    ageMax = 90
+  )
+
+  expect_identical(
+    vectorized$populations[c("young", "old")],
+    scalar$populations[c("young", "old")]
+  )
+})
+
+test_that("addPopulation recycles a scalar field and aligns a length-N field", {
+  project <- testProject()
+  addPopulation(
+    project,
+    c("a", "b"),
+    species = "Human",
+    numberOfIndividuals = c(5, 7)
+  )
+  expect_identical(project$populations$a$species, "Human")
+  expect_identical(project$populations$b$species, "Human")
+  expect_identical(project$populations$a$numberOfIndividuals, 5)
+  expect_identical(project$populations$b$numberOfIndividuals, 7)
+})
+
+test_that("addPopulation persists all N to disk in one write-through", {
+  project <- testProject()
+  addPopulation(
+    project,
+    c("a", "b"),
+    species = "Human",
+    numberOfIndividuals = 5
+  )
+  reloaded <- loadProject(project$jsonPath)
+  expect_true(all(c("a", "b") %in% names(reloaded$populations)))
+})
+
+test_that("addPopulation aborts the whole batch and writes nothing on one bad entry", {
+  project <- testProject()
+  before <- names(project$populations)
+  expect_error(
+    addPopulation(
+      project,
+      c("a", "b"),
+      species = "Human",
+      numberOfIndividuals = c(5, -1)
+    )
+  )
+  expect_identical(names(project$populations), before)
+  reloaded <- loadProject(project$jsonPath)
+  expect_identical(names(reloaded$populations), before)
+})
+
+test_that("addPopulation aborts on a mismatched scalar field length", {
+  project <- testProject()
+  expect_snapshot(
+    error = TRUE,
+    addPopulation(
+      project,
+      c("a", "b", "c"),
+      species = "Human",
+      numberOfIndividuals = c(5, 7)
+    )
+  )
+})
+
+test_that("setPopulation vectorizes a partial update across N ids", {
+  project <- testProject()
+  addPopulation(
+    project,
+    c("a", "b"),
+    species = "Human",
+    numberOfIndividuals = 5
+  )
+  setPopulation(project, c("a", "b"), numberOfIndividuals = c(50, 60))
+  expect_identical(project$populations$a$numberOfIndividuals, 50)
+  expect_identical(project$populations$b$numberOfIndividuals, 60)
+  expect_identical(project$populations$a$species, "Human")
+})
+
+test_that("removePopulation removes a vector of ids in one write-through", {
+  project <- testProject()
+  addPopulation(
+    project,
+    c("a", "b"),
+    species = "Human",
+    numberOfIndividuals = 5
+  )
+  removePopulation(project, c("a", "b"))
+  expect_false(any(c("a", "b") %in% names(project$populations)))
+  reloaded <- loadProject(project$jsonPath)
+  expect_false(any(c("a", "b") %in% names(reloaded$populations)))
+})
+
+test_that("removePopulation warns when still referenced by a scenario, removes anyway", {
+  project <- testProject()
+  withr::local_options(cli.unicode = FALSE)
+  # `testpopulation` is the `populationId` of two scenarios in the fixture.
+  expect_snapshot(removePopulation(project, "testpopulation"))
+  expect_false("testpopulation" %in% names(project$populations))
+})
+
+# Print method ----
+
+test_that("print.Population renders the configured fields", {
+  project <- testProject()
+  withr::local_options(cli.unicode = FALSE)
+  local_reproducible_output()
+  expect_snapshot(print(project$populations[["testpopulation"]]))
+})
+
+test_that("print.Population renders a minimal population", {
+  project <- testProject()
+  addPopulation(project, "minimal", species = "Human", numberOfIndividuals = 10)
+  withr::local_options(cli.unicode = FALSE)
+  local_reproducible_output()
+  expect_snapshot(print(project$populations[["minimal"]]))
+})

--- a/tests/testthat/test-project-lifecycle.R
+++ b/tests/testthat/test-project-lifecycle.R
@@ -35,9 +35,9 @@ test_that("loadProject() warns on a dangling cross-reference", {
       outputPaths = list(O1 = "Organism|A|Concentration in container"),
       scenarios = list(list(
         name = "S",
-        individualId = "Ghost",
+        individual = "Ghost",
         modelFile = "m.pkml",
-        outputPathIds = list("O1")
+        outputPaths = list("O1")
       )),
       individuals = structure(list(), names = character(0)),
       populations = structure(list(), names = character(0)),
@@ -58,73 +58,18 @@ test_that("loadProject() loads a clean project without a cross-reference warning
   expect_no_warning(testProject())
 })
 
-test_that("saveProject writes a Project to disk and clears modified flag", {
-  project <- testProject()
+test_that("a bound project's container edit persists immediately", {
+  tmp <- saveSnapshot(testProject(), local_projectPath())
+  project <- loadProject(tmp)
+
   project$modelFolder <- "AnotherModels"
-  expect_true(project$modified)
 
-  tmp <- withr::local_tempfile(fileext = ".json")
-  saveProject(project, tmp)
-  expect_true(file.exists(tmp))
-  expect_false(project$modified)
-})
-
-test_that("saveProject defaults to project$jsonPath when path is NULL", {
-  tmp_src <- withr::local_tempfile(fileext = ".json")
-  project <- testProject()
-  saveProject(project, tmp_src)
-  reloaded <- loadProject(tmp_src)
-  reloaded$modelFolder <- "Models2"
-  saveProject(reloaded)
-  expect_false(reloaded$modified)
-})
-
-test_that("saveProject errors when project has no jsonPath and path is NULL", {
-  project <- Project$new()
-  expect_snapshot(saveProject(project), error = TRUE)
-})
-
-test_that("saveProject to a new path rebinds jsonPath, projectFilePath, and projectDirPath", {
-  project <- testProject()
-  newPath <- withr::local_tempfile(fileext = ".json")
-
-  saveProject(project, newPath)
-
-  expect_identical(project$jsonPath, fs::path_abs(newPath))
-  expect_identical(project$projectFilePath, fs::path_abs(newPath))
-  expect_identical(project$projectDirPath, dirname(fs::path_abs(newPath)))
-})
-
-test_that("a bare saveProject after a save-as writes to the new location", {
-  project <- testProject()
-  newPath <- withr::local_tempfile(fileext = ".json")
-  saveProject(project, newPath)
-
-  project$modelFolder <- "Models2"
-  expect_true(project$modified)
-
-  saveProject(project)
-  expect_false(project$modified)
+  # Container metadata is write-through: a reload sees the new value with no
+  # separate save step.
   expect_identical(
-    loadProject(newPath)$modelFolder,
-    fs::path_abs(
-      file.path(dirname(fs::path_abs(newPath)), "Models2")
-    )
+    loadProject(tmp)$modelFolder,
+    fs::path_abs(file.path(dirname(tmp), "AnotherModels"))
   )
-})
-
-test_that("saveProject surfaces a missing parent directory with file context", {
-  project <- testProject()
-  badPath <- file.path(withr::local_tempdir(), "does-not-exist", "Project.json")
-  # Path is environment-specific, so match the message rather than snapshot it.
-  expect_error(
-    saveProject(project, badPath),
-    "Parent directory does not exist"
-  )
-})
-
-test_that("saveProject errors on non-Project input", {
-  expect_error(saveProject("not a project"), "Project")
 })
 
 test_that("exampleProject() succeeds", {
@@ -304,13 +249,13 @@ test_that("a mutation after validateProject() forces .ensureValid to re-validate
   expect_false(project$validatedSinceMutation)
 })
 
-test_that("mutated project survives a saveProject -> loadProject round-trip", {
+test_that("mutated project survives a snapshot -> loadProject round-trip", {
   project <- testProject()
 
-  addOutputPath(project, "RoundtripX", "Organism|A|Concentration in container")
+  addOutputPath(project, "roundtripx", "Organism|A|Concentration in container")
   addIndividual(
     project,
-    "Pediatric_male",
+    "pediatric_male",
     species = "Human",
     population = "European_ICRP_2002",
     gender = "MALE",
@@ -324,9 +269,9 @@ test_that("mutated project survives a saveProject -> loadProject round-trip", {
   reloaded <- loadProject(out)
 
   expect_identical(
-    reloaded$outputPaths$RoundtripX,
-    project$outputPaths$RoundtripX
+    reloaded$outputPaths$roundtripx,
+    project$outputPaths$roundtripx
   )
   expect_named(reloaded$individuals, names(project$individuals))
-  expect_identical(reloaded$individuals$Pediatric_male$weight, 25)
+  expect_identical(reloaded$individuals$pediatric_male$weight, 25)
 })

--- a/tests/testthat/test-project-to-json.R
+++ b/tests/testthat/test-project-to-json.R
@@ -13,22 +13,66 @@ test_that(".projectToJson() returns a JSON-shaped list with the canonical top-le
     c(
       "schemaVersion",
       "esqlabsRVersion",
+      "name",
+      "description",
+      "definitionsFolder",
       "filePaths",
+      "defaultSimulationRunOptions",
       "observedData",
       "outputPaths",
       "scenarios",
-      "modelParameterSets",
+      "parameterSets",
+      "initialConditions",
       "individuals",
-      "individualParameterSets",
       "populations",
       "applications",
-      "applicationParameterSets",
+      "dataCombined",
       "plots",
-      "parameterIdentification"
+      "plotGrids",
+      "parameterIdentification",
+      # The Excel-bridge block is emitted only when the project carries
+      # Excel-bridge fields (the bundled example does).
+      "excel"
     ),
     ignore.order = TRUE
   )
   expect_identical(tree$schemaVersion, "2.0")
+})
+
+test_that(".projectToJson() splits the container path fields into filePaths and excel", {
+  project <- exampleProject()
+  tree <- esqlabsR:::.projectToJson(project)
+
+  # The four live working folders stay in `filePaths`.
+  expect_named(
+    tree$filePaths,
+    c("modelFolder", "populationsFolder", "dataFolder", "outputFolder"),
+    ignore.order = TRUE
+  )
+  # The seven Excel-bridge sheet names move to the `excel` block.
+  expect_named(
+    tree$excel,
+    c(
+      "configurationsFolder",
+      "modelParamsFile",
+      "individualsFile",
+      "populationsFile",
+      "scenariosFile",
+      "applicationsFile",
+      "plotsFile"
+    ),
+    ignore.order = TRUE
+  )
+})
+
+test_that(".projectToJson() omits the excel block for a from-scratch project", {
+  project <- Project$new()
+  tree <- esqlabsR:::.projectToJson(project)
+
+  expect_false("excel" %in% names(tree))
+  expect_null(tree$name)
+  expect_null(tree$description)
+  expect_null(tree$defaultSimulationRunOptions)
 })
 
 test_that(".projectToJson() rejects non-Project input", {
@@ -89,16 +133,8 @@ test_that("round-trip is structurally identical for the bundled example", {
   expect_identical(reloaded$filePaths, project$filePaths)
   expect_identical(reloaded$outputPaths, project$outputPaths)
   expect_identical(
-    reloaded$modelParameterSets,
-    project$modelParameterSets
-  )
-  expect_identical(
-    reloaded$individualParameterSets,
-    project$individualParameterSets
-  )
-  expect_identical(
-    reloaded$applicationParameterSets,
-    project$applicationParameterSets
+    reloaded$parameterSets,
+    project$parameterSets
   )
   expect_identical(reloaded$individuals, project$individuals)
   expect_identical(reloaded$populations, project$populations)
@@ -119,17 +155,17 @@ test_that("round-trip is structurally identical for the bundled example", {
   )
 })
 
-test_that(".dataCombinedToNestedJson re-adds the name field and drops empty sublists", {
+test_that(".dataCombinedToNestedJson re-adds the id field and drops empty sublists", {
   parsed <- list(
     DC1 = list(simulated = list(list(label = "a")), observed = list()),
     DC2 = list(simulated = list(), observed = list(list(label = "b")))
   )
   json <- esqlabsR:::.dataCombinedToNestedJson(parsed)
   expect_length(json, 2)
-  expect_equal(json[[1]]$name, "DC1")
+  expect_equal(json[[1]]$dataCombinedId, "DC1")
   expect_equal(json[[1]]$simulated[[1]]$label, "a")
   expect_null(json[[1]]$observed) # empty observed dropped
-  expect_equal(json[[2]]$name, "DC2")
+  expect_equal(json[[2]]$dataCombinedId, "DC2")
   expect_null(json[[2]]$simulated)
   expect_equal(json[[2]]$observed[[1]]$label, "b")
 })
@@ -139,20 +175,33 @@ test_that(".dataCombinedToNestedJson handles NULL and empty input", {
   expect_identical(esqlabsR:::.dataCombinedToNestedJson(NULL), list())
 })
 
-test_that(".dataFrameToListOfLists drops NA cells per row", {
-  df <- data.frame(
-    plotId = c("P1", "P2"),
-    plotType = c("individual", "population"),
-    title = c("T1", NA),
-    stringsAsFactors = FALSE
+test_that(".plotEntriesToJson strips the entry class and drops the list name", {
+  entries <- list(
+    P1 = structure(
+      list(plotId = "P1", plotType = "individual", title = "T1"),
+      class = c("Plot", "list")
+    ),
+    P2 = structure(
+      list(plotId = "P2", plotType = "population"),
+      class = c("Plot", "list")
+    )
   )
-  result <- esqlabsR:::.dataFrameToListOfLists(df)
+  result <- esqlabsR:::.plotEntriesToJson(entries)
+  # A plain unnamed array of records, with the Plot class stripped so it never
+  # leaks into JSON.
+  expect_null(names(result))
   expect_length(result, 2)
+  expect_identical(class(result[[1]]), "list")
   expect_equal(result[[1]]$title, "T1")
-  expect_null(result[[2]]$title) # NA dropped
+  expect_false("title" %in% names(result[[2]]))
 })
 
-test_that(".plotsToJson returns NULL when project has no plots section", {
+test_that(".plotEntriesToJson returns an empty list for NULL or empty", {
+  expect_identical(esqlabsR:::.plotEntriesToJson(NULL), list())
+  expect_identical(esqlabsR:::.plotEntriesToJson(list()), list())
+})
+
+test_that("the plots-section serializers return NULL when empty", {
   tmp <- withr::local_tempfile(fileext = ".json")
   jsonlite::write_json(
     list(schemaVersion = "2.0", esqlabsRVersion = "6.0.0"),
@@ -160,7 +209,9 @@ test_that(".plotsToJson returns NULL when project has no plots section", {
     auto_unbox = TRUE
   )
   project <- loadProject(tmp)
-  expect_null(esqlabsR:::.plotsToJson(project))
+  expect_null(esqlabsR:::.dataCombinedSectionToJson(project))
+  expect_null(esqlabsR:::.plotsSectionToJson(project))
+  expect_null(esqlabsR:::.plotGridsSectionToJson(project))
 })
 
 test_that("round-trip preserves length-1 arrays as arrays, not scalars", {
@@ -169,12 +220,12 @@ test_that("round-trip preserves length-1 arrays as arrays, not scalars", {
   esqlabsR:::.saveProjectJson(project, out)
 
   raw <- jsonlite::fromJSON(out, simplifyVector = FALSE)
-  # outputPathIds for Aciclovir_iv has one entry; auto_unbox must
+  # outputPaths for Aciclovir_iv has one entry; auto_unbox must
   # not collapse it to a scalar string.
-  ids <- raw$scenarios[[1L]]$outputPathIds
+  ids <- raw$scenarios[[1L]]$outputPaths
   expect_type(ids, "list")
   expect_length(ids, 1L)
-  expect_identical(ids[[1L]], "Aciclovir_PVB")
+  expect_identical(ids[[1L]], "aciclovir_pvb")
 })
 
 test_that("round-trip preserves NULL fields", {
@@ -183,10 +234,10 @@ test_that("round-trip preserves NULL fields", {
   esqlabsR:::.saveProjectJson(project, out)
 
   raw <- jsonlite::fromJSON(out, simplifyVector = FALSE)
-  # The first scenario has populationId: null and steadyStateTime: null.
+  # The first scenario has population: null and steadyStateTime: null.
   # Without `null = "null"`, jsonlite would drop them; the field would be
   # absent on reload, breaking equality.
-  expect_null(raw$scenarios[[1L]]$populationId)
+  expect_null(raw$scenarios[[1L]]$population)
   expect_null(raw$scenarios[[1L]]$steadyStateTime)
 })
 
@@ -242,9 +293,8 @@ test_that("empty map sections serialize as JSON objects, not arrays", {
   expect_match(text, '"filePaths":\\s*\\{\\s*\\}')
   expect_match(text, '"outputPaths":\\s*\\{\\s*\\}')
   expect_match(text, '"applications":\\s*\\{\\s*\\}')
-  expect_match(text, '"modelParameterSets":\\s*\\{\\s*\\}')
-  expect_match(text, '"individualParameterSets":\\s*\\{\\s*\\}')
-  expect_match(text, '"applicationParameterSets":\\s*\\{\\s*\\}')
+  expect_match(text, '"parameterSets":\\s*\\{\\s*\\}')
+  expect_match(text, '"initialConditions":\\s*\\{\\s*\\}')
   expect_match(text, '"scenarios":\\s*\\[\\s*\\]')
   expect_match(text, '"individuals":\\s*\\[\\s*\\]')
   expect_match(text, '"populations":\\s*\\[\\s*\\]')
@@ -268,13 +318,17 @@ test_that("empty map sections survive a round-trip as empty named lists", {
   # sections that way), so jsonlite returns a *named* empty list. The
   # contract is that this representation is stable: a second save/reload
   # produces an identical structure.
+  # Section accessors wrap the stored list in a printable DefinitionList; unwrap
+  # to assert the underlying named-empty shape.
   empty_named <- structure(list(), names = character(0L))
   expect_identical(reloaded$filePaths, empty_named)
-  expect_identical(reloaded$outputPaths, empty_named)
-  expect_identical(reloaded$applications, empty_named)
-  expect_identical(reloaded$modelParameterSets, empty_named)
-  expect_identical(reloaded$individualParameterSets, empty_named)
-  expect_identical(reloaded$applicationParameterSets, empty_named)
+  expect_identical(.unwrapDefinitionList(reloaded$outputPaths), empty_named)
+  expect_identical(.unwrapDefinitionList(reloaded$applications), empty_named)
+  expect_identical(.unwrapDefinitionList(reloaded$parameterSets), empty_named)
+  expect_identical(
+    .unwrapDefinitionList(reloaded$initialConditions),
+    empty_named
+  )
 
   # And the round-trip is stable from there: re-saving and re-loading does
   # not drift further.
@@ -285,16 +339,39 @@ test_that("empty map sections survive a round-trip as empty named lists", {
   expect_identical(reloaded2$outputPaths, reloaded$outputPaths)
   expect_identical(reloaded2$applications, reloaded$applications)
   expect_identical(
-    reloaded2$modelParameterSets,
-    reloaded$modelParameterSets
+    reloaded2$parameterSets,
+    reloaded$parameterSets
   )
-  expect_identical(
-    reloaded2$individualParameterSets,
-    reloaded$individualParameterSets
+})
+
+test_that("a populated initialConditions section round-trips through a snapshot", {
+  # An inline snapshot with one initial-condition set. Loading it, saving a
+  # snapshot, and reloading yields an identical section (a fixed point).
+  src <- withr::local_tempfile(fileext = ".json")
+  jsonlite::write_json(
+    list(
+      schemaVersion = "2.0",
+      esqlabsRVersion = "6.0.0",
+      initialConditions = list(
+        testinitialset = list(
+          list(path = "Organism|A|Concentration", value = 1.5, unit = "mg/l"),
+          list(path = "Organism|B|Concentration", value = 0.5, unit = "µmol/l")
+        )
+      )
+    ),
+    src,
+    auto_unbox = TRUE
   )
+  project <- loadProject(src)
+  expect_named(project$initialConditions, "testinitialset")
+  expect_length(project$initialConditions$testinitialset, 2L)
+
+  out <- withr::local_tempfile(fileext = ".json")
+  esqlabsR:::.saveProjectJson(project, out)
+  reloaded <- loadProject(out)
   expect_identical(
-    reloaded2$applicationParameterSets,
-    reloaded$applicationParameterSets
+    reloaded$initialConditions,
+    project$initialConditions
   )
 })
 
@@ -305,7 +382,7 @@ test_that("round-trip preserves a steady-state scenario including unit conversio
 
   raw <- jsonlite::fromJSON(out, simplifyVector = FALSE)
   ss <- Filter(
-    function(s) s$name == "Aciclovir_iv_steadystate",
+    function(s) s$name == "aciclovir_iv_steadystate",
     raw$scenarios
   )[[1L]]
 
@@ -317,22 +394,22 @@ test_that("round-trip preserves a steady-state scenario including unit conversio
   expect_identical(ss$steadyStateTimeUnit, "h")
 })
 
-test_that("round-trip preserves outputPathIds order", {
+test_that("round-trip preserves outputPaths order", {
   project <- exampleProject()
   out <- withr::local_tempfile(fileext = ".json")
   esqlabsR:::.saveProjectJson(project, out)
 
   raw <- jsonlite::fromJSON(out, simplifyVector = FALSE)
   ss <- Filter(
-    function(s) s$name == "Aciclovir_iv_steadystate",
+    function(s) s$name == "aciclovir_iv_steadystate",
     raw$scenarios
   )[[1L]]
 
   # JSON declared fat_cell, PVB (non-alphabetical). The order must be
   # preserved through parse -> serialize.
   expect_identical(
-    ss$outputPathIds,
-    list("Aciclovir_fat_cell", "Aciclovir_PVB")
+    ss$outputPaths,
+    list("aciclovir_fat_cell", "aciclovir_pvb")
   )
 })
 
@@ -340,7 +417,7 @@ test_that("steadyState=false with a declared time and unit round-trips", {
   raw <- list(
     list(
       name = "S",
-      individualId = "I",
+      individual = "I",
       modelFile = "m.pkml",
       steadyState = FALSE,
       steadyStateTime = 2,
@@ -369,7 +446,7 @@ test_that("a standalone simulationTimeUnit round-trips when simulationTime is nu
   raw <- list(
     list(
       name = "S",
-      individualId = "I",
+      individual = "I",
       modelFile = "m.pkml",
       simulationTimeUnit = "h"
     )
@@ -385,7 +462,7 @@ test_that("a standalone simulationTimeUnit round-trips when simulationTime is nu
   expect_identical(out$simulationTimeUnit, "h")
 })
 
-test_that("populationId is emitted even when simulationType has drifted", {
+test_that("population is emitted even when simulationType has drifted", {
   sc <- Scenario(
     scenarioName = "S",
     modelFile = "m.pkml",
@@ -397,7 +474,7 @@ test_that("populationId is emitted even when simulationType has drifted", {
 
   project <- .fakeProject(scenarios = list(S = sc))
   out <- esqlabsR:::.scenariosToJson(project)[[1L]]
-  expect_identical(out$populationId, "Pop")
+  expect_identical(out$population, "Pop")
 })
 
 test_that(".validateScenarios warns on populationId / simulationType drift", {
@@ -409,28 +486,24 @@ test_that(".validateScenarios warns on populationId / simulationType drift", {
   expect_true(any(grepl("populationId but simulationType", msgs)))
 })
 
-test_that(".scenariosToJson errors when scenario outputPaths reference unknown ids", {
-  project <- exampleProject()
-  # Mutate the first scenario to add a named path whose id is not in
-  # project$outputPaths. (Parser would have rejected this, but a Chapter
-  # 7+ programmatic mutation could land us here.)
-  project$scenarios[[1L]]$outputPaths <- c(
-    project$scenarios[[1L]]$outputPaths,
-    c(UnknownId = "Organism|NotDeclared|Path")
-  )
+test_that(".scenariosToJson keeps unknown outputPaths (referential, lazy)", {
+  # An unknown outputPathId is a referential issue caught lazily by the
+  # cross-reference validator, not a serialization error: the id round-trips
+  # verbatim so a transiently-dangling reference is not lost on save.
+  sc <- Scenario(scenarioName = "S", modelFile = "m.pkml")
+  sc$outputPaths <- c(UnknownId = "Organism|NotDeclared|Path")
+  project <- .fakeProject(scenarios = list(S = sc))
 
-  expect_error(
-    esqlabsR:::.projectToJson(project),
-    "unknown outputPathIds.*UnknownId"
-  )
+  out <- esqlabsR:::.scenariosToJson(project)[[1L]]
+  expect_identical(out$outputPaths, list("UnknownId"))
 })
 
 test_that(".scenariosToJson errors when outputPaths has unnamed elements", {
-  project <- exampleProject()
-  # Strip names to simulate a programmatic mutation that violates the invariant.
-  project$scenarios[[1L]]$outputPaths <- unname(
-    project$scenarios[[1L]]$outputPaths
-  )
+  # Build the bad state on an in-memory project so the serializer guard is
+  # exercised directly (a tree-backed project would fail-fast at write).
+  sc <- Scenario(scenarioName = "S", modelFile = "m.pkml")
+  sc$outputPaths <- unname(c(PVB = "Organism|PVB|Drug"))
+  project <- .fakeProject(scenarios = list(S = sc))
 
   expect_error(
     esqlabsR:::.projectToJson(project),
@@ -439,21 +512,24 @@ test_that(".scenariosToJson errors when outputPaths has unnamed elements", {
 })
 
 test_that(".scenariosToJson errors when simulateSteadyState is TRUE without a unit", {
-  project <- exampleProject()
-  # Aciclovir_iv has simulateSteadyState=FALSE and no unit.
-  # Flip the flag without setting the unit — the round-trip cannot
-  # carry the steady-state time, so the serializer must reject it.
-  project$scenarios[["Aciclovir_iv"]]$simulateSteadyState <- TRUE
+  # The round-trip cannot carry the steady-state time without a unit, so the
+  # serializer must reject it. Built on an in-memory project to exercise the
+  # serializer guard directly.
+  sc <- Scenario(scenarioName = "S", modelFile = "m.pkml")
+  sc$simulateSteadyState <- TRUE
+  project <- .fakeProject(scenarios = list(S = sc))
 
   expect_error(
     esqlabsR:::.projectToJson(project),
-    "Aciclovir_iv.*simulateSteadyState=TRUE.*steadyStateTimeUnit"
+    "S.*simulateSteadyState=TRUE.*steadyStateTimeUnit"
   )
 })
 
 test_that("round-trip preserves empty modelParameterSets as a JSON array", {
   project <- exampleProject()
-  project$scenarios[["Aciclovir_iv"]]$modelParameterSets <- character(0)
+  scenarios <- project$.getSection("scenarios")
+  scenarios[["aciclovir_iv"]]$modelParameterSets <- character(0)
+  project$.setSection("scenarios", scenarios)
 
   out <- withr::local_tempfile(fileext = ".json")
   esqlabsR:::.saveProjectJson(project, out)
@@ -461,21 +537,23 @@ test_that("round-trip preserves empty modelParameterSets as a JSON array", {
 
   # Empty modelParameterSets must serialise as `[]`, not `null`, so the
   # JSON shape stays an array.
-  mp <- raw$scenarios[[1L]]$modelParameterSets
+  mp <- raw$scenarios[[1L]]$parameterSets
   expect_type(mp, "list")
   expect_length(mp, 0L)
 })
 
-test_that("round-trip preserves empty outputPathIds as a JSON array", {
+test_that("round-trip preserves empty outputPaths as a JSON array", {
   project <- exampleProject()
-  project$scenarios[["Aciclovir_iv"]]$outputPaths <- NULL
+  scenarios <- project$.getSection("scenarios")
+  scenarios[["aciclovir_iv"]]$outputPaths <- NULL
+  project$.setSection("scenarios", scenarios)
 
   out <- withr::local_tempfile(fileext = ".json")
   esqlabsR:::.saveProjectJson(project, out)
   raw <- jsonlite::fromJSON(out, simplifyVector = FALSE)
 
   # Absent / empty outputPaths must serialise as `[]`, not `null`.
-  ids <- raw$scenarios[[1L]]$outputPathIds
+  ids <- raw$scenarios[[1L]]$outputPaths
   expect_type(ids, "list")
   expect_length(ids, 0L)
 })
@@ -492,11 +570,11 @@ test_that(".scenariosToJson preserves both ids when two ids map to the same lite
     },
     "scenarios": [{
       "name": "S",
-      "individualId": "I",
-      "populationId": null,
+      "individual": "I",
+      "population": null,
       "readPopulationFromCSV": false,
-      "modelParameterSets": [],
-      "applicationProtocol": null,
+      "parameterSets": [],
+      "application": null,
       "simulationTime": null,
       "simulationTimeUnit": null,
       "steadyState": false,
@@ -504,7 +582,7 @@ test_that(".scenariosToJson preserves both ids when two ids map to the same lite
       "steadyStateTimeUnit": null,
       "overwriteFormulasInSS": false,
       "modelFile": "M.pkml",
-      "outputPathIds": ["primary", "alias"]
+      "outputPaths": ["primary", "alias"]
     }],
     "modelParameterSets": {},
     "individuals": [],
@@ -518,5 +596,5 @@ test_that(".scenariosToJson preserves both ids when two ids map to the same lite
   project <- suppressWarnings(loadProject(jsonPath))
   rebuilt <- esqlabsR:::.scenariosToJson(project)
 
-  expect_equal(rebuilt[[1]]$outputPathIds, list("primary", "alias"))
+  expect_equal(rebuilt[[1]]$outputPaths, list("primary", "alias"))
 })

--- a/tests/testthat/test-project.R
+++ b/tests/testthat/test-project.R
@@ -3,7 +3,6 @@ test_that("Project$new() creates an empty in-memory project", {
   expect_s3_class(project, "Project")
   expect_null(project$projectFilePath)
   expect_null(project$projectDirPath)
-  expect_false(project$modified)
   expect_false(project$validatedSinceMutation)
 })
 
@@ -13,14 +12,7 @@ test_that("Project$new(path) loads a v2.0 JSON file", {
   )
   expect_s3_class(project, "Project")
   expect_equal(project$schemaVersion, "2.0")
-  expect_false(project$modified)
-})
-
-test_that("Excel-bridge file fields can be set and clear modified flag accordingly", {
-  project <- Project$new()
-  expect_false(project$modified)
-  project$modelParamsFile <- "X.xlsx"
-  expect_true(project$modified)
+  expect_false(project$validatedSinceMutation)
 })
 
 test_that("asList round-trips with .projectToJson", {
@@ -124,19 +116,11 @@ test_that("project$dataFolder is NULL when filePaths.dataFolder is unset", {
 })
 
 test_that("project path fields are writable after the merger", {
-  project <- loadProject(
-    system.file(
-      "extdata",
-      "projects",
-      "Example",
-      "Project.json",
-      package = "esqlabsR",
-      mustWork = TRUE
-    )
-  )
-  expect_false(project$modified)
+  tmp <- saveSnapshot(testProject(), local_projectPath())
+  project <- loadProject(tmp)
+
   project$modelFolder <- "AnotherModels"
-  expect_true(project$modified)
+  expect_match(project$modelFolder, "AnotherModels$")
 })
 
 test_that(".clean_path expands env vars (other than PATH) and resolves to absolute", {
@@ -209,8 +193,9 @@ test_that("loadProject() exposes filePaths verbatim", {
 
   expect_type(project$filePaths, "list")
   expect_identical(project$filePaths$modelFolder, "Models/Simulations/")
-  expect_identical(project$filePaths$configurationsFolder, "Configurations/")
   expect_identical(project$filePaths$dataFolder, "Data/")
+  # The Excel-bridge sheet names live in the separate `excel` block now.
+  expect_identical(project$excel$configurationsFolder, "Configurations/")
 })
 
 test_that("loadProject() preserves outputPaths as a named list", {
@@ -219,11 +204,11 @@ test_that("loadProject() preserves outputPaths as a named list", {
   expect_type(project$outputPaths, "list")
   expect_named(
     project$outputPaths,
-    c("Aciclovir_PVB", "Aciclovir_fat_cell"),
+    c("aciclovir_pvb", "aciclovir_fat_cell"),
     ignore.order = TRUE
   )
   expect_identical(
-    project$outputPaths$Aciclovir_PVB,
+    project$outputPaths$aciclovir_pvb,
     "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)"
   )
 })
@@ -235,74 +220,85 @@ test_that("loadProject() parses scenarios into Scenario objects keyed by name", 
   expect_length(project$scenarios, 3L)
   expect_named(
     project$scenarios,
-    c("Aciclovir_iv", "Aciclovir_iv_population", "Aciclovir_iv_steadystate")
+    c("aciclovir_iv", "aciclovir_iv_population", "aciclovir_iv_steadystate")
   )
 
-  first <- project$scenarios[["Aciclovir_iv"]]
+  first <- project$scenarios[["aciclovir_iv"]]
   expect_s3_class(first, "Scenario")
-  expect_identical(first$scenarioName, "Aciclovir_iv")
-  expect_identical(first$individualId, "Adult_male")
+  expect_identical(first$scenarioName, "aciclovir_iv")
+  expect_identical(first$individualId, "adult_male")
   expect_null(first$populationId)
-  expect_identical(first$modelParameterSets, c("Global", "Aciclovir"))
+  expect_identical(first$modelParameterSets, c("global", "aciclovir"))
 })
 
-test_that("loadProject() preserves modelParameterSets as a named list of sets", {
+test_that("loadProject() preserves parameterSets as a single named list of sets", {
   project <- exampleProject()
 
+  # The three former parameter-set kinds (model / individual / application)
+  # now share one `parameterSets` map keyed by set id.
   expect_named(
-    project$modelParameterSets,
-    c("Global", "Aciclovir"),
+    project$parameterSets,
+    c(
+      "global",
+      "aciclovir",
+      "adult_male_default",
+      "aciclovir_iv_250mg_default"
+    ),
     ignore.order = TRUE
   )
-  expect_length(project$modelParameterSets$Global, 1L)
+  expect_length(project$parameterSets$global, 1L)
   expect_identical(
-    project$modelParameterSets$Global[[1L]]$parameterName,
+    project$parameterSets$global[[1L]]$parameterName,
     "EHC continuous fraction"
   )
-})
-
-test_that("loadProject() preserves individualParameterSets as a named list of sets", {
-  project <- exampleProject()
-
-  expect_named(project$individualParameterSets, "Adult_male_default")
-  expect_length(project$individualParameterSets$Adult_male_default, 1L)
   expect_identical(
-    project$individualParameterSets$Adult_male_default[[1L]]$parameterName,
+    project$parameterSets$adult_male_default[[1L]]$parameterName,
     "GFR"
   )
-})
-
-test_that("loadProject() preserves applicationParameterSets as a named list of sets", {
-  project <- exampleProject()
-
-  expect_named(project$applicationParameterSets, "Aciclovir_iv_250mg_default")
-  expect_length(
-    project$applicationParameterSets$Aciclovir_iv_250mg_default,
-    1L
-  )
   expect_identical(
-    project$applicationParameterSets$Aciclovir_iv_250mg_default[[
-      1L
-    ]]$parameterName,
+    project$parameterSets$aciclovir_iv_250mg_default[[1L]]$parameterName,
     "Dose"
   )
+})
+
+test_that("loadProject() reads initialConditions and the binding is read-only", {
+  project <- testProject()
+  # The TestProject fixture carries one initial-condition set referenced by a
+  # scenario; the binding surfaces it keyed by set id.
+  expect_true("testinitialset" %in% names(project$initialConditions))
+  set <- project$initialConditions$testinitialset
+  expect_s3_class(set, "InitialConditionSet")
+  expect_identical(set[[1L]]$path, "Organism|VenousBlood|Plasma|Aciclovir")
+
+  expect_error(project$initialConditions <- list(), "read-only")
+})
+
+test_that("a project with no initial-conditions tree surfaces an empty section", {
+  blank <- loadProject(system.file(
+    "extdata",
+    "projects",
+    "Blank",
+    "Project.json",
+    package = "esqlabsR"
+  ))
+  expect_identical(.unwrapDefinitionList(blank$initialConditions), list())
 })
 
 test_that("loadProject() preserves individuals as a named list keyed by individualId", {
   project <- exampleProject()
 
-  expect_named(project$individuals, "Adult_male")
-  ind <- project$individuals[["Adult_male"]]
+  expect_named(project$individuals, "adult_male")
+  ind <- project$individuals[["adult_male"]]
   expect_s3_class(ind, "Individual")
   expect_identical(ind$gender, "MALE")
-  expect_identical(ind$parameterSets, "Adult_male_default")
+  expect_identical(ind$parameterSets, "adult_male_default")
 })
 
 test_that("loadProject() preserves populations as a named list keyed by populationId", {
   project <- exampleProject()
 
-  expect_named(project$populations, "European_adults")
-  pop <- project$populations[["European_adults"]]
+  expect_named(project$populations, "european_adults")
+  pop <- project$populations[["european_adults"]]
   expect_s3_class(pop, "Population")
   expect_identical(pop$numberOfIndividuals, 50)
 })
@@ -310,10 +306,10 @@ test_that("loadProject() preserves populations as a named list keyed by populati
 test_that("loadProject() preserves applications as a named list keyed by protocol name", {
   project <- exampleProject()
 
-  expect_named(project$applications, "Aciclovir_iv_250mg")
-  app <- project$applications[["Aciclovir_iv_250mg"]]
+  expect_named(project$applications, "aciclovir_iv_250mg")
+  app <- project$applications[["aciclovir_iv_250mg"]]
   expect_s3_class(app, "Application")
-  expect_identical(app$parameterSets, "Aciclovir_iv_250mg_default")
+  expect_identical(app$parameterSets, "aciclovir_iv_250mg_default")
 })
 
 test_that("loadProject() preserves the observedData section", {
@@ -326,28 +322,26 @@ test_that("loadProject() preserves the observedData section", {
   expect_identical(source$sheets, list("Laskin 1982.Group A"))
 })
 
-test_that("loadProject() parses plots into the asymmetric in-memory shape", {
+test_that("loadProject() parses plots into three top-level keyed sections", {
   project <- exampleProject()
 
-  expect_type(project$plots, "list")
-  expect_named(
-    project$plots,
-    c("dataCombined", "plotConfiguration", "plotGrids"),
-    ignore.order = TRUE
-  )
-  # dataCombined: named list keyed by name (no `name` field on entries)
-  expect_named(project$plots$dataCombined, "Aciclovir_individual")
-  dc <- project$plots$dataCombined$Aciclovir_individual
+  # dataCombined: named list keyed by id (no `dataCombinedId` field on entries)
+  expect_named(project$dataCombined, "aciclovir_individual")
+  dc <- project$dataCombined$aciclovir_individual
   expect_named(dc, c("simulated", "observed"), ignore.order = TRUE)
   expect_length(dc$simulated, 1L)
   expect_length(dc$observed, 1L)
-  # plotConfiguration / plotGrids: data.frames
-  expect_s3_class(project$plots$plotConfiguration, "data.frame")
-  expect_s3_class(project$plots$plotGrids, "data.frame")
-  expect_equal(nrow(project$plots$plotConfiguration), 1L)
-  expect_equal(nrow(project$plots$plotGrids), 1L)
-  expect_true("plotId" %in% names(project$plots$plotConfiguration))
-  expect_true("name" %in% names(project$plots$plotGrids))
+  # plots / plotGrids: keyed lists, each entry a classed named list of its
+  # rationalized fields.
+  expect_named(project$plots, "p1")
+  expect_named(project$plotGrids, "individual_diagnostics")
+  p1 <- project$plots$p1
+  expect_s3_class(p1, "Plot")
+  expect_identical(p1$plotId, "p1")
+  expect_identical(p1$dataCombinedId, "aciclovir_individual")
+  grid <- project$plotGrids$individual_diagnostics
+  expect_s3_class(grid, "PlotGrid")
+  expect_identical(grid$plotGridId, "individual_diagnostics")
 })
 
 test_that("loadProject() rejects a missing schemaVersion", {
@@ -418,27 +412,28 @@ test_that("loadProject() defaults missing optional sections to empty lists", {
 
   project <- loadProject(tmp)
 
+  # Section accessors wrap the stored list in a printable DefinitionList; unwrap
+  # to assert the underlying absent-vs-empty shape the parser produced.
   expect_identical(project$filePaths, structure(list(), names = character(0L)))
-  expect_identical(project$outputPaths, list())
-  expect_identical(project$scenarios, list())
-  expect_identical(project$modelParameterSets, list())
-  expect_identical(project$individualParameterSets, list())
-  expect_identical(project$applicationParameterSets, list())
-  expect_identical(project$individuals, list())
-  expect_identical(project$populations, list())
+  expect_identical(.unwrapDefinitionList(project$outputPaths), list())
+  expect_identical(.unwrapDefinitionList(project$scenarios), list())
+  expect_identical(.unwrapDefinitionList(project$parameterSets), list())
+  expect_identical(.unwrapDefinitionList(project$individuals), list())
+  expect_identical(.unwrapDefinitionList(project$populations), list())
   expect_identical(
-    project$applications,
+    .unwrapDefinitionList(project$applications),
     structure(list(), names = character(0L))
   )
-  expect_identical(project$observedData, list())
-  expect_null(project$plots)
+  expect_identical(.unwrapDefinitionList(project$observedData), list())
+  expect_identical(.unwrapDefinitionList(project$dataCombined), list())
+  expect_identical(.unwrapDefinitionList(project$plots), list())
+  expect_identical(.unwrapDefinitionList(project$plotGrids), list())
 })
 
 test_that("Project lifecycle fields are read-only", {
   project <- exampleProject()
 
   expect_error(project$validatedSinceMutation <- TRUE, "readonly")
-  expect_error(project$modified <- TRUE, "readonly")
 })
 
 test_that("Project$print() summarises section counts", {
@@ -449,77 +444,413 @@ test_that("Project$print() summarises section counts", {
   expect_output(print(project), "scenarios:\\s+3")
   expect_output(print(project), "individuals:\\s+1")
   expect_output(print(project), "populations:\\s+1")
-  # plotConfiguration is a 1-row, 15-column data frame: report 1 plot,
-  # not the column count.
+  # The three plots-related sections each report their entry count.
+  expect_output(print(project), "dataCombined:\\s+1")
+  expect_output(print(project), "plots:\\s+1")
+  expect_output(print(project), "plotGrids:\\s+1")
+})
+
+# Container rework: metadata, definitionsFolder, the filePaths/excel split,
+# and defaultSimulationRunOptions.
+
+test_that("loadProject() exposes name and description metadata", {
+  project <- exampleProject()
+  expect_identical(project$name, "Example")
+  expect_identical(project$description, "Aciclovir IV PK example project")
+})
+
+test_that("name and description are writable and persist write-through", {
+  project <- exampleProject()
+  project$name <- "Renamed"
+  project$description <- "A new description"
+  expect_identical(project$name, "Renamed")
+  expect_identical(project$description, "A new description")
+
+  reloaded <- loadProject(project$jsonPath)
+  expect_identical(reloaded$name, "Renamed")
+  expect_identical(reloaded$description, "A new description")
+})
+
+test_that("filePaths holds only the four live working folders", {
+  project <- exampleProject()
+  expect_named(
+    project$filePaths,
+    c("modelFolder", "populationsFolder", "dataFolder", "outputFolder"),
+    ignore.order = TRUE
+  )
+})
+
+test_that("excel exposes the seven Excel-bridge sheet-name fields", {
+  project <- exampleProject()
+  expect_named(
+    project$excel,
+    c(
+      "configurationsFolder",
+      "modelParamsFile",
+      "individualsFile",
+      "populationsFile",
+      "scenariosFile",
+      "applicationsFile",
+      "plotsFile"
+    ),
+    ignore.order = TRUE
+  )
+  expect_identical(project$excel$modelParamsFile, "ModelParameters.xlsx")
+})
+
+test_that("excel is read-only", {
+  project <- exampleProject()
+  expect_error(project$excel <- list(), "readonly")
+})
+
+test_that("a from-scratch project carries no excel block", {
+  project <- Project$new()
+  expect_length(project$excel, 0L)
+})
+
+test_that("definitionsFolder defaults to 'definitions' and is reported", {
+  project <- exampleProject()
+  expect_identical(project$definitionsFolder, "definitions")
+})
+
+test_that("a legacy flat-filePaths Project.json loads and splits the fields", {
+  tmp <- withr::local_tempfile(fileext = ".json")
+  jsonlite::write_json(
+    list(
+      schemaVersion = "2.0",
+      esqlabsRVersion = "6.0.0",
+      filePaths = list(
+        modelFolder = "Models/",
+        configurationsFolder = "Configurations/",
+        modelParamsFile = "ModelParameters.xlsx",
+        dataFolder = "Data/",
+        outputFolder = "Results/"
+      ),
+      outputPaths = structure(list(), names = character(0)),
+      scenarios = list()
+    ),
+    tmp,
+    auto_unbox = TRUE,
+    null = "null"
+  )
+  project <- loadProject(tmp)
+
+  expect_named(
+    project$filePaths,
+    c("modelFolder", "dataFolder", "outputFolder"),
+    ignore.order = TRUE
+  )
+  expect_named(
+    project$excel,
+    c("configurationsFolder", "modelParamsFile"),
+    ignore.order = TRUE
+  )
+})
+
+test_that("definitionsFolder honors a non-default tree location", {
+  # Write a tree project under a custom definitions folder, then load it.
+  src <- exampleProject()
+  scratch <- src$clone()
+  scratch$definitionsFolder <- "defs"
+  dir <- withr::local_tempdir("custom_defs_")
+  esqlabsR:::.writeProjectTree(scratch, dir)
+
+  expect_true(dir.exists(file.path(dir, "defs", "scenarios")))
+  expect_false(dir.exists(file.path(dir, "definitions")))
+
+  reloaded <- loadProject(file.path(dir, "Project.json"))
+  expect_identical(reloaded$definitionsFolder, "defs")
+  expect_length(reloaded$scenarios, 3L)
+})
+
+test_that("the tree wins over a conflicting non-empty inline Project.json section", {
+  # A tree project never writes an inline copy of a section, so a non-empty
+  # inline section that disagrees with the tree can only arise from hand-editing
+  # the Project.json. Construct that conflicting state directly and assert the
+  # loader takes the tree value and ignores the stale inline copy.
+  project <- testProject()
+  jsonPath <- project$jsonPath
+  treeDir <- file.path(dirname(jsonPath), "definitions", "scenarios")
+  expect_true(dir.exists(treeDir))
+
+  raw <- jsonlite::fromJSON(jsonPath, simplifyVector = FALSE)
+  expect_length(raw$scenarios, 0L)
+
+  # Inject a conflicting inline scenario for an id that also lives in the tree,
+  # giving it a different modelFile than the tree entity carries.
+  treeModelFile <- project$scenarios[["testscenario"]]$modelFile
+  raw$scenarios <- list(
+    list(
+      name = "testscenario",
+      modelFile = "INLINE_SHOULD_NOT_WIN.pkml"
+    )
+  )
+  writeLines(
+    jsonlite::toJSON(raw, auto_unbox = TRUE, null = "null", pretty = TRUE),
+    jsonPath
+  )
+
+  reloaded <- loadProject(jsonPath)
+  expect_identical(
+    reloaded$scenarios[["testscenario"]]$modelFile,
+    treeModelFile
+  )
+  expect_false(
+    identical(
+      reloaded$scenarios[["testscenario"]]$modelFile,
+      "INLINE_SHOULD_NOT_WIN.pkml"
+    )
+  )
+})
+
+test_that("a container-field write empties sections in Project.json yet the tree restores them on reload", {
+  treeSections <- c(
+    "scenarios",
+    "individuals",
+    "populations",
+    "parameterSets",
+    "applications",
+    "outputPaths",
+    "observedData",
+    "dataCombined",
+    "plots",
+    "plotGrids",
+    "parameterIdentification"
+  )
+  project <- exampleProject()
+  before <- vapply(treeSections, \(s) length(project[[s]]), integer(1))
+  expect_gt(sum(before), 0L)
+
+  # A container-metadata write persists only the container; the tree owns the
+  # sections, so they must not be re-inlined into Project.json.
+  project$name <- "RenamedX"
+  onDisk <- jsonlite::fromJSON(project$jsonPath, simplifyVector = FALSE)
+  expect_identical(onDisk$name, "RenamedX")
+  expect_false(is.null(onDisk$filePaths))
+  for (s in treeSections) {
+    expect_length(onDisk[[s]], 0L)
+  }
+
+  # Reload restores every section from the tree, and the metadata edit stuck.
+  reloaded <- loadProject(project$jsonPath)
+  after <- vapply(treeSections, \(s) length(reloaded[[s]]), integer(1))
+  expect_identical(after, before)
+  expect_identical(reloaded$name, "RenamedX")
+})
+
+test_that("Project$print() shows name and description", {
+  project <- exampleProject()
+  expect_output(print(project), "name:\\s+Example")
   expect_output(
     print(project),
-    "1 dataCombined / 1 plot\\(s\\) / 1 grid\\(s\\)"
+    "description:\\s+Aciclovir IV PK example project"
   )
 })
 
-test_that(".markSaved clears modified but leaves validatedSinceMutation set", {
+test_that("defaultSimulationRunOptions round-trips and defaults to NULL", {
+  project <- exampleProject()
+  expect_null(project$defaultSimulationRunOptions)
+
+  project$defaultSimulationRunOptions <- list(
+    numberOfCores = 2,
+    checkForNegativeValues = TRUE
+  )
+  reloaded <- loadProject(project$jsonPath)
+  expect_equal(reloaded$defaultSimulationRunOptions$numberOfCores, 2)
+  expect_true(reloaded$defaultSimulationRunOptions$checkForNegativeValues)
+})
+
+test_that("an Excel-bridge file field write targets the excel block", {
+  project <- Project$new()
+  project$modelParamsFile <- "X.xlsx"
+  expect_match(project$modelParamsFile, "X\\.xlsx$")
+  expect_identical(project$excel$modelParamsFile, "X.xlsx")
+})
+
+test_that(".markValidated leaves the validation cache set until the next mutation", {
   project <- testProject()
-  # A mutation marks the project modified and clears the validation flag.
+  project$.markValidated()
+  expect_true(project$validatedSinceMutation)
+
+  # A mutation clears the validation cache so runScenarios()/createPlots()
+  # re-validate the new shape.
   project$.markModified()
-  expect_true(project$modified)
-
-  # Validating sets the flag; a subsequent save must not clear it.
-  project$.markValidated()
-  project$.markSaved()
-
-  expect_false(project$modified)
-  # Saving is not a mutation, so a project validated before the save stays
-  # validated after it; runScenarios()/createPlots() need not re-validate.
-  expect_true(project$validatedSinceMutation)
-})
-
-test_that("a fresh project starts unmodified and unvalidated", {
-  project <- testProject()
-  expect_false(project$modified)
   expect_false(project$validatedSinceMutation)
 })
 
-test_that("a direct write to a section field invalidates the project", {
+test_that("a fresh project starts unvalidated", {
   project <- testProject()
-  project$.markValidated()
-  expect_false(project$modified)
-  expect_true(project$validatedSinceMutation)
-
-  project$scenarios[["New"]] <- Scenario(
-    scenarioName = "New",
-    modelFile = "m.pkml"
-  )
-
-  expect_true(project$modified)
   expect_false(project$validatedSinceMutation)
 })
 
-test_that("the documented c() attach idiom invalidates the project", {
+test_that("addScenario() invalidates the validation cache", {
   project <- testProject()
-  scenarios <- list(Attached = Scenario(scenarioName = "Attached"))
+  project$.markValidated()
+  expect_true(project$validatedSinceMutation)
 
-  project$scenarios <- c(project$scenarios, scenarios)
+  addScenario(project, "new", modelFile = "m.pkml")
 
-  expect_true(project$modified)
-  expect_s3_class(project$scenarios[["Attached"]], "Scenario")
+  expect_false(project$validatedSinceMutation)
 })
 
-test_that("nested subscript-assignment on a section entry invalidates the project", {
+test_that("setScenario() invalidates the validation cache", {
   project <- testProject()
-  project$individuals[["Indiv1"]]$weight <- 81
+  project$.markValidated()
 
-  expect_true(project$modified)
-  expect_identical(project$individuals[["Indiv1"]]$weight, 81)
+  setScenario(project, "testscenario", modelFile = "Aciclovir.pkml")
+
+  expect_false(project$validatedSinceMutation)
+  expect_s3_class(project$scenarios[["testscenario"]], "Scenario")
+})
+
+test_that("a section-entry authoring write invalidates the validation cache", {
+  project <- testProject()
+  project$.markValidated()
+  setIndividual(project, "indiv1", weight = 81)
+
+  expect_false(project$validatedSinceMutation)
+  expect_identical(project$individuals[["indiv1"]]$weight, 81)
 })
 
 test_that("an extracted Scenario is a copy and cannot mutate the project silently", {
   project <- testProject()
-  sc <- project$scenarios[["TestScenario"]]
+  project$.markValidated()
+  sc <- project$scenarios[["testscenario"]]
   sc$modelFile <- "HIJACKED.pkml"
 
-  expect_false(project$modified)
+  # Reading and mutating a copy is not a project mutation.
+  expect_true(project$validatedSinceMutation)
   expect_false(
-    identical(project$scenarios[["TestScenario"]]$modelFile, "HIJACKED.pkml")
+    identical(project$scenarios[["testscenario"]]$modelFile, "HIJACKED.pkml")
+  )
+})
+
+# Section accessors are read-only ----
+
+test_that("a whole-section assignment through a section accessor is rejected", {
+  project <- testProject()
+  expect_snapshot(error = TRUE, project$scenarios <- list())
+})
+
+test_that("a subscript assignment through a section accessor is rejected", {
+  project <- testProject()
+  expect_snapshot(
+    error = TRUE,
+    project$scenarios[["aciclovir_iv"]] <- Scenario(
+      scenarioName = "aciclovir_iv",
+      modelFile = "m.pkml"
+    )
+  )
+})
+
+test_that("a nested field assignment through a section accessor is rejected", {
+  project <- testProject()
+  # The most insidious form: `project$scenarios[["x"]]$field <- v` desugars to
+  # the same read-modify-write the subscript form does, so it is rejected too.
+  expect_snapshot(
+    error = TRUE,
+    project$scenarios[["testscenario"]]$individualId <- "indiv1"
+  )
+})
+
+test_that("a negative-index assignment through a section accessor is rejected", {
+  project <- testProject()
+  expect_snapshot(error = TRUE, project$scenarios[-1] <- list())
+})
+
+test_that("the read-only block applies to every section accessor", {
+  project <- testProject()
+  sections <- c(
+    "outputPaths",
+    "scenarios",
+    "parameterSets",
+    "initialConditions",
+    "individuals",
+    "populations",
+    "applications",
+    "observedData",
+    "dataCombined",
+    "plots",
+    "plotGrids",
+    "parameterIdentification"
+  )
+  for (section in sections) {
+    expect_error(
+      eval(bquote(project[[.(section)]] <- list())),
+      "read-only"
+    )
+  }
+})
+
+test_that("sub-element and negative-index assignment are rejected on every section accessor", {
+  project <- testProject()
+  # The scenarios section is covered by its own dedicated blocks above; the
+  # DefinitionList replacement methods (`[[<-`/`[<-`/`$<-`) dispatch purely on
+  # the shared wrapper class (the kind only feeds the message text), so a loop
+  # over the other ten sections asserts they traverse the same read-only path.
+  sections <- c(
+    "outputPaths",
+    "parameterSets",
+    "initialConditions",
+    "individuals",
+    "populations",
+    "applications",
+    "observedData",
+    "dataCombined",
+    "plots",
+    "plotGrids",
+    "parameterIdentification"
+  )
+  for (section in sections) {
+    expect_error(
+      eval(bquote(project[[.(section)]][["new_id"]] <- list())),
+      "read-only"
+    )
+    expect_error(
+      eval(bquote(project[[.(section)]][-1] <- list())),
+      "read-only"
+    )
+  }
+})
+
+test_that("reading a record, editing the copy, and re-submitting it is the supported edit loop", {
+  project <- testProject()
+  # The canonical edit loop: the accessor returns a detached copy; mutating it
+  # does not touch the project, and the change lands only when re-submitted
+  # through an authoring function.
+  sc <- project$scenarios[["testscenario"]]
+  sc$modelFile <- "Edited.pkml"
+  expect_false(
+    identical(project$scenarios[["testscenario"]]$modelFile, "Edited.pkml")
+  )
+  setScenario(project, "testscenario", modelFile = "Edited.pkml")
+  expect_identical(
+    project$scenarios[["testscenario"]]$modelFile,
+    "Edited.pkml"
+  )
+})
+
+# The sanctioned write path (the authoring functions, funneling through the
+# internal .setSection() entry point) must reject a structurally bad record,
+# not silently persist it: a wrong-typed reference field and an unknown field
+# both abort. (Regression guard for the write-path validation gap.)
+test_that("the write path rejects a wrong-typed scalar reference field", {
+  project <- testProject()
+  scenarios <- project$.getSection("scenarios")
+  scenarios[["testscenario"]]$individualId <- list(a = 1)
+  expect_error(
+    project$.setSection("scenarios", scenarios),
+    "individualId.*single string"
+  )
+})
+
+test_that("the write path rejects an unknown field on a record", {
+  project <- testProject()
+  scenarios <- project$.getSection("scenarios")
+  scenarios[["testscenario"]]$totallyBogusField <- "nonsense"
+  expect_error(
+    project$.setSection("scenarios", scenarios),
+    "unknown field"
   )
 })
 
@@ -529,17 +860,20 @@ test_that("jsonPath is read-only and aliases projectFilePath", {
   expect_snapshot(error = TRUE, project$jsonPath <- "elsewhere.json")
 })
 
-test_that("sync() reports a direct section-field write as unsaved changes", {
-  tmp <- withr::local_tempfile(fileext = ".json")
-  saveProject(testProject(), tmp)
+test_that("syncStatus() reports NA when there is no Excel side-car", {
+  tmp <- saveSnapshot(testProject(), local_projectPath())
   project <- loadProject(tmp)
 
-  project$scenarios[["TestScenario"]]$modelFile <- "Changed.pkml"
+  # Every section is write-through, so the project and its entity files never
+  # diverge; with no Project.xlsx alongside there is nothing to compare.
+  status <- project$syncStatus(silent = TRUE)
+  expect_identical(status$excel_in_sync, NA)
+  expect_identical(status$details, list())
+})
 
-  status <- project$sync(silent = TRUE)
-  expect_true(status$unsaved_changes)
-  expect_false(status$json_modified)
-  expect_false(status$in_sync)
+test_that("syncStatus() reports NA for an in-memory project", {
+  status <- Project$new()$syncStatus(silent = TRUE)
+  expect_identical(status$excel_in_sync, NA)
 })
 
 # Clone safety ----
@@ -548,14 +882,14 @@ test_that("mutating a clone's scenario leaves the source untouched", {
   project <- testProject()
   clone <- project$clone()
 
-  clone$scenarios[["TestScenario"]]$modelFile <- "OnlyOnClone.pkml"
+  setScenario(clone, "testscenario", modelFile = "OnlyOnClone.pkml")
 
   expect_identical(
-    clone$scenarios[["TestScenario"]]$modelFile,
+    clone$scenarios[["testscenario"]]$modelFile,
     "OnlyOnClone.pkml"
   )
   expect_false(
-    identical(project$scenarios[["TestScenario"]]$modelFile, "OnlyOnClone.pkml")
+    identical(project$scenarios[["testscenario"]]$modelFile, "OnlyOnClone.pkml")
   )
 })
 
@@ -564,31 +898,94 @@ test_that("adding a scenario to a clone leaves the source untouched", {
   clone <- project$clone()
   before <- length(project$scenarios)
 
-  clone$scenarios[["Fresh"]] <- Scenario(scenarioName = "Fresh")
+  addScenario(clone, "fresh", modelFile = "Aciclovir.pkml")
 
   expect_length(project$scenarios, before)
-  expect_false("Fresh" %in% names(project$scenarios))
+  expect_false("fresh" %in% names(project$scenarios))
 })
 
 test_that("mutating a clone's nested individual entry leaves the source untouched", {
   project <- testProject()
   clone <- project$clone()
 
-  clone$individuals[["Indiv1"]]$weight <- 99
+  setIndividual(clone, "indiv1", weight = 99)
 
-  expect_identical(clone$individuals[["Indiv1"]]$weight, 99)
-  expect_false(identical(project$individuals[["Indiv1"]]$weight, 99))
+  expect_identical(clone$individuals[["indiv1"]]$weight, 99)
+  expect_false(identical(project$individuals[["indiv1"]]$weight, 99))
 })
 
-test_that("clone modified/validated flags are independent of the source", {
+test_that("clone validated flag is independent of the source", {
   project <- testProject()
   project$.markValidated()
   clone <- project$clone()
 
-  clone$scenarios[["TestScenario"]]$modelFile <- "Changed.pkml"
+  setScenario(clone, "testscenario", modelFile = "Changed.pkml")
 
-  expect_true(clone$modified)
+  # Mutating the clone clears only the clone's validation cache; the source's
+  # cache is untouched.
   expect_false(clone$validatedSinceMutation)
-  expect_false(project$modified)
   expect_true(project$validatedSinceMutation)
+})
+
+# DefinitionList section-accessor printing ----
+
+test_that("a section accessor prints a count and the definition names", {
+  project <- testProject()
+  withr::local_options(cli.unicode = FALSE)
+  local_reproducible_output()
+  expect_snapshot(print(project$individuals))
+  expect_snapshot(print(project$parameterSets))
+})
+
+test_that("an empty section accessor prints zero definitions", {
+  project <- .fakeProject()
+  withr::local_options(cli.unicode = FALSE)
+  local_reproducible_output()
+  expect_snapshot(print(project$individuals))
+})
+
+test_that("print on a section accessor returns the value invisibly", {
+  project <- testProject()
+  expect_invisible(print(project$individuals))
+  returned <- withr::with_output_sink(
+    withr::local_tempfile(),
+    print(project$individuals)
+  )
+  expect_s3_class(returned, "DefinitionList")
+})
+
+test_that("a wrapped section accessor still behaves as a list", {
+  project <- testProject()
+  indivs <- project$individuals
+  expect_type(indivs, "list")
+  expect_length(indivs, 1L)
+  expect_named(indivs, "indiv1")
+  expect_s3_class(indivs[["indiv1"]], "Individual")
+  # c() and named extraction are transparent.
+  expect_length(c(indivs, list(extra = 1)), 2L)
+})
+
+test_that("the stored section stays a plain list (no DefinitionList class)", {
+  project <- testProject()
+  # Reading wraps, but the backing private store is plain: a round-trip
+  # through a mutator persists and reloads identically.
+  stored <- .unwrapDefinitionList(project$individuals)
+  expect_false(inherits(stored, "DefinitionList"))
+
+  addIndividual(project, "extra", species = "Human", gender = "MALE")
+  reloaded <- loadProject(project$jsonPath)
+  expect_true("extra" %in% names(reloaded$individuals))
+  expect_false(inherits(
+    .unwrapDefinitionList(reloaded$individuals),
+    "DefinitionList"
+  ))
+})
+
+test_that("the three plots sections each print a count and ids", {
+  project <- exampleProject()
+  withr::local_options(cli.unicode = FALSE)
+  local_reproducible_output()
+  expect_snapshot(print(project$plots))
+  expect_snapshot(print(project$plotGrids))
+  expect_snapshot(print(project$dataCombined))
 })

--- a/tests/testthat/test-scenario-execution.R
+++ b/tests/testthat/test-scenario-execution.R
@@ -1,8 +1,85 @@
-# Local test helper. Once Task 8 ships loadProject(), the production
-# helpers.R::testProject() will work directly and this can be removed.
-.testProject <- function() {
-  testProject()
+# Local test helper delegating to helpers.R::testProject(). It forwards the
+# calling test's frame so the throwaway project copy (a write-through entity
+# tree) lives until the test finishes, not until this wrapper returns.
+.testProject <- function(envir = parent.frame()) {
+  testProject(envir = envir)
 }
+
+test_that(".buildSimulationRunOptions returns NULL when no defaults are declared", {
+  expect_null(esqlabsR:::.buildSimulationRunOptions(NULL))
+  expect_null(esqlabsR:::.buildSimulationRunOptions(list()))
+})
+
+test_that(".buildSimulationRunOptions maps the three settable fields", {
+  opts <- esqlabsR:::.buildSimulationRunOptions(list(
+    numberOfCores = 3,
+    checkForNegativeValues = TRUE,
+    showProgress = FALSE
+  ))
+  expect_s3_class(opts, "SimulationRunOptions")
+  expect_identical(opts$numberOfCores, 3L)
+  expect_true(opts$checkForNegativeValues)
+  expect_false(opts$showProgress)
+})
+
+test_that(".buildSimulationRunOptions leaves an unset field at its default", {
+  baseline <- ospsuite::SimulationRunOptions$new()$checkForNegativeValues
+  opts <- esqlabsR:::.buildSimulationRunOptions(list(numberOfCores = 1))
+  expect_identical(opts$numberOfCores, 1L)
+  expect_identical(opts$checkForNegativeValues, baseline)
+})
+
+test_that("runScenarios falls back to the project default run options when the caller passes none", {
+  # Capture the run options `.runScenariosFromProject` resolves without a native
+  # simulation: mock `.prepareScenario` to record them and abort immediately.
+  withr::local_options(lifecycle_verbosity = "quiet")
+  project <- .testProject()
+  project$defaultSimulationRunOptions <- list(numberOfCores = 2)
+
+  captured <- NULL
+  local_mocked_bindings(
+    .prepareScenario = function(scenario, project, ..., simulationRunOptions) {
+      captured <<- simulationRunOptions
+      stop("stop before simulating")
+    }
+  )
+  expect_error(
+    esqlabsR:::.runScenariosFromProject(
+      project,
+      scenarioNames = "testscenario"
+    ),
+    "stop before simulating"
+  )
+  expect_s3_class(captured, "SimulationRunOptions")
+  expect_identical(captured$numberOfCores, 2L)
+})
+
+test_that("runScenarios lets an explicit simulationRunOptions argument win over the project default", {
+  # The caller's argument must override `defaultSimulationRunOptions` entirely,
+  # not merge with it. Same capture-then-abort mock, no native simulation.
+  withr::local_options(lifecycle_verbosity = "quiet")
+  project <- .testProject()
+  project$defaultSimulationRunOptions <- list(numberOfCores = 2)
+  callerOptions <- ospsuite::SimulationRunOptions$new(numberOfCores = 5)
+
+  captured <- NULL
+  local_mocked_bindings(
+    .prepareScenario = function(scenario, project, ..., simulationRunOptions) {
+      captured <<- simulationRunOptions
+      stop("stop before simulating")
+    }
+  )
+  expect_error(
+    esqlabsR:::.runScenariosFromProject(
+      project,
+      scenarioNames = "testscenario",
+      simulationRunOptions = callerOptions
+    ),
+    "stop before simulating"
+  )
+  expect_identical(captured, callerOptions)
+  expect_identical(captured$numberOfCores, 5L)
+})
 
 test_that(".parameterSetToStructure flattens record-shape into paths/values/units", {
   records <- list(
@@ -27,7 +104,7 @@ test_that(".parameterSetToStructure returns NULL on empty input", {
 
 test_that(".mergeScenarioParameters returns NULL when no layer contributes", {
   project <- .testProject()
-  scenario <- project$scenarios[["TestScenario"]]
+  scenario <- project$scenarios[["testscenario"]]
   scenario$modelParameterSets <- NULL
   scenario$individualId <- NULL
   scenario$applicationProtocol <- NA
@@ -38,7 +115,7 @@ test_that(".mergeScenarioParameters returns NULL when no layer contributes", {
 
 test_that(".mergeScenarioParameters layer 1 (modelParameterSets) iterates listed groups in order", {
   project <- .testProject()
-  scenario <- project$scenarios[["TestScenario_steadystate"]]
+  scenario <- project$scenarios[["testscenario_steadystate"]]
   scenario$individualId <- NULL
   scenario$applicationProtocol <- NA
   merged <- esqlabsR:::.mergeScenarioParameters(scenario, project, NULL)
@@ -48,8 +125,9 @@ test_that(".mergeScenarioParameters layer 1 (modelParameterSets) iterates listed
 
 test_that(".mergeScenarioParameters layer 4 (application) overrides layer 1 on overlapping path", {
   project <- .testProject()
-  scenario <- project$scenarios[["TestScenario"]]
-  project$modelParameterSets$Global <- list(
+  scenario <- project$scenarios[["testscenario"]]
+  parameterSets <- project$.getSection("parameterSets")
+  parameterSets$global <- list(
     list(
       containerPath = "OverlapContainer",
       parameterName = "OverlapParam",
@@ -57,7 +135,7 @@ test_that(".mergeScenarioParameters layer 4 (application) overrides layer 1 on o
       units = NULL
     )
   )
-  project$applicationParameterSets$Override <- list(
+  parameterSets$override <- list(
     list(
       containerPath = "OverlapContainer",
       parameterName = "OverlapParam",
@@ -65,7 +143,10 @@ test_that(".mergeScenarioParameters layer 4 (application) overrides layer 1 on o
       units = NULL
     )
   )
-  project$applications$Aciclovir_iv_250mg$parameterSets <- list("Override")
+  project$.setSection("parameterSets", parameterSets)
+  apps <- project$.getSection("applications")
+  apps$aciclovir_iv_250mg$parameterSets <- list("override")
+  project$.setSection("applications", apps)
   scenario$individualId <- NULL
   merged <- esqlabsR:::.mergeScenarioParameters(scenario, project, NULL)
   idx <- match("OverlapContainer|OverlapParam", merged$paths)
@@ -74,7 +155,7 @@ test_that(".mergeScenarioParameters layer 4 (application) overrides layer 1 on o
 
 test_that(".mergeScenarioParameters layer 5 (customParams) wins over all earlier layers", {
   project <- .testProject()
-  scenario <- project$scenarios[["TestScenario"]]
+  scenario <- project$scenarios[["testscenario"]]
   customParams <- list(
     paths = "Organism|Liver|EHC continuous fraction",
     values = 42,
@@ -87,7 +168,7 @@ test_that(".mergeScenarioParameters layer 5 (customParams) wins over all earlier
 
 test_that(".mergeScenarioParameters skips application layer when applicationProtocol is NA", {
   project <- .testProject()
-  scenario <- project$scenarios[["TestScenario"]]
+  scenario <- project$scenarios[["testscenario"]]
   scenario$applicationProtocol <- NA
   scenario$modelParameterSets <- NULL
   scenario$individualId <- NULL
@@ -98,7 +179,7 @@ test_that(".mergeScenarioParameters skips application layer when applicationProt
 
 test_that(".mergeScenarioParameters errors when applicationProtocol is set but unknown", {
   project <- .testProject()
-  scenario <- project$scenarios[["TestScenario"]]
+  scenario <- project$scenarios[["testscenario"]]
   scenario$applicationProtocol <- "DoesNotExist"
   expect_error(
     esqlabsR:::.mergeScenarioParameters(scenario, project, NULL),
@@ -108,8 +189,8 @@ test_that(".mergeScenarioParameters errors when applicationProtocol is set but u
 
 test_that(".mergeScenarioParameters silently skips an unknown modelParameterSets group", {
   project <- .testProject()
-  scenario <- project$scenarios[["TestScenario"]]
-  scenario$modelParameterSets <- c("Global", "DoesNotExist")
+  scenario <- project$scenarios[["testscenario"]]
+  scenario$modelParameterSets <- c("global", "DoesNotExist")
   scenario$individualId <- NULL
   scenario$applicationProtocol <- NA
   merged <- esqlabsR:::.mergeScenarioParameters(scenario, project, NULL)
@@ -118,11 +199,13 @@ test_that(".mergeScenarioParameters silently skips an unknown modelParameterSets
 
 test_that(".mergeScenarioParameters silently skips an unknown individual parameter-set id", {
   project <- .testProject()
-  scenario <- project$scenarios[["TestScenario"]]
-  project$individuals[[1L]]$parameterSets <- list(
-    "Indiv1_default",
+  scenario <- project$scenarios[["testscenario"]]
+  individuals <- project$.getSection("individuals")
+  individuals[[1L]]$parameterSets <- list(
+    "indiv1_default",
     "DoesNotExist"
   )
+  project$.setSection("individuals", individuals)
   scenario$modelParameterSets <- NULL
   scenario$applicationProtocol <- NA
   merged <- esqlabsR:::.mergeScenarioParameters(scenario, project, NULL)
@@ -131,11 +214,13 @@ test_that(".mergeScenarioParameters silently skips an unknown individual paramet
 
 test_that(".mergeScenarioParameters silently skips an unknown application parameter-set id", {
   project <- .testProject()
-  scenario <- project$scenarios[["TestScenario"]]
-  project$applications$Aciclovir_iv_250mg$parameterSets <- list(
-    "Aciclovir_iv_250mg_default",
+  scenario <- project$scenarios[["testscenario"]]
+  apps <- project$.getSection("applications")
+  apps$aciclovir_iv_250mg$parameterSets <- list(
+    "aciclovir_iv_250mg_default",
     "DoesNotExist"
   )
+  project$.setSection("applications", apps)
   scenario$modelParameterSets <- NULL
   scenario$individualId <- NULL
   merged <- esqlabsR:::.mergeScenarioParameters(scenario, project, NULL)
@@ -145,20 +230,78 @@ test_that(".mergeScenarioParameters silently skips an unknown application parame
   )
 })
 
+# Initial conditions merge ----
+
+test_that(".initialConditionSetToStructure flattens records into paths/values/units", {
+  records <- list(
+    list(path = "Organism|A", value = 1.5, unit = "mg/l"),
+    list(path = "Organism|B", value = 2, unit = NULL)
+  )
+  out <- esqlabsR:::.initialConditionSetToStructure(records)
+  expect_equal(out$paths, c("Organism|A", "Organism|B"))
+  expect_equal(out$values, c(1.5, 2))
+  expect_equal(out$units, c("mg/l", ""))
+})
+
+test_that(".initialConditionSetToStructure returns NULL on empty input", {
+  expect_null(esqlabsR:::.initialConditionSetToStructure(NULL))
+  expect_null(esqlabsR:::.initialConditionSetToStructure(list()))
+})
+
+test_that(".mergeScenarioInitialConditions returns NULL when no set is referenced", {
+  project <- .testProject()
+  scenario <- project$scenarios[["testscenario"]]
+  scenario$initialConditions <- NULL
+  expect_null(
+    esqlabsR:::.mergeScenarioInitialConditions(scenario, project)
+  )
+})
+
+test_that(".mergeScenarioInitialConditions folds referenced sets last-write-wins", {
+  project <- .testProject()
+  addInitialConditions(project, "icset")
+  suppressMessages(
+    addInitialConditionEntry(
+      project,
+      "icset",
+      path = c("Organism|A", "Organism|B"),
+      value = c(1, 2),
+      unit = c("mg/l", "µmol/l")
+    )
+  )
+  scenario <- project$scenarios[["testscenario"]]
+  scenario$initialConditions <- "icset"
+  merged <- esqlabsR:::.mergeScenarioInitialConditions(scenario, project)
+  expect_equal(merged$paths, c("Organism|A", "Organism|B"))
+  expect_equal(merged$values, c(1, 2))
+})
+
+test_that(".mergeScenarioInitialConditions silently skips an unknown set id", {
+  project <- .testProject()
+  addInitialConditions(project, "icset")
+  suppressMessages(
+    addInitialConditionEntry(project, "icset", "Organism|A", 1, "mg/l")
+  )
+  scenario <- project$scenarios[["testscenario"]]
+  scenario$initialConditions <- c("icset", "DoesNotExist")
+  merged <- esqlabsR:::.mergeScenarioInitialConditions(scenario, project)
+  expect_equal(merged$paths, "Organism|A")
+})
+
 test_that(".runScenariosFromProject returns the documented per-scenario list shape (individual)", {
   withr::local_options(lifecycle_verbosity = "quiet")
   project <- .testProject()
   out <- esqlabsR:::.runScenariosFromProject(
     project,
-    scenarioNames = "TestScenario"
+    scenarioNames = "testscenario"
   )
-  expect_named(out, "TestScenario")
+  expect_named(out, "testscenario")
   expect_named(
-    out$TestScenario,
+    out$testscenario,
     c("simulation", "results", "outputValues", "population")
   )
-  expect_s3_class(out$TestScenario$simulation, "Simulation")
-  expect_null(out$TestScenario$population)
+  expect_s3_class(out$testscenario$simulation, "Simulation")
+  expect_null(out$testscenario$population)
 })
 
 test_that(".runScenariosFromProject runs a steady-state scenario without error", {
@@ -166,9 +309,31 @@ test_that(".runScenariosFromProject runs a steady-state scenario without error",
   project <- .testProject()
   out <- esqlabsR:::.runScenariosFromProject(
     project,
-    scenarioNames = "TestScenario_steadystate"
+    scenarioNames = "testscenario_steadystate"
   )
-  expect_s3_class(out$TestScenario_steadystate$simulation, "Simulation")
+  expect_s3_class(out$testscenario_steadystate$simulation, "Simulation")
+})
+
+test_that(".runScenariosFromProject applies a scenario's initialConditions", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+  project <- .testProject()
+  path <- "Organism|VenousBlood|Plasma|Aciclovir"
+  addInitialConditions(project, "icset")
+  suppressMessages(
+    addInitialConditionEntry(project, "icset", path, 7, "µmol")
+  )
+  setScenario(project, "testscenario", initialConditions = "icset")
+
+  out <- esqlabsR:::.runScenariosFromProject(
+    project,
+    scenarioNames = "testscenario"
+  )
+  applied <- ospsuite::getQuantityValuesByPath(
+    quantityPaths = path,
+    simulation = out$testscenario$simulation,
+    units = "µmol"
+  )
+  expect_equal(applied, 7)
 })
 
 test_that(".runScenariosFromProject runs a population scenario and attaches a Population", {
@@ -176,9 +341,9 @@ test_that(".runScenariosFromProject runs a population scenario and attaches a Po
   project <- .testProject()
   out <- esqlabsR:::.runScenariosFromProject(
     project,
-    scenarioNames = "PopulationScenario"
+    scenarioNames = "populationscenario"
   )
-  expect_s3_class(out$PopulationScenario$population, "Population")
+  expect_s3_class(out$populationscenario$population, "Population")
 })
 
 test_that(".runScenariosFromProject runs a CSV-population scenario and attaches a Population", {
@@ -186,9 +351,9 @@ test_that(".runScenariosFromProject runs a CSV-population scenario and attaches 
   project <- .testProject()
   out <- esqlabsR:::.runScenariosFromProject(
     project,
-    scenarioNames = "PopulationScenarioFromCSV"
+    scenarioNames = "populationscenariofromcsv"
   )
-  expect_s3_class(out$PopulationScenarioFromCSV$population, "Population")
+  expect_s3_class(out$populationscenariofromcsv$population, "Population")
 })
 
 test_that(".runScenariosFromProject errors on unknown scenarioNames", {
@@ -206,17 +371,15 @@ test_that("a scenario with an absolute modelFile runs when modelFolder is NULL",
   withr::local_options(lifecycle_verbosity = "quiet")
   project <- .testProject()
   absModel <- normalizePath(file.path(project$modelFolder, "Aciclovir.pkml"))
-  scenario <- project$scenarios[["TestScenario"]]
-  scenario$modelFile <- absModel
-  project$scenarios[["TestScenario"]] <- scenario
+  setScenario(project, "testscenario", modelFile = absModel)
   project$modelFolder <- NULL
 
   out <- esqlabsR:::.runScenariosFromProject(
     project,
-    scenarioNames = "TestScenario",
+    scenarioNames = "testscenario",
     validate = FALSE
   )
-  expect_false(is.null(out$TestScenario$outputValues))
+  expect_false(is.null(out$testscenario$outputValues))
 })
 
 test_that("a relative modelFile with NULL modelFolder aborts with a clear message", {
@@ -227,7 +390,7 @@ test_that("a relative modelFile with NULL modelFolder aborts with a clear messag
     error = TRUE,
     esqlabsR:::.runScenariosFromProject(
       project,
-      scenarioNames = "TestScenario",
+      scenarioNames = "testscenario",
       validate = FALSE
     )
   )

--- a/tests/testthat/test-scenario-from-pkml.R
+++ b/tests/testthat/test-scenario-from-pkml.R
@@ -30,8 +30,8 @@ test_that("paramSheets argument is soft-deprecated", {
     suppressMessages(createScenariosFromPKML(
       pkmlFixture,
       project = project,
-      scenarioNames = "Test1",
-      modelParameterSets = "Global",
+      scenarios = "test1",
+      parameterSets = "Global",
       paramSheets = "Aciclovir"
     )),
     class = "lifecycle_warning_deprecated"
@@ -40,22 +40,20 @@ test_that("paramSheets argument is soft-deprecated", {
 
 # createScenariosFromPKML: in-place mutation ----
 
-test_that("createScenariosFromPKML adds scenarios in place, marks the project modified, and returns it invisibly", {
+test_that("createScenariosFromPKML adds scenarios in place and returns the project invisibly", {
   project <- testProject()
-  expect_false(project$modified)
 
   expect_snapshot(
     result <- createScenariosFromPKML(
       pkmlFixture,
       project = project,
-      scenarioNames = "Seeded"
+      scenarios = "seeded"
     )
   )
 
   expect_identical(result, project)
-  expect_true("Seeded" %in% names(project$scenarios))
-  expect_s3_class(project$scenarios[["Seeded"]], "Scenario")
-  expect_true(project$modified)
+  expect_true("seeded" %in% names(project$scenarios))
+  expect_s3_class(project$scenarios[["seeded"]], "Scenario")
 })
 
 # createScenariosFromPKML: output path resolution ----
@@ -67,33 +65,33 @@ test_that("PKML-extracted output paths reuse existing project ids for known lite
   suppressMessages(createScenariosFromPKML(
     pkmlFixture,
     project = project,
-    scenarioNames = "Seeded"
+    scenarios = "seeded"
   ))
 
-  sc <- project$scenarios[["Seeded"]]
+  sc <- project$scenarios[["seeded"]]
   # The PVB path is already registered as `Aciclovir_PVB`, so its id is reused.
-  expect_true("Aciclovir_PVB" %in% names(sc$outputPaths))
+  expect_true("aciclovir_pvb" %in% names(sc$outputPaths))
   expect_true(all(names(sc$outputPaths) %in% names(project$outputPaths)))
 })
 
 test_that("PKML-extracted output paths register generated readable ids when unknown", {
   project <- .fakeProject(
-    modelParameterSets = list(Global = list())
+    parameterSets = list(global = list())
   )
   project$modelFolder <- dirname(pkmlFixture)
 
   suppressMessages(createScenariosFromPKML(
     pkmlFixture,
     project = project,
-    scenarioNames = "Seeded"
+    scenarios = "seeded"
   ))
 
-  sc <- project$scenarios[["Seeded"]]
+  sc <- project$scenarios[["seeded"]]
   expect_gt(length(sc$outputPaths), 0)
   # Every id used by the scenario must be registered on the project.
   expect_true(all(names(sc$outputPaths) %in% names(project$outputPaths)))
   # Generated ids are readable (built from the path's last two segments).
-  expect_match(names(sc$outputPaths), "^Aciclovir_", all = TRUE)
+  expect_match(names(sc$outputPaths), "^aciclovir_", all = TRUE)
 })
 
 test_that("user-supplied named outputPaths register under the user ids", {
@@ -103,13 +101,13 @@ test_that("user-supplied named outputPaths register under the user ids", {
   suppressMessages(createScenariosFromPKML(
     pkmlFixture,
     project = project,
-    scenarioNames = "Seeded",
+    scenarios = "seeded",
     outputPaths = c(
       plasma = "Organism|VenousBlood|Plasma|Aciclovir|Concentration"
     )
   ))
 
-  sc <- project$scenarios[["Seeded"]]
+  sc <- project$scenarios[["seeded"]]
   expect_named(sc$outputPaths, "plasma")
   expect_identical(
     project$outputPaths[["plasma"]],
@@ -119,32 +117,32 @@ test_that("user-supplied named outputPaths register under the user ids", {
 
 test_that("user-supplied outputPaths reuse the existing id when the literal path already exists", {
   project <- testProject()
-  existingPath <- project$outputPaths[["Aciclovir_PVB"]]
+  existingPath <- project$outputPaths[["aciclovir_pvb"]]
   idsBefore <- names(project$outputPaths)
 
   suppressMessages(createScenariosFromPKML(
     pkmlFixture,
     project = project,
-    scenarioNames = "Seeded",
+    scenarios = "seeded",
     # User invents a different id for an already-registered path.
     outputPaths = stats::setNames(existingPath, "myAlias")
   ))
 
-  sc <- project$scenarios[["Seeded"]]
+  sc <- project$scenarios[["seeded"]]
   # The registered id wins; the user alias is dropped, no new entry added.
-  expect_named(sc$outputPaths, "Aciclovir_PVB")
+  expect_named(sc$outputPaths, "aciclovir_pvb")
   expect_identical(names(project$outputPaths), idsBefore)
 })
 
 test_that("user alias ignored in favour of registered id emits an inform", {
   project <- testProject()
-  existingPath <- project$outputPaths[["Aciclovir_PVB"]]
+  existingPath <- project$outputPaths[["aciclovir_pvb"]]
 
   expect_snapshot(
     createScenariosFromPKML(
       pkmlFixture,
       project = project,
-      scenarioNames = "Seeded",
+      scenarios = "seeded",
       outputPaths = stats::setNames(existingPath, "myAlias")
     )
   )
@@ -160,8 +158,8 @@ test_that("named outputPaths colliding with an existing id mapped to a different
     createScenariosFromPKML(
       pkmlFixture,
       project = project,
-      scenarioNames = "Seeded",
-      outputPaths = c(Aciclovir_PVB = "Organism|Some|Other|Path")
+      scenarios = "seeded",
+      outputPaths = c(aciclovir_pvb = "Organism|Some|Other|Path")
     )
   )
 
@@ -176,11 +174,11 @@ test_that("comma-separated outputPaths strings are split and registered per scen
   suppressMessages(createScenariosFromPKML(
     pkmlFixture,
     project = project,
-    scenarioNames = "Seeded",
+    scenarios = "seeded",
     outputPaths = "Organism|A|Conc, Organism|B|Conc"
   ))
 
-  sc <- project$scenarios[["Seeded"]]
+  sc <- project$scenarios[["seeded"]]
   expect_length(sc$outputPaths, 2)
   expect_setequal(
     unname(sc$outputPaths),
@@ -195,34 +193,34 @@ test_that("list-valued outputPaths assign per-scenario named vectors", {
   suppressMessages(createScenariosFromPKML(
     c(pkmlFixture, pkmlFixture),
     project = project,
-    scenarioNames = c("A", "B"),
+    scenarios = c("a", "b"),
     outputPaths = list(
       c(p1 = "Organism|A|Conc"),
       c(p2 = "Organism|B|Conc")
     )
   ))
 
-  expect_named(project$scenarios[["A"]]$outputPaths, "p1")
-  expect_named(project$scenarios[["B"]]$outputPaths, "p2")
+  expect_named(project$scenarios[["a"]]$outputPaths, "p1")
+  expect_named(project$scenarios[["b"]]$outputPaths, "p2")
 })
 
 # createScenariosFromPKML: model parameter sets ----
 
-test_that("comma-separated modelParameterSets are split and FK-validated", {
+test_that("comma-separated parameterSets are split and FK-validated", {
   project <- testProject()
   suppressMessages(createScenariosFromPKML(
     pkmlFixture,
     project = project,
-    scenarioNames = "Seeded",
-    modelParameterSets = "Global, Aciclovir"
+    scenarios = "seeded",
+    parameterSets = "global, aciclovir"
   ))
   expect_identical(
-    project$scenarios[["Seeded"]]$modelParameterSets,
-    c("Global", "Aciclovir")
+    project$scenarios[["seeded"]]$modelParameterSets,
+    c("global", "aciclovir")
   )
 })
 
-test_that("unknown modelParameterSets abort and leave the project unchanged", {
+test_that("unknown parameterSets abort and leave the project unchanged", {
   project <- testProject()
   scenariosBefore <- names(project$scenarios)
   expect_snapshot(
@@ -230,8 +228,8 @@ test_that("unknown modelParameterSets abort and leave the project unchanged", {
     createScenariosFromPKML(
       pkmlFixture,
       project = project,
-      scenarioNames = "Seeded",
-      modelParameterSets = "DoesNotExist"
+      scenarios = "seeded",
+      parameterSets = "DoesNotExist"
     )
   )
   expect_identical(names(project$scenarios), scenariosBefore)
@@ -244,36 +242,38 @@ test_that("applicationProtocol defaults to NA and the seeded scenario passes val
   suppressMessages(createScenariosFromPKML(
     pkmlFixture,
     project = project,
-    scenarioNames = "Seeded"
+    scenarios = "seeded"
   ))
-  expect_true(is.na(project$scenarios[["Seeded"]]$applicationProtocol))
+  expect_true(is.na(project$scenarios[["seeded"]]$applicationProtocol))
   expect_false(isAnyCriticalErrors(validateProject(project)))
 })
 
-test_that("user applicationProtocols are taken verbatim without Excel sanitization", {
+test_that("a user application is taken verbatim without Excel sanitization", {
   project <- testProject()
-  longProtocol <- "Aciclovir_iv_250mg"
+  # A canonical (already-lowercase) protocol id is taken as-is: no warning,
+  # no Excel-specific mangling beyond id canonicalization.
+  longProtocol <- "aciclovir_iv_250mg"
   expect_no_warning(suppressMessages(createScenariosFromPKML(
     pkmlFixture,
     project = project,
-    scenarioNames = "Seeded",
-    applicationProtocols = longProtocol
+    scenarios = "seeded",
+    application = longProtocol
   )))
   expect_identical(
-    project$scenarios[["Seeded"]]$applicationProtocol,
+    project$scenarios[["seeded"]]$applicationProtocol,
     longProtocol
   )
 })
 
-test_that("unknown applicationProtocols abort", {
+test_that("an unknown application aborts", {
   project <- testProject()
   expect_snapshot(
     error = TRUE,
     createScenariosFromPKML(
       pkmlFixture,
       project = project,
-      scenarioNames = "Seeded",
-      applicationProtocols = "NoSuchProtocol"
+      scenarios = "seeded",
+      application = "NoSuchProtocol"
     )
   )
 })
@@ -287,10 +287,10 @@ test_that("duplicate scenario names are expanded with numeric suffixes", {
     createScenariosFromPKML(
       c(pkmlFixture, pkmlFixture),
       project = project,
-      scenarioNames = c("S", "S")
+      scenarios = c("s", "s")
     )
   )
-  expect_true(all(c("S", "S_2") %in% names(project$scenarios)))
+  expect_true(all(c("s", "s_2") %in% names(project$scenarios)))
 })
 
 test_that("duplicate-name expansion respects explicit later names", {
@@ -299,9 +299,9 @@ test_that("duplicate-name expansion respects explicit later names", {
   suppressWarnings(suppressMessages(createScenariosFromPKML(
     rep(pkmlFixture, 3),
     project = project,
-    scenarioNames = c("S", "S", "S_2")
+    scenarios = c("s", "s", "s_2")
   )))
-  expect_true(all(c("S", "S_2", "S_2_2") %in% names(project$scenarios)))
+  expect_true(all(c("s", "s_2", "s_2_2") %in% names(project$scenarios)))
 })
 
 test_that("scenario names colliding with pre-existing project scenarios are suffixed", {
@@ -309,19 +309,19 @@ test_that("scenario names colliding with pre-existing project scenarios are suff
   suppressWarnings(suppressMessages(createScenariosFromPKML(
     pkmlFixture,
     project = project,
-    scenarioNames = "TestScenario"
+    scenarios = "testscenario"
   )))
-  expect_true("TestScenario_2" %in% names(project$scenarios))
+  expect_true("testscenario_2" %in% names(project$scenarios))
 })
 
-test_that("scenarioNames = NULL derives names from the simulation and dedupes a recycled PKML", {
+test_that("scenarios = NULL derives names from the simulation and dedupes a recycled PKML", {
   project <- .fakeProject()
   project$modelFolder <- dirname(pkmlFixture)
   suppressWarnings(suppressMessages(createScenariosFromPKML(
     pkmlFixture,
     project = project,
-    individualId = NULL,
-    populationId = NULL,
+    individual = NULL,
+    population = NULL,
     simulationTime = c("0, 1, 1", "0, 2, 1", "0, 3, 1")
   )))
   # Three scenarios from one recycled PKML, names deduped off the sim name.
@@ -336,9 +336,9 @@ test_that("simulation time and unit are extracted from the PKML output schema", 
   suppressMessages(createScenariosFromPKML(
     pkmlFixture,
     project = project,
-    scenarioNames = "Seeded"
+    scenarios = "seeded"
   ))
-  sc <- project$scenarios[["Seeded"]]
+  sc <- project$scenarios[["seeded"]]
   expect_false(is.null(sc$simulationTime))
   expect_false(is.null(sc$simulationTimeUnit))
 })
@@ -348,11 +348,11 @@ test_that("user simulationTime overrides PKML extraction", {
   suppressMessages(createScenariosFromPKML(
     pkmlFixture,
     project = project,
-    scenarioNames = "Seeded",
+    scenarios = "seeded",
     simulationTime = "0, 24, 60",
     simulationTimeUnit = "h"
   ))
-  sc <- project$scenarios[["Seeded"]]
+  sc <- project$scenarios[["seeded"]]
   expect_identical(sc$simulationTimeUnit, "h")
   expect_identical(sc$simulationTime, list(c(0, 24, 60)))
 })
@@ -364,10 +364,10 @@ test_that("a user simulationTimeUnit is recorded on the extracted scenario", {
   suppressMessages(createScenariosFromPKML(
     pkmlFixture,
     project = project,
-    scenarioNames = "Seeded",
+    scenarios = "seeded",
     simulationTimeUnit = "min"
   ))
-  expect_identical(project$scenarios[["Seeded"]]$simulationTimeUnit, "min")
+  expect_identical(project$scenarios[["seeded"]]$simulationTimeUnit, "min")
 })
 
 # createScenariosFromPKML: steady state ----
@@ -377,12 +377,12 @@ test_that("steadyState = TRUE seeds a base-unit steadyStateTime and a unit", {
   suppressMessages(createScenariosFromPKML(
     pkmlFixture,
     project = project,
-    scenarioNames = "SS",
+    scenarios = "ss",
     steadyState = TRUE,
     steadyStateTime = 10,
     steadyStateTimeUnit = "h"
   ))
-  sc <- project$scenarios[["SS"]]
+  sc <- project$scenarios[["ss"]]
   expect_true(sc$simulateSteadyState)
   # 10 h stored in base units (minutes).
   expect_equal(sc$steadyStateTime, 600)
@@ -394,10 +394,10 @@ test_that("steadyState defaults to 1000 min when no time is supplied", {
   suppressMessages(createScenariosFromPKML(
     pkmlFixture,
     project = project,
-    scenarioNames = "SS",
+    scenarios = "ss",
     steadyState = TRUE
   ))
-  sc <- project$scenarios[["SS"]]
+  sc <- project$scenarios[["ss"]]
   expect_equal(sc$steadyStateTime, 1000)
   expect_identical(sc$steadyStateTimeUnit, "min")
 })
@@ -405,10 +405,10 @@ test_that("steadyState defaults to 1000 min when no time is supplied", {
 test_that("seeded scenarios match addScenario-created scenarios field for field", {
   fromPkml <- testProject()
   suppressMessages(createScenariosFromPKML(
-    pkmlFixture,
+    file.path(fromPkml$modelFolder, "Aciclovir.pkml"),
     project = fromPkml,
-    scenarioNames = "Seeded",
-    outputPaths = c(Aciclovir_PVB = fromPkml$outputPaths[["Aciclovir_PVB"]]),
+    scenarios = "seeded",
+    outputPaths = c(aciclovir_pvb = fromPkml$outputPaths[["aciclovir_pvb"]]),
     simulationTime = "0, 24, 60",
     simulationTimeUnit = "h"
   ))
@@ -416,16 +416,16 @@ test_that("seeded scenarios match addScenario-created scenarios field for field"
   viaAdd <- testProject()
   addScenario(
     viaAdd,
-    scenarioName = "Seeded",
+    id = "seeded",
     modelFile = "Aciclovir.pkml",
-    outputPathIds = "Aciclovir_PVB",
+    outputPaths = "aciclovir_pvb",
     simulationTime = "0, 24, 60",
     simulationTimeUnit = "h"
   )
 
   expect_equal(
-    fromPkml$scenarios[["Seeded"]],
-    viaAdd$scenarios[["Seeded"]]
+    fromPkml$scenarios[["seeded"]],
+    viaAdd$scenarios[["seeded"]]
   )
 })
 
@@ -434,11 +434,11 @@ test_that("seeded scenarios match addScenario-created scenarios field for field"
 test_that("modelFile is stored relative to project$modelFolder as a plain character", {
   project <- testProject()
   suppressMessages(createScenariosFromPKML(
-    pkmlFixture,
+    file.path(project$modelFolder, "Aciclovir.pkml"),
     project = project,
-    scenarioNames = "Seeded"
+    scenarios = "seeded"
   ))
-  sc <- project$scenarios[["Seeded"]]
+  sc <- project$scenarios[["seeded"]]
   expect_identical(sc$modelFile, "Aciclovir.pkml")
   expect_type(sc$modelFile, "character")
 })
@@ -450,10 +450,10 @@ test_that("NULL modelFolder falls back to the absolute pkml path with a warning"
     suppressMessages(createScenariosFromPKML(
       pkmlFixture,
       project = project,
-      scenarioNames = "Seeded"
+      scenarios = "seeded"
     ))
   )
-  sc <- project$scenarios[["Seeded"]]
+  sc <- project$scenarios[["seeded"]]
   expect_true(fs::is_absolute_path(sc$modelFile))
 })
 
@@ -466,37 +466,35 @@ test_that("inconsistent vector argument lengths abort", {
     createScenariosFromPKML(
       rep(pkmlFixture, 2),
       project = project,
-      scenarioNames = c("A", "B", "C")
+      scenarios = c("A", "B", "C")
     )
   )
 })
 
 test_that("a failing addScenario rolls back scenarios and outputPaths", {
   project <- .fakeProject(
-    modelParameterSets = list(Global = list())
+    parameterSets = list(global = list())
   )
   project$modelFolder <- dirname(pkmlFixture)
   scenariosBefore <- names(project$scenarios)
   outputsBefore <- names(project$outputPaths)
-  modifiedBefore <- project$modified
 
   expect_error(
     suppressMessages(createScenariosFromPKML(
       rep(pkmlFixture, 2),
       project = project,
-      scenarioNames = c("Ok", "Bad"),
-      modelParameterSets = c("Global", "DoesNotExist")
+      scenarios = c("Ok", "Bad"),
+      parameterSets = c("Global", "DoesNotExist")
     ))
   )
 
   expect_identical(names(project$scenarios), scenariosBefore)
   expect_identical(names(project$outputPaths), outputsBefore)
-  expect_identical(project$modified, modifiedBefore)
 })
 
 test_that("a failing addScenario rollback preserves validatedSinceMutation", {
   project <- .fakeProject(
-    modelParameterSets = list(Global = list())
+    parameterSets = list(global = list())
   )
   project$modelFolder <- dirname(pkmlFixture)
   project$.markValidated()
@@ -505,60 +503,89 @@ test_that("a failing addScenario rollback preserves validatedSinceMutation", {
     suppressMessages(createScenariosFromPKML(
       rep(pkmlFixture, 2),
       project = project,
-      scenarioNames = c("Ok", "Bad"),
-      modelParameterSets = c("Global", "DoesNotExist")
+      scenarios = c("Ok", "Bad"),
+      parameterSets = c("Global", "DoesNotExist")
     ))
   )
 
   expect_true(project$validatedSinceMutation)
 })
 
+test_that("a failing addScenario rolls back the on-disk scenario tree", {
+  # The in-memory rollback tests use `.fakeProject()` (no directory), so the
+  # branch that writes the restored section back to disk is never hit. Use a
+  # real on-disk project so the rollback materializes to `definitions/scenarios`.
+  project <- testProject()
+  project$modelFolder <- dirname(pkmlFixture)
+  scenariosDir <- file.path(
+    project$projectDirPath,
+    project$definitionsFolder,
+    "scenarios"
+  )
+  filesBefore <- sort(list.files(scenariosDir))
+
+  expect_error(
+    suppressMessages(createScenariosFromPKML(
+      rep(pkmlFixture, 2),
+      project = project,
+      scenarios = c("Ok", "Bad"),
+      parameterSets = c("global", "doesnotexist")
+    ))
+  )
+
+  # The successful first scenario must not survive on disk.
+  expect_identical(sort(list.files(scenariosDir)), filesBefore)
+  reloaded <- loadProject(project$projectFilePath)
+  expect_named(
+    reloaded$scenarios,
+    names(project$scenarios),
+    ignore.order = TRUE
+  )
+  expect_false("ok" %in% names(reloaded$scenarios))
+})
+
 # createScenariosFromPKML: end-to-end round trips ----
 
-test_that("end-to-end: seed from PKML, saveProject, loadProject round-trips", {
+test_that("end-to-end: seed from PKML, snapshot, loadProject round-trips", {
   project <- testProject()
   suppressMessages(createScenariosFromPKML(
     pkmlFixture,
     project = project,
-    scenarioNames = "Seeded"
+    scenarios = "seeded"
   ))
 
-  dir <- withr::local_tempdir()
-  path <- file.path(dir, "Project.json")
-  saveProject(project, path)
+  path <- saveSnapshot(project, local_projectPath())
   reloaded <- loadProject(path)
 
   expect_equal(
-    reloaded$scenarios[["Seeded"]],
-    project$scenarios[["Seeded"]]
+    reloaded$scenarios[["seeded"]],
+    project$scenarios[["seeded"]]
   )
   expect_equal(reloaded$outputPaths, project$outputPaths)
 })
 
-test_that("end-to-end: steadyState = TRUE round-trips through save and load", {
+test_that("end-to-end: steadyState = TRUE round-trips through snapshot and load", {
   project <- testProject()
   suppressMessages(createScenariosFromPKML(
     pkmlFixture,
     project = project,
-    scenarioNames = "SS",
+    scenarios = "ss",
     steadyState = TRUE,
     steadyStateTime = 10,
     steadyStateTimeUnit = "h"
   ))
 
-  dir <- withr::local_tempdir()
-  path <- file.path(dir, "Project.json")
-  saveProject(project, path)
+  path <- saveSnapshot(project, local_projectPath())
   reloaded <- loadProject(path)
 
-  expect_equal(reloaded$scenarios[["SS"]], project$scenarios[["SS"]])
+  expect_equal(reloaded$scenarios[["ss"]], project$scenarios[["ss"]])
 })
 
 # Internal helpers ----
 
 test_that(".dedupeScenarioNames probes suffixes against project and call names", {
-  out <- suppressWarnings(.dedupeScenarioNames(c("S", "S", "S_2"), character()))
-  expect_identical(out, c("S", "S_2", "S_2_2"))
+  out <- suppressWarnings(.dedupeScenarioNames(c("s", "s", "s_2"), character()))
+  expect_identical(out, c("s", "s_2", "s_2_2"))
 
   expect_warning(
     .dedupeScenarioNames("TestScenario", "TestScenario"),
@@ -613,19 +640,20 @@ test_that(".extractSimulationTimeFromPkml returns NULLs when the schema has no i
 })
 
 test_that(".generateOutputPathId builds readable ids from the last two segments", {
+  # Generated ids are canonical (lowercase) so addOutputPath() does not warn.
   expect_identical(
     .generateOutputPathId(
       "Organism|Fat|Intracellular|Aciclovir|Concentration in container",
       character()
     ),
-    "Aciclovir_Concentration_in_container"
+    "aciclovir_concentration_in_container"
   )
   expect_identical(
     .generateOutputPathId(
       "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)",
-      "Aciclovir_Plasma_Peripheral_Venous_Blood"
+      "aciclovir_plasma_peripheral_venous_blood"
     ),
-    "Aciclovir_Plasma_Peripheral_Venous_Blood_2"
+    "aciclovir_plasma_peripheral_venous_blood_2"
   )
 })
 

--- a/tests/testthat/test-scenarios.R
+++ b/tests/testthat/test-scenarios.R
@@ -44,7 +44,8 @@ test_that("as.list(Scenario()) exposes exactly the v2.0 schema fields", {
       "steadyStateTime",
       "steadyStateTimeUnit",
       "overwriteFormulasInSS",
-      "modelParameterSets"
+      "modelParameterSets",
+      "initialConditions"
     )
   )
 })
@@ -81,24 +82,60 @@ test_that(".parseScenarios returns list() for NULL input", {
 
 test_that(".parseScenarios copies basic fields for an individual scenario", {
   project <- exampleProject()
-  sc <- project$scenarios[["Aciclovir_iv"]]
+  sc <- project$scenarios[["aciclovir_iv"]]
 
   expect_s3_class(sc, "Scenario")
-  expect_identical(sc$scenarioName, "Aciclovir_iv")
+  expect_identical(sc$scenarioName, "aciclovir_iv")
   expect_identical(sc$modelFile, "Aciclovir.pkml")
-  expect_identical(sc$individualId, "Adult_male")
-  expect_identical(sc$applicationProtocol, "Aciclovir_iv_250mg")
-  expect_identical(sc$modelParameterSets, c("Global", "Aciclovir"))
+  expect_identical(sc$individualId, "adult_male")
+  expect_identical(sc$applicationProtocol, "aciclovir_iv_250mg")
+  expect_identical(sc$modelParameterSets, c("global", "aciclovir"))
   expect_null(sc$populationId)
   expect_identical(sc$simulationType, "Individual")
   expect_false(sc$readPopulationFromCSV)
 })
 
+test_that(".parseScenarios reads a scenario's initialConditions references", {
+  raw <- list(list(
+    name = "WithIC",
+    modelFile = "m.pkml",
+    parameterSets = list("ps1"),
+    initialConditions = list("ic1", "ic2")
+  ))
+  sc <- esqlabsR:::.parseScenarios(raw, list())[["WithIC"]]
+  expect_identical(sc$initialConditions, c("ic1", "ic2"))
+})
+
+test_that(".parseScenarios leaves initialConditions NULL when JSON omits it", {
+  raw <- list(list(name = "NoIC", modelFile = "m.pkml"))
+  sc <- esqlabsR:::.parseScenarios(raw, list())[["NoIC"]]
+  expect_null(sc$initialConditions)
+})
+
+test_that("a scenario's initialConditions round-trips through serialize/parse", {
+  sc <- Scenario(
+    scenarioName = "RT",
+    modelFile = "m.pkml",
+    initialConditions = c("ic1", "ic2")
+  )
+  json <- esqlabsR:::.scenarioToJson(sc, outputPaths = list())
+  expect_identical(json$initialConditions, list("ic1", "ic2"))
+
+  reparsed <- esqlabsR:::.parseScenarios(
+    list(stats::setNames(
+      list(json$name, json$modelFile, json$initialConditions),
+      c("name", "modelFile", "initialConditions")
+    )),
+    list()
+  )[["RT"]]
+  expect_identical(reparsed$initialConditions, c("ic1", "ic2"))
+})
+
 test_that(".parseScenarios sets simulationType=Population when populationId present", {
   project <- exampleProject()
-  sc <- project$scenarios[["Aciclovir_iv_population"]]
+  sc <- project$scenarios[["aciclovir_iv_population"]]
 
-  expect_identical(sc$populationId, "European_adults")
+  expect_identical(sc$populationId, "european_adults")
   expect_identical(sc$simulationType, "Population")
 })
 
@@ -106,9 +143,9 @@ test_that(".parseScenarios defaults applicationProtocol to NA when JSON has null
   raw <- list(
     list(
       name = "X",
-      individualId = "i",
+      individual = "i",
       modelFile = "m.pkml",
-      applicationProtocol = NULL
+      application = NULL
     )
   )
   result <- esqlabsR:::.parseScenarios(raw, list())
@@ -119,7 +156,7 @@ test_that(".parseScenarios defaults applicationProtocol to NA when JSON has null
 
 test_that(".parseScenarios converts steadyStateTime to base units (minutes)", {
   project <- exampleProject()
-  sc <- project$scenarios[["Aciclovir_iv_steadystate"]]
+  sc <- project$scenarios[["aciclovir_iv_steadystate"]]
 
   expect_true(sc$simulateSteadyState)
   # 1 hour -> 60 minutes
@@ -127,9 +164,29 @@ test_that(".parseScenarios converts steadyStateTime to base units (minutes)", {
   expect_identical(sc$steadyStateTimeUnit, "h")
 })
 
+test_that(".parseScenarios coerces a whole-number steadyStateTime to double", {
+  # `jsonlite::fromJSON` reads a whole number as integer; a same-unit
+  # conversion preserves that type, so without an explicit coercion the parsed
+  # value would be integer while a freshly built scenario's default is double,
+  # breaking a byte-equivalent round trip.
+  raw <- list(
+    list(
+      name = "WholeSS",
+      individual = "i",
+      modelFile = "m.pkml",
+      steadyStateTime = 1000L,
+      steadyStateTimeUnit = "min"
+    )
+  )
+  sc <- esqlabsR:::.parseScenarios(raw, list())[["WholeSS"]]
+
+  expect_type(sc$steadyStateTime, "double")
+  expect_identical(sc$steadyStateTime, 1000)
+})
+
 test_that(".parseScenarios leaves simulateSteadyState=FALSE when JSON omits/sets false", {
   project <- exampleProject()
-  sc <- project$scenarios[["Aciclovir_iv"]]
+  sc <- project$scenarios[["aciclovir_iv"]]
 
   expect_false(sc$simulateSteadyState)
   expect_null(sc$steadyStateTimeUnit)
@@ -141,7 +198,7 @@ test_that(".parseScenarios errors when steadyStateTime set without unit", {
   raw <- list(
     list(
       name = "BadSS",
-      individualId = "i",
+      individual = "i",
       modelFile = "m.pkml",
       steadyStateTime = 5,
       steadyStateTimeUnit = NULL
@@ -155,7 +212,7 @@ test_that(".parseScenarios errors when steadyStateTime set without unit", {
 
 test_that(".parseScenarios parses simulationTime to a list of length-3 numerics", {
   project <- exampleProject()
-  sc <- project$scenarios[["Aciclovir_iv"]]
+  sc <- project$scenarios[["aciclovir_iv"]]
 
   expect_type(sc$simulationTime, "list")
   expect_length(sc$simulationTime, 1L)
@@ -163,14 +220,14 @@ test_that(".parseScenarios parses simulationTime to a list of length-3 numerics"
   expect_identical(sc$simulationTimeUnit, "h")
 })
 
-test_that(".parseScenarios resolves outputPathIds to literal outputPaths in declared order", {
+test_that(".parseScenarios resolves outputPaths ids to literal outputPaths in declared order", {
   project <- exampleProject()
-  sc <- project$scenarios[["Aciclovir_iv_steadystate"]]
+  sc <- project$scenarios[["aciclovir_iv_steadystate"]]
 
   expect_type(sc$outputPaths, "character")
   expect_length(sc$outputPaths, 2L)
   # Names are the ids, values are the literal paths; order follows JSON declaration.
-  expect_named(sc$outputPaths, c("Aciclovir_fat_cell", "Aciclovir_PVB"))
+  expect_named(sc$outputPaths, c("aciclovir_fat_cell", "aciclovir_pvb"))
   expect_identical(
     unname(sc$outputPaths),
     c(
@@ -180,41 +237,66 @@ test_that(".parseScenarios resolves outputPathIds to literal outputPaths in decl
   )
 })
 
-test_that(".parseScenarios single outputPathId resolves to a length-1 named character vector", {
+test_that(".parseScenarios single outputPaths id resolves to a length-1 named character vector", {
   project <- exampleProject()
-  sc <- project$scenarios[["Aciclovir_iv"]]
+  sc <- project$scenarios[["aciclovir_iv"]]
 
   expect_type(sc$outputPaths, "character")
   expect_length(sc$outputPaths, 1L)
-  expect_named(sc$outputPaths, "Aciclovir_PVB")
+  expect_named(sc$outputPaths, "aciclovir_pvb")
   expect_identical(
     unname(sc$outputPaths),
     "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)"
   )
 })
 
-test_that(".parseScenarios errors on unknown outputPathIds with the scenario name", {
+test_that(".parseScenarios keeps unknown outputPaths ids as dangling refs (lazy)", {
+  # Referential integrity is lazy: an unknown output-path id does not abort
+  # the parse; it survives as a name with an NA literal path so the
+  # cross-reference validator can flag it later.
   raw <- list(
     list(
       name = "BadRefs",
-      individualId = "i",
+      individual = "i",
       modelFile = "m.pkml",
-      outputPathIds = list("Aciclovir_PVB", "Nope", "AlsoNope")
+      outputPaths = list("Aciclovir_PVB", "Nope", "AlsoNope")
     )
   )
   outputPaths <- list(Aciclovir_PVB = "Organism|PVB|...")
 
-  expect_error(
-    esqlabsR:::.parseScenarios(raw, outputPaths),
-    "BadRefs.*Nope.*AlsoNope"
+  sc <- esqlabsR:::.parseScenarios(raw, outputPaths)[["BadRefs"]]
+  expect_named(sc$outputPaths, c("Aciclovir_PVB", "Nope", "AlsoNope"))
+  expect_identical(
+    unname(sc$outputPaths[["Aciclovir_PVB"]]),
+    "Organism|PVB|..."
   )
+  expect_true(is.na(sc$outputPaths[["Nope"]]))
+  expect_true(is.na(sc$outputPaths[["AlsoNope"]]))
 })
 
-test_that(".parseScenarios leaves outputPaths NULL when JSON omits outputPathIds", {
+test_that(".parseScenarios collapses duplicate outputPaths ids to one (first-seen order)", {
+  # A repeated id is redundant, not an error: it must resolve to a single
+  # entry so the path is never run or plotted twice, keeping first-seen order.
+  raw <- list(
+    list(
+      name = "Dups",
+      individual = "i",
+      modelFile = "m.pkml",
+      outputPaths = list("a", "a", "b", "a")
+    )
+  )
+  outputPaths <- list(a = "PATH_A", b = "PATH_B")
+
+  sc <- esqlabsR:::.parseScenarios(raw, outputPaths)[["Dups"]]
+  expect_named(sc$outputPaths, c("a", "b"))
+  expect_identical(unname(sc$outputPaths), c("PATH_A", "PATH_B"))
+})
+
+test_that(".parseScenarios leaves outputPaths NULL when JSON omits outputPaths", {
   raw <- list(
     list(
       name = "NoOutputs",
-      individualId = "i",
+      individual = "i",
       modelFile = "m.pkml"
     )
   )
@@ -223,16 +305,62 @@ test_that(".parseScenarios leaves outputPaths NULL when JSON omits outputPathIds
   expect_null(result[["NoOutputs"]]$outputPaths)
 })
 
-test_that("addScenario aborts when a referenced individualId is unknown", {
+test_that("addScenario aborts when a referenced individual is unknown", {
   project <- testProject()
   expect_snapshot(
     error = TRUE,
     addScenario(
       project,
-      scenarioName = "Bad",
+      id = "bad",
       modelFile = "Aciclovir.pkml",
-      individualId = "Ghost"
+      individual = "Ghost"
     )
+  )
+})
+
+test_that("addScenario accepts a valid initialConditions reference", {
+  project <- testProject()
+  addInitialConditions(project, "icset")
+  addScenario(
+    project,
+    id = "withic",
+    modelFile = "Aciclovir.pkml",
+    initialConditions = "icset"
+  )
+  expect_identical(project$scenarios[["withic"]]$initialConditions, "icset")
+})
+
+test_that("addScenario aborts eagerly on a dangling initialConditions ref", {
+  project <- testProject()
+  expect_snapshot(
+    error = TRUE,
+    addScenario(
+      project,
+      id = "bad",
+      modelFile = "Aciclovir.pkml",
+      initialConditions = "ghostset"
+    )
+  )
+})
+
+test_that("setScenario updates and clears the initialConditions reference", {
+  project <- testProject()
+  addInitialConditions(project, "icset")
+  addScenario(project, id = "sc", modelFile = "Aciclovir.pkml")
+
+  setScenario(project, "sc", initialConditions = "icset")
+  expect_identical(project$scenarios[["sc"]]$initialConditions, "icset")
+
+  setScenario(project, "sc", initialConditions = NULL)
+  expect_null(project$scenarios[["sc"]]$initialConditions)
+})
+
+test_that("setScenario aborts eagerly on a dangling initialConditions ref", {
+  project <- testProject()
+  addScenario(project, id = "sc", modelFile = "Aciclovir.pkml")
+  expect_snapshot(
+    error = TRUE,
+    setScenario(project, "sc", initialConditions = "ghostset")
   )
 })
 
@@ -242,74 +370,490 @@ test_that("addScenario rejects NA-valued FK args", {
     error = TRUE,
     addScenario(
       project,
-      scenarioName = "S",
+      id = "S",
       modelFile = "Aciclovir.pkml",
-      individualId = NA_character_
+      individual = NA_character_
     )
   )
   expect_snapshot(
     error = TRUE,
     addScenario(
       project,
-      scenarioName = "S",
+      id = "S",
       modelFile = "Aciclovir.pkml",
-      outputPathIds = c("Output1", NA_character_)
+      outputPaths = c("Output1", NA_character_)
     )
   )
 })
 
-test_that("removeScenario uses scenarioName argument matching addScenario", {
+test_that("addScenario collapses duplicate outputPaths to one (first-seen order)", {
   project <- testProject()
   addScenario(
     project,
-    scenarioName = "ToRemove",
-    modelFile = "Aciclovir.pkml"
+    id = "dupout",
+    modelFile = "Aciclovir.pkml",
+    outputPaths = c("aciclovir_pvb", "aciclovir_pvb", "aciclovir_fat_cell")
   )
-  expect_true("ToRemove" %in% names(project$scenarios))
-  removeScenario(project, scenarioName = "ToRemove")
-  expect_false("ToRemove" %in% names(project$scenarios))
+  sc <- project$scenarios[["dupout"]]
+  expect_named(sc$outputPaths, c("aciclovir_pvb", "aciclovir_fat_cell"))
 })
 
-test_that("addScenario and removeScenario mark the project modified", {
+test_that("setScenario collapses duplicate outputPaths to one (first-seen order)", {
+  project <- testProject()
+  setScenario(
+    project,
+    "testscenario",
+    outputPaths = c(
+      "aciclovir_fat_cell",
+      "aciclovir_pvb",
+      "aciclovir_fat_cell"
+    )
+  )
+  sc <- project$scenarios[["testscenario"]]
+  expect_named(sc$outputPaths, c("aciclovir_fat_cell", "aciclovir_pvb"))
+})
+
+test_that("removeScenario uses the id argument matching addScenario", {
+  project <- testProject()
+  addScenario(
+    project,
+    id = "toremove",
+    modelFile = "Aciclovir.pkml"
+  )
+  expect_true("toremove" %in% names(project$scenarios))
+  removeScenario(project, id = "toremove")
+  expect_false("toremove" %in% names(project$scenarios))
+})
+
+test_that("addScenario and removeScenario clear the validation cache", {
   project <- testProject()
   project$.markValidated()
-  expect_false(project$modified)
+  expect_true(project$validatedSinceMutation)
 
-  addScenario(project, scenarioName = "X", modelFile = "Aciclovir.pkml")
-  expect_true(project$modified)
+  addScenario(project, id = "x", modelFile = "Aciclovir.pkml")
+  expect_false(project$validatedSinceMutation)
 
   project$.markValidated()
-  removeScenario(project, scenarioName = "X")
-  expect_true(project$modified)
+  removeScenario(project, id = "x")
+  expect_false(project$validatedSinceMutation)
 })
 
 test_that("addScenario stores steadyStateTime in base units and round-trips the declared unit", {
   project <- testProject()
   addScenario(
     project,
-    scenarioName = "SS",
+    id = "ss",
     modelFile = "Aciclovir.pkml",
-    individualId = "Indiv1",
+    individual = "indiv1",
     steadyState = TRUE,
     steadyStateTime = 10,
     steadyStateTimeUnit = "h"
   )
 
   # Stored value is the base unit (minutes): 10 h -> 600 min.
-  expect_equal(project$scenarios[["SS"]]$steadyStateTime, 600)
-  expect_equal(project$scenarios[["SS"]]$steadyStateTimeUnit, "h")
+  expect_equal(project$scenarios[["ss"]]$steadyStateTime, 600)
+  expect_equal(project$scenarios[["ss"]]$steadyStateTimeUnit, "h")
 
   # Saved JSON carries the declared 10 / "h" (the serializer converts the
   # base-unit value back to the declared unit).
   out <- withr::local_tempfile(fileext = ".json")
   esqlabsR:::.saveProjectJson(project, out)
   raw <- jsonlite::fromJSON(out, simplifyVector = FALSE)
-  savedSS <- Filter(\(s) identical(s[["name"]], "SS"), raw$scenarios)[[1]]
+  savedSS <- Filter(\(s) identical(s[["name"]], "ss"), raw$scenarios)[[1]]
   expect_equal(savedSS$steadyStateTime, 10)
   expect_equal(savedSS$steadyStateTimeUnit, "h")
 
   # Reload round-trips back to the base-unit value.
   reloaded <- loadProject(out)
-  expect_equal(reloaded$scenarios[["SS"]]$steadyStateTime, 600)
-  expect_equal(reloaded$scenarios[["SS"]]$steadyStateTimeUnit, "h")
+  expect_equal(reloaded$scenarios[["ss"]]$steadyStateTime, 600)
+  expect_equal(reloaded$scenarios[["ss"]]$steadyStateTimeUnit, "h")
+})
+
+# setScenario ----
+
+test_that("setScenario changes a field and persists to file and memory", {
+  project <- testProject()
+  dir <- file.path(project$projectDirPath, "definitions", "scenarios")
+
+  setScenario(project, "testscenario", simulationTime = "0, 48, 120")
+
+  expect_equal(
+    project$scenarios[["testscenario"]]$simulationTime,
+    list(c(0, 48, 120))
+  )
+  reloaded <- loadProject(project$jsonPath)
+  expect_equal(
+    reloaded$scenarios[["testscenario"]]$simulationTime,
+    list(c(0, 48, 120))
+  )
+  expect_true(file.exists(file.path(dir, "testscenario.json")))
+})
+
+test_that("setScenario partial update leaves other fields untouched", {
+  project <- testProject()
+  before <- project$scenarios[["testscenario"]]
+
+  setScenario(project, "testscenario", simulationTimeUnit = "min")
+  after <- project$scenarios[["testscenario"]]
+
+  expect_equal(after$simulationTimeUnit, "min")
+  # Every other field is unchanged.
+  for (f in setdiff(names(before), "simulationTimeUnit")) {
+    expect_equal(after[[f]], before[[f]])
+  }
+})
+
+test_that("setScenario invalidates the validation cache", {
+  project <- testProject()
+  project$.markValidated()
+  expect_true(project$validatedSinceMutation)
+
+  setScenario(project, "testscenario", simulationTimeUnit = "min")
+
+  expect_false(project$validatedSinceMutation)
+})
+
+test_that("setScenario can clear an optional field with NULL", {
+  project <- testProject()
+  expect_false(is.null(project$scenarios[["populationscenario"]]$individualId))
+
+  setScenario(project, "populationscenario", individual = NULL)
+
+  expect_null(project$scenarios[["populationscenario"]]$individualId)
+  reloaded <- loadProject(project$jsonPath)
+  expect_null(reloaded$scenarios[["populationscenario"]]$individualId)
+})
+
+test_that("setScenario aborts on a non-existent scenario, no file written", {
+  project <- testProject()
+  dir <- file.path(project$projectDirPath, "definitions", "scenarios")
+  before <- list.files(dir)
+
+  expect_snapshot(
+    error = TRUE,
+    setScenario(project, "Ghost", simulationTimeUnit = "min")
+  )
+  expect_setequal(list.files(dir), before)
+})
+
+test_that("setScenario fails fast on a structural violation, disk and memory untouched", {
+  project <- testProject()
+  dir <- file.path(project$projectDirPath, "definitions", "scenarios")
+  before <- project$scenarios[["testscenario"]]
+  beforeFile <- readLines(file.path(dir, "testscenario.json"))
+
+  # Clearing modelFile is a structural violation; the write-through must abort.
+  expect_error(
+    setScenario(project, "testscenario", modelFile = NULL),
+    "modelFile"
+  )
+  # Neither memory nor disk changed.
+  expect_equal(project$scenarios[["testscenario"]], before)
+  expect_identical(readLines(file.path(dir, "testscenario.json")), beforeFile)
+})
+
+test_that("setScenario rejects an unknown foreign key like addScenario", {
+  project <- testProject()
+  expect_snapshot(
+    error = TRUE,
+    setScenario(project, "testscenario", individual = "Ghost")
+  )
+})
+
+test_that("the write path allows a dangling outputPathId as a lazy referential finding", {
+  project <- testProject()
+  # The authoring functions check references eagerly, but the lower-level
+  # write-through entry point (`.setSection()`) is structural-only: an unknown
+  # output-path id is allowed at write time (referential checks are lazy); it
+  # is the cross-reference validator that flags it later.
+  scenarios <- project$.getSection("scenarios")
+  sc <- scenarios[["testscenario"]]
+  sc$outputPaths <- c(sc$outputPaths, Ghost = NA_character_)
+  scenarios[["testscenario"]] <- sc
+  expect_no_error(project$.setSection("scenarios", scenarios))
+})
+
+test_that("setScenario on a clone leaves the source's on-disk tree untouched", {
+  source <- testProject()
+  dir <- file.path(source$projectDirPath, "definitions", "scenarios")
+  sourceFile <- readLines(file.path(dir, "testscenario.json"))
+
+  clone <- source$clone()
+  setScenario(clone, "testscenario", simulationTimeUnit = "min")
+
+  # The clone changed in memory only; the source's file is untouched.
+  expect_equal(clone$scenarios[["testscenario"]]$simulationTimeUnit, "min")
+  expect_identical(readLines(file.path(dir, "testscenario.json")), sourceFile)
+})
+
+# renameScenario ----
+
+test_that("renameScenario moves the entity file and changes the in-memory key", {
+  project <- testProject()
+  dir <- file.path(project$projectDirPath, "definitions", "scenarios")
+  before <- readLines(file.path(dir, "testscenario.json"))
+
+  renameScenario(project, "testscenario", "renamed")
+
+  # In-memory: old key gone, new key present.
+  expect_false("testscenario" %in% names(project$scenarios))
+  expect_true("renamed" %in% names(project$scenarios))
+  # On disk: old file removed, new file written.
+  expect_false(file.exists(file.path(dir, "testscenario.json")))
+  expect_true(file.exists(file.path(dir, "renamed.json")))
+
+  # Content is preserved up to the name field: the only difference between the
+  # old and new file is the line carrying the scenario name (now the new id).
+  after <- readLines(file.path(dir, "renamed.json"))
+  changed <- which(before != after)
+  expect_length(changed, 1L)
+  expect_match(before[changed], "testscenario")
+  expect_match(after[changed], "renamed")
+})
+
+test_that("renameScenario updates the record's stored name so a reload round-trips", {
+  project <- testProject()
+
+  renameScenario(project, "testscenario", "renamed")
+
+  expect_equal(project$scenarios[["renamed"]]$scenarioName, "renamed")
+  # A reload re-derives scenarios from the tree; the new key must validate and
+  # round-trip (name == key invariant holds).
+  reloaded <- loadProject(project$jsonPath)
+  expect_true("renamed" %in% names(reloaded$scenarios))
+  expect_equal(reloaded$scenarios[["renamed"]]$scenarioName, "renamed")
+  expect_no_error(validateProject(reloaded))
+})
+
+test_that("renameScenario errors clearly on a non-existent id", {
+  project <- testProject()
+  expect_snapshot(
+    error = TRUE,
+    renameScenario(project, "Ghost", "renamed")
+  )
+})
+
+test_that("renameScenario errors when the target id already exists", {
+  project <- testProject()
+  expect_snapshot(
+    error = TRUE,
+    renameScenario(project, "testscenario", "populationscenario")
+  )
+})
+
+test_that("renameScenario canonicalizes newId, warning and landing on the canonical form", {
+  project <- testProject()
+  expect_snapshot(
+    renameScenario(project, "testscenario", "New Name")
+  )
+  expect_true("new name" %in% names(project$scenarios))
+  expect_false("testscenario" %in% names(project$scenarios))
+})
+
+test_that("renameScenario on a clone leaves the source's on-disk tree untouched", {
+  source <- testProject()
+  dir <- file.path(source$projectDirPath, "definitions", "scenarios")
+  sourceFiles <- list.files(dir)
+
+  clone <- source$clone()
+  renameScenario(clone, "testscenario", "renamed")
+
+  # The clone changed in memory only; the source's tree is untouched.
+  expect_true("renamed" %in% names(clone$scenarios))
+  expect_setequal(list.files(dir), sourceFiles)
+})
+
+# duplicateScenario ----
+
+test_that("duplicateScenario creates an independent on-disk and in-memory copy", {
+  project <- testProject()
+  dir <- file.path(project$projectDirPath, "definitions", "scenarios")
+
+  duplicateScenario(project, "testscenario", "copy")
+
+  # Both exist in memory; the original is untouched.
+  expect_true(all(c("testscenario", "copy") %in% names(project$scenarios)))
+  expect_equal(project$scenarios[["copy"]]$scenarioName, "copy")
+  # The copy is a new entity file alongside the original.
+  expect_true(file.exists(file.path(dir, "testscenario.json")))
+  expect_true(file.exists(file.path(dir, "copy.json")))
+})
+
+test_that("duplicateScenario produces an independent copy: mutating it leaves the original", {
+  project <- testProject()
+  originalBefore <- project$scenarios[["testscenario"]]
+
+  duplicateScenario(project, "testscenario", "copy")
+  setScenario(project, "copy", simulationTimeUnit = "min")
+
+  expect_equal(project$scenarios[["copy"]]$simulationTimeUnit, "min")
+  # The original record (and its file) is unchanged.
+  expect_equal(project$scenarios[["testscenario"]], originalBefore)
+  reloaded <- loadProject(project$jsonPath)
+  expect_equal(
+    reloaded$scenarios[["testscenario"]]$simulationTimeUnit,
+    originalBefore$simulationTimeUnit
+  )
+})
+
+test_that("duplicateScenario errors on a non-existent source id", {
+  project <- testProject()
+  expect_snapshot(
+    error = TRUE,
+    duplicateScenario(project, "Ghost", "copy")
+  )
+})
+
+test_that("duplicateScenario errors when the target id already exists", {
+  project <- testProject()
+  expect_snapshot(
+    error = TRUE,
+    duplicateScenario(project, "testscenario", "populationscenario")
+  )
+})
+
+test_that("duplicateScenario on a clone leaves the source's on-disk tree untouched", {
+  source <- testProject()
+  dir <- file.path(source$projectDirPath, "definitions", "scenarios")
+  sourceFiles <- list.files(dir)
+
+  clone <- source$clone()
+  duplicateScenario(clone, "testscenario", "copy")
+
+  expect_true("copy" %in% names(clone$scenarios))
+  expect_setequal(list.files(dir), sourceFiles)
+})
+
+# Vectorized authoring ----
+
+test_that("addScenario adds N scenarios in one call equal to N scalar adds", {
+  vectorized <- testProject()
+  addScenario(
+    vectorized,
+    c("s1", "s2"),
+    modelFile = "Aciclovir.pkml",
+    individual = "indiv1",
+    outputPaths = "aciclovir_pvb"
+  )
+
+  scalar <- testProject()
+  addScenario(
+    scalar,
+    "s1",
+    modelFile = "Aciclovir.pkml",
+    individual = "indiv1",
+    outputPaths = "aciclovir_pvb"
+  )
+  addScenario(
+    scalar,
+    "s2",
+    modelFile = "Aciclovir.pkml",
+    individual = "indiv1",
+    outputPaths = "aciclovir_pvb"
+  )
+
+  expect_identical(
+    vectorized$scenarios[c("s1", "s2")],
+    scalar$scenarios[c("s1", "s2")]
+  )
+})
+
+test_that("removeScenario warns when a dataCombined still references it", {
+  project <- testProject()
+  addDataCombined(
+    project,
+    "dc_ref",
+    simulated = list(
+      list(
+        label = "ref",
+        scenario = "testscenario",
+        path = "Organism|A|Concentration"
+      )
+    )
+  )
+  expect_snapshot(removeScenario(project, "testscenario"))
+})
+
+test_that("addScenario recycles a scalar field and applies outputPaths whole", {
+  project <- testProject()
+  addScenario(
+    project,
+    c("s1", "s2"),
+    modelFile = "Aciclovir.pkml",
+    individual = c("indiv1", NULL),
+    outputPaths = c("aciclovir_pvb", "aciclovir_fat_cell")
+  )
+  expect_identical(project$scenarios$s1$modelFile, "Aciclovir.pkml")
+  expect_identical(project$scenarios$s2$modelFile, "Aciclovir.pkml")
+  # outputPaths applied whole to both scenarios.
+  expect_identical(
+    names(project$scenarios$s1$outputPaths),
+    c("aciclovir_pvb", "aciclovir_fat_cell")
+  )
+  expect_identical(
+    names(project$scenarios$s2$outputPaths),
+    c("aciclovir_pvb", "aciclovir_fat_cell")
+  )
+})
+
+test_that("addScenario persists all N to disk in one write-through", {
+  project <- testProject()
+  addScenario(project, c("s1", "s2"), modelFile = "Aciclovir.pkml")
+  reloaded <- loadProject(project$jsonPath)
+  expect_true(all(c("s1", "s2") %in% names(reloaded$scenarios)))
+})
+
+test_that("addScenario aborts the whole batch and writes nothing on a bad reference", {
+  project <- testProject()
+  before <- names(project$scenarios)
+  expect_error(
+    addScenario(
+      project,
+      c("s1", "s2"),
+      modelFile = "Aciclovir.pkml",
+      individual = c("indiv1", "ghost")
+    )
+  )
+  expect_identical(names(project$scenarios), before)
+  reloaded <- loadProject(project$jsonPath)
+  expect_identical(names(reloaded$scenarios), before)
+})
+
+test_that("addScenario aborts on a mismatched scalar field length", {
+  project <- testProject()
+  expect_snapshot(
+    error = TRUE,
+    addScenario(
+      project,
+      c("s1", "s2", "s3"),
+      modelFile = c("A.pkml", "B.pkml")
+    )
+  )
+})
+
+test_that("setScenario vectorizes a partial update across N ids", {
+  project <- testProject()
+  addScenario(project, c("s1", "s2"), modelFile = "Aciclovir.pkml")
+  setScenario(project, c("s1", "s2"), simulationTimeUnit = c("min", "s"))
+  expect_identical(project$scenarios$s1$simulationTimeUnit, "min")
+  expect_identical(project$scenarios$s2$simulationTimeUnit, "s")
+  expect_identical(project$scenarios$s1$modelFile, "Aciclovir.pkml")
+})
+
+test_that("removeScenario removes a vector of ids in one write-through", {
+  project <- testProject()
+  addScenario(project, c("s1", "s2"), modelFile = "Aciclovir.pkml")
+  removeScenario(project, c("s1", "s2"))
+  expect_false(any(c("s1", "s2") %in% names(project$scenarios)))
+  reloaded <- loadProject(project$jsonPath)
+  expect_false(any(c("s1", "s2") %in% names(reloaded$scenarios)))
+})
+
+# Print method ----
+
+test_that("print.Scenario renders the configured fields", {
+  project <- testProject()
+  withr::local_options(cli.unicode = FALSE)
+  local_reproducible_output()
+  expect_snapshot(print(project$scenarios[["testscenario"]]))
 })

--- a/tests/testthat/test-simulation.R
+++ b/tests/testthat/test-simulation.R
@@ -29,6 +29,40 @@ test_that("`initializeSimulation()` does not fail when additionalParams is empty
   expect_true(isOfType(simulationResults, "SimulationResults"))
 })
 
+test_that("`initializeSimulation()` applies additionalInitialConditions", {
+  simulation <- loadSimulation(system.file(
+    "extdata",
+    "simple.pkml",
+    package = "ospsuite"
+  ))
+  initialConditions <- list(
+    paths = "Organism|A",
+    values = 42,
+    units = "µmol"
+  )
+  initializeSimulation(
+    simulation,
+    additionalInitialConditions = initialConditions
+  )
+  applied <- ospsuite::getQuantityValuesByPath(
+    quantityPaths = "Organism|A",
+    simulation = simulation
+  )
+  expect_equal(applied, 42)
+})
+
+test_that("`initializeSimulation()` does not fail when additionalInitialConditions is empty", {
+  simulation <- loadSimulation(system.file(
+    "extdata",
+    "simple.pkml",
+    package = "ospsuite"
+  ))
+  emptyIC <- list(paths = NULL, values = NULL, units = NULL)
+  initializeSimulation(simulation, additionalInitialConditions = emptyIC)
+  simulationResults <- runSimulations(simulation)
+  expect_true(isOfType(simulationResults, "SimulationResults"))
+})
+
 
 test_that("`compareSimulations()` produces no differences with identical simulations", {
   simPath <- system.file("extdata", "simple.pkml", package = "ospsuite")
@@ -80,15 +114,16 @@ test_that("`compareSimulations()` lists differencies on parameter correctly", {
 # getAllApplicationParameters
 
 simPath <- system.file("extdata", "Aciclovir.pkml", package = "ospsuite")
-simulation <- loadSimulation(simPath)
 
 test_that("It returns application parameters when no molecules are defined", {
+  simulation <- loadSimulation(simPath)
   applicationParams <- getAllApplicationParameters(simulation = simulation)
 
   expect_length(applicationParams, 5)
 })
 
 test_that("It returns application parameters when a molecule are defined", {
+  simulation <- loadSimulation(simPath)
   molecule <- "Aciclovir"
   applicationParams <- getAllApplicationParameters(
     simulation = simulation,
@@ -99,6 +134,7 @@ test_that("It returns application parameters when a molecule are defined", {
 })
 
 test_that("It returns an empty list when a molecule is defined that is not in the model", {
+  simulation <- loadSimulation(simPath)
   molecule <- "Foo"
   applicationParams <- getAllApplicationParameters(
     simulation = simulation,

--- a/tests/testthat/test-snapshot.R
+++ b/tests/testthat/test-snapshot.R
@@ -1,0 +1,347 @@
+# Tests for the single-file snapshot artifact (R/entity-files.R):
+# the `.esqlabsR` extension normalization on saveSnapshot(), and the
+# two-argument loadSnapshot(file, dir) which reads a snapshot and writes a
+# full definitions/<kind>/ tree project at `dir`, returning the Project bound
+# to `dir`. Loading a snapshot IS materializing it; the surface is just save
+# and load, with no separate explode-the-tree verb.
+
+# --- saveSnapshot: the `.esqlabsR` extension ----------------------------------
+
+test_that("saveSnapshot normalizes a no-extension path to .esqlabsR", {
+  project <- testProject()
+  dir <- withr::local_tempdir()
+  out <- saveSnapshot(project, file.path(dir, "study1"))
+
+  expect_identical(fs::path_ext(out), "esqlabsR")
+  expect_true(file.exists(out))
+  expect_false(file.exists(file.path(dir, "study1")))
+})
+
+test_that("saveSnapshot normalizes a .json path to .esqlabsR", {
+  project <- testProject()
+  dir <- withr::local_tempdir()
+  out <- saveSnapshot(project, file.path(dir, "study1.json"))
+
+  expect_identical(fs::path_ext(out), "esqlabsR")
+  expect_true(file.exists(out))
+  expect_false(file.exists(file.path(dir, "study1.json")))
+})
+
+test_that("saveSnapshot keeps an explicit .esqlabsR path verbatim", {
+  project <- testProject()
+  dir <- withr::local_tempdir()
+  out <- saveSnapshot(project, file.path(dir, "study1.esqlabsR"))
+
+  expect_identical(out, file.path(dir, "study1.esqlabsR"))
+  expect_true(file.exists(out))
+})
+
+test_that("saveSnapshot honors a different explicit extension with a note", {
+  project <- testProject()
+  dir <- withr::local_tempdir()
+  # The note carries the tempdir path, so match the canonical-form sentence
+  # rather than snapshotting the whole message.
+  expect_message(
+    out <- saveSnapshot(project, file.path(dir, "study1.txt")),
+    "canonical single-file snapshot extension"
+  )
+
+  expect_identical(fs::path_ext(out), "txt")
+  expect_true(file.exists(out))
+})
+
+test_that("the .esqlabsR snapshot content is the inlined-JSON snapshot", {
+  project <- testProject()
+  dir <- withr::local_tempdir()
+  out <- saveSnapshot(project, file.path(dir, "study1"))
+
+  # Content is still JSON, with every section inlined and no tree alongside.
+  raw <- jsonlite::fromJSON(out, simplifyVector = FALSE)
+  expect_length(raw$scenarios, length(project$scenarios))
+  expect_false(dir.exists(file.path(dir, "definitions")))
+})
+
+test_that("saveSnapshot refuses the own container path", {
+  project <- testProject()
+  # Passing the container path (Project.json) is refused even though it would
+  # normalize to Project.esqlabsR, because the intent is clearly the container.
+  expect_snapshot(saveSnapshot(project, project$jsonPath), error = TRUE)
+})
+
+test_that("saveSnapshot writes Project.esqlabsR next to the container safely", {
+  project <- testProject()
+  # A no-extension stem of the container basename normalizes to a distinct
+  # `.esqlabsR` file, so it does not clobber the authoritative Project.json.
+  containerNoExt <- fs::path_ext_remove(project$jsonPath)
+  out <- saveSnapshot(project, containerNoExt)
+
+  expect_identical(out, fs::path_ext_set(containerNoExt, "esqlabsR"))
+  expect_true(file.exists(out))
+  # The authoritative container is untouched (still tree-shape: scenarios []).
+  raw <- jsonlite::fromJSON(project$jsonPath, simplifyVector = FALSE)
+  expect_length(raw$scenarios, 0L)
+})
+
+# --- loadSnapshot(file, dir): load IS the materialize -------------------------
+
+test_that("loadSnapshot writes a tree and returns the Project bound to dir", {
+  out <- saveSnapshot(testProject(), file.path(withr::local_tempdir(), "study"))
+  dir <- withr::local_tempdir()
+
+  project <- loadSnapshot(out, dir)
+
+  # The full tree project is written at `dir`: container + per-kind tree.
+  expect_true(file.exists(file.path(dir, "Project.json")))
+  expect_true(dir.exists(file.path(dir, "definitions", "scenarios")))
+  # The returned project is bound to `dir`.
+  expect_identical(
+    project$projectDirPath,
+    dirname(fs::path_abs(
+      file.path(dir, "Project.json")
+    ))
+  )
+})
+
+test_that("loadSnapshot's tree reloads via loadProject identically", {
+  source <- exampleProject()
+  out <- saveSnapshot(source, file.path(withr::local_tempdir(), "study"))
+  dir <- withr::local_tempdir()
+
+  project <- loadSnapshot(out, dir)
+  reloaded <- loadProject(file.path(dir, "Project.json"))
+
+  expect_named(
+    reloaded$scenarios,
+    names(project$scenarios),
+    ignore.order = TRUE
+  )
+  expect_named(
+    reloaded$individuals,
+    names(project$individuals),
+    ignore.order = TRUE
+  )
+  expect_named(
+    reloaded$parameterSets,
+    names(project$parameterSets),
+    ignore.order = TRUE
+  )
+  expect_named(
+    reloaded$dataCombined,
+    names(project$dataCombined),
+    ignore.order = TRUE
+  )
+})
+
+test_that("a loadSnapshot project edits write-through to dir like any tree", {
+  out <- saveSnapshot(testProject(), file.path(withr::local_tempdir(), "study"))
+  dir <- withr::local_tempdir()
+  project <- loadSnapshot(out, dir)
+  before <- names(project$scenarios)
+  scenarioDir <- file.path(dir, "definitions", "scenarios")
+
+  addScenario(project, "freshone", modelFile = "Aciclovir.pkml")
+  # Write-through lands the file under `dir`, and a reload sees it alongside
+  # the materialized siblings.
+  expect_true(file.exists(file.path(scenarioDir, "freshone.json")))
+  reloaded <- loadProject(file.path(dir, "Project.json"))
+  expect_named(
+    reloaded$scenarios,
+    c(before, "freshone"),
+    ignore.order = TRUE
+  )
+
+  removeScenario(project, "freshone")
+  expect_false(file.exists(file.path(scenarioDir, "freshone.json")))
+})
+
+test_that("loadSnapshot reads a .esqlabsR snapshot", {
+  out <- saveSnapshot(testProject(), file.path(withr::local_tempdir(), "study"))
+  expect_identical(fs::path_ext(out), "esqlabsR")
+
+  project <- loadSnapshot(out, withr::local_tempdir())
+  expect_named(
+    project$scenarios,
+    names(testProject()$scenarios),
+    ignore.order = TRUE
+  )
+})
+
+test_that("loadSnapshot still reads a plain inlined Project.json (back-compat)", {
+  # importProjectFromExcel() writes a single inlined Project.json; loadSnapshot()
+  # must still accept that legacy form as the snapshot to materialize.
+  source <- testProject()
+  legacyDir <- withr::local_tempdir()
+  legacy <- file.path(legacyDir, "Project.json")
+  .saveProjectJson(source, legacy, includeScenarios = TRUE)
+
+  dir <- withr::local_tempdir()
+  project <- loadSnapshot(legacy, dir)
+  expect_true(dir.exists(file.path(dir, "definitions", "scenarios")))
+  expect_named(
+    project$scenarios,
+    names(source$scenarios),
+    ignore.order = TRUE
+  )
+})
+
+test_that("loadSnapshot creates dir when absent", {
+  out <- saveSnapshot(testProject(), file.path(withr::local_tempdir(), "study"))
+  dir <- file.path(withr::local_tempdir(), "new", "nested")
+  expect_false(dir.exists(dir))
+
+  project <- loadSnapshot(out, dir)
+  expect_true(dir.exists(file.path(dir, "definitions", "scenarios")))
+  expect_identical(
+    project$projectDirPath,
+    dirname(fs::path_abs(
+      file.path(dir, "Project.json")
+    ))
+  )
+})
+
+test_that("loadSnapshot refuses a dir that already holds a project", {
+  out <- saveSnapshot(testProject(), file.path(withr::local_tempdir(), "study"))
+  # `dir` already contains a tree project, so materializing into it would
+  # clobber the existing work; refuse rather than silently overwrite. The
+  # message carries the (per-run) tempdir path, so match the stable sentence.
+  dir <- testProject()$projectDirPath
+
+  expect_error(loadSnapshot(out, dir), "already contains an esqlabsR project")
+})
+
+test_that("snapshot -> loadSnapshot -> snapshot is a fixed point over .esqlabsR", {
+  project <- testProject()
+
+  out1 <- saveSnapshot(project, file.path(withr::local_tempdir(), "study"))
+  expect_identical(fs::path_ext(out1), "esqlabsR")
+  reloaded <- loadSnapshot(out1, withr::local_tempdir())
+
+  out2 <- saveSnapshot(reloaded, file.path(withr::local_tempdir(), "study"))
+  # Byte-stable git diffs are the stated design goal, so assert byte equality,
+  # not just structural equality: the two snapshots must be identical line for
+  # line.
+  expect_identical(readLines(out1), readLines(out2))
+})
+
+test_that("snapshot preserves metadata and the filePaths/excel split", {
+  project <- exampleProject()
+
+  out <- saveSnapshot(project, file.path(withr::local_tempdir(), "study"))
+  restored <- loadSnapshot(out, withr::local_tempdir())
+
+  expect_identical(restored$name, "Example")
+  expect_identical(restored$description, "Aciclovir IV PK example project")
+  expect_identical(restored$definitionsFolder, "definitions")
+  expect_named(
+    restored$filePaths,
+    c("modelFolder", "populationsFolder", "dataFolder", "outputFolder"),
+    ignore.order = TRUE
+  )
+  expect_length(restored$excel, 7L)
+})
+
+test_that("loadSnapshot errors on a non-existent snapshot file", {
+  # The message carries the (per-run) path, so match the stable sentence.
+  dir <- withr::local_tempdir()
+  expect_error(
+    loadSnapshot(file.path(dir, "missing.esqlabsR"), withr::local_tempdir()),
+    "File not found"
+  )
+})
+
+# --- migration of a legacy inlined single-file project ------------------------
+
+test_that("loadSnapshot migrates a legacy inlined Project.json end to end", {
+  # The public migration path for a handed-over single-file project is
+  # loadSnapshot(file, dir): it explodes the inlined snapshot into a tree.
+  source <- exampleProject()
+  legacyDir <- withr::local_tempdir()
+  legacy <- file.path(legacyDir, "Project.json")
+  .saveProjectJson(source, legacy, includeScenarios = TRUE)
+
+  dir <- withr::local_tempdir()
+  loadSnapshot(legacy, dir)
+  migrated <- loadProject(file.path(dir, "Project.json"))
+
+  # Section for section, the migrated tree project matches the original.
+  expect_named(
+    migrated$scenarios,
+    names(source$scenarios),
+    ignore.order = TRUE
+  )
+  expect_named(
+    migrated$individuals,
+    names(source$individuals),
+    ignore.order = TRUE
+  )
+  expect_named(
+    migrated$populations,
+    names(source$populations),
+    ignore.order = TRUE
+  )
+  expect_named(
+    migrated$applications,
+    names(source$applications),
+    ignore.order = TRUE
+  )
+  expect_named(
+    migrated$parameterSets,
+    names(source$parameterSets),
+    ignore.order = TRUE
+  )
+  expect_named(
+    migrated$outputPaths,
+    names(source$outputPaths),
+    ignore.order = TRUE
+  )
+  expect_named(
+    migrated$parameterIdentification,
+    names(source$parameterIdentification),
+    ignore.order = TRUE
+  )
+  expect_named(
+    migrated$dataCombined,
+    names(source$dataCombined),
+    ignore.order = TRUE
+  )
+})
+
+# A legacy single-file Project.json may carry non-canonical ids (mixed case),
+# which the entity tree (keyed by canonical id) cannot store. loadSnapshot()
+# must canonicalize on the way in, lossless across every section: definitions
+# AND the references that point at them (a scenario id used by a plot's
+# dataCombined row and by a PI task / output mapping) are lowercased together,
+# so the migrated tree's foreign keys still resolve.
+test_that("loadSnapshot migrates a non-canonical legacy Project.json losslessly", {
+  source <- exampleProject()
+  legacyDir <- withr::local_tempdir()
+  legacy <- file.path(legacyDir, "Project.json")
+  .saveProjectJson(source, legacy, includeScenarios = TRUE)
+
+  # Make two ids non-canonical everywhere they appear (definition and every
+  # reference), exactly as a hand-authored legacy file would: a scenario id
+  # (referenced by a plot row and a PI task) and an output-path id (referenced
+  # by a PI output mapping).
+  txt <- readLines(legacy)
+  txt <- gsub("\"aciclovir_iv\"", "\"Aciclovir_IV\"", txt, fixed = TRUE)
+  txt <- gsub("\"aciclovir_pvb\"", "\"Aciclovir_PVB\"", txt, fixed = TRUE)
+  writeLines(txt, legacy)
+
+  dir <- withr::local_tempdir()
+  # The migration must not abort on the non-canonical id at the tree writer.
+  expect_no_error(loadSnapshot(legacy, dir))
+  migrated <- loadProject(file.path(dir, "Project.json"))
+
+  # The scenario and output-path definitions are filed under their canonical
+  # lowercase ids.
+  expect_true("aciclovir_iv" %in% names(migrated$scenarios))
+  expect_true("aciclovir_pvb" %in% names(migrated$outputPaths))
+
+  # The references that pointed at them are canonicalized too, so they resolve.
+  piTask <- migrated$parameterIdentification[[1]]
+  expect_identical(as.character(piTask$scenarios), "aciclovir_iv")
+  expect_identical(piTask$outputMappings[[1]]$outputPathId, "aciclovir_pvb")
+
+  simScenario <- migrated$dataCombined[[1]]$simulated[[1]]$scenario
+  expect_identical(simScenario, "aciclovir_iv")
+})


### PR DESCRIPTION
Full context: https://github.com/esqLABS/esqlabsR/issues/1088

This is PR1 of the stacked series that integrates the `entity-files-scenarios` delta onto `json-based-project`. It lands the persistence substrate the entire entity-files model stands on: a one-file-per-entity on-disk tree (`definitions/<kind>/*.json`) with a generic loader, serializer, and write-through persister, plus the id canonicalizer that gives every authored id a deterministic, filesystem-safe form. Nothing else in the stack can be reviewed sensibly until this exists, so it is the bottom of the stack, based directly on `json-based-project`.

The series is carved by conceptual layer and sliced for reviewability, not for individual buildability. By design each PR is one squash commit equal to the net delta of a fixed, disjoint file-set; the contract is on the sum, so after the final PR merges `json-based-project` is tree-identical to `entity-files-scenarios`.

## Persistence engine

- `R/entity-files.R` (new): the per-kind entity-tree spec (`kind`/`serialize`/`parse`), the generic `.loadEntityTree` / `.serializeEntitySet` / `.persistSectionChanges` engine (serialize-all-before-write-any atomicity, case-insensitive collision rejection, encoding-safe sort), the `definitions/` directory resolvers, and the `.esqlabsR` snapshot read/write plus `loadSnapshot` / `materializeProject` primitives.
- `R/entity-id.R` (new): `.canonicalizeId()` (vectorized, warn-on-change, collision-error), `.nearestMatch()` (adist-based did-you-mean), `.suggestSuffix()`.
- `R/project-lifecycle.R`: `loadProject()` reading the tree (with an inline-`Project.json` snapshot fallback) and `initProject()` scaffolding.

Plus the accompanying tests and snapshots (`test-entity-files*.R`, `test-entity-id.R`, `test-snapshot.R`, `test-project-lifecycle.R`).

## Stacking notes

This PR is not individually CI-green, and that is expected. Its consumers (the `Project` R6 write-through wiring, the per-section authoring code) arrive in later stacked PRs, so the package will not load or pass tests in isolation on this branch. Two further consequences of the whole-file-per-layer slicing:

- `R/entity-files.R`'s net delta includes hunks that conceptually belong to later layers (the plots kinds, the initial-conditions kind) because this PR owns the whole file. A reviewer sees the file's final shape.
- The roxygen source in the two new R files changes here, but the generated `man/*.Rd` and `NAMESPACE` export lines land in the final documentation-regeneration PR, so the exported surface has no generated docs yet on this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added snapshot save/load support for sharing projects as a single file.
  * Projects now persist authored sections as separate files, improving reload and edit behavior.
  * Entity IDs are now automatically normalized for safer file handling, with clearer suggestions for close matches.

* **Bug Fixes**
  * Added stronger validation for malformed or conflicting entity files.
  * Improved error handling when loading into invalid or non-empty locations.
  * Write-through edits now update the project state and files more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
