### PR TITLE
Project class core: write-through bindings, syncStatus, snapshot verbs, container/metadata reshape

### DIFF
--- a/R/project-to-json.R
+++ b/R/project-to-json.R
@@ -3,7 +3,7 @@
 # Inverse of `Project$.read_json()` (called by `Project$new()`). Walks a
 # `Project` and emits a v2.0 `Project.json` file. The contract is:
 #
-#   loadProject(path) |> saveProject(out)  produces a JSON file that, when
+#   loadProject(path) |> saveSnapshot(out)  produces a JSON file that, when
 #   re-loaded, yields a `Project` structurally identical to the first one.
 #
 # Layered to mirror the end-state shape: a top-level `.projectToJson()`
@@ -11,10 +11,10 @@
 # etc.). Today every per-section helper is essentially a passthrough — the
 # parser stores each section JSON-faithfully, so there is no transformation
 # to perform on the way out. The seams exist so future migrations
-# (relative-path resolution in `.filePathsToJson`, `outputPaths` →
-# `outputPathIds` rewriting in `.scenariosToJson`, unit conversions, plot
-# nesting, ...) can land in one section at a time without rearranging the
-# top-level call shape.
+# (relative-path resolution in `.filePathsToJson`, the named-vector
+# `outputPaths` record field rewritten to the `outputPaths` id array in
+# `.scenariosToJson`, unit conversions, plot nesting, ...) can land in one
+# section at a time without rearranging the top-level call shape.
 
 #' Internal: render a `Project` to a JSON-shaped R list in the v2.0 schema.
 #'
@@ -23,34 +23,116 @@
 #' writing and re-parsing it yields a structurally identical `Project`.
 #'
 #' @param project A `Project` (R6) instance.
+#' @param includeScenarios Logical. When `TRUE` (default), the `scenarios`
+#'   array is inlined (the self-contained snapshot shape). When `FALSE`,
+#'   `scenarios` is emitted as an empty array, because scenarios are
+#'   persisted as an entity tree alongside the container, not inline. Ignored
+#'   when `containerOnly` is `TRUE` (every section is emptied then).
+#' @param containerOnly Logical. When `TRUE`, every tree-owned section
+#'   (scenarios, individuals, populations, parameterSets, applications,
+#'   outputPaths, observedData, dataCombined, plots, plotGrids,
+#'   parameterIdentification) is emitted in its canonical empty shape rather
+#'   than serialized, leaving only the container itself (metadata, filePaths,
+#'   defaultSimulationRunOptions, excel). This is the on-disk `Project.json`
+#'   container shape: the `definitions/<kind>/` tree owns every section and
+#'   wins on reload, so re-serializing the sections here is wasted work. When
+#'   `FALSE` (default) the sections are serialized (the self-contained snapshot
+#'   shape).
 #'
 #' @return A nested list shaped exactly the v2.0 JSON schema, ready for
 #'   `jsonlite::write_json(..., auto_unbox = TRUE, null = "null")`.
 #'
 #' @keywords internal
 #' @noRd
-.projectToJson <- function(project) {
+.projectToJson <- function(
+  project,
+  includeScenarios = TRUE,
+  containerOnly = FALSE
+) {
   if (!inherits(project, "Project")) {
     cli::cli_abort("{.arg project} must be a {.cls Project} R6 instance.")
   }
 
+  # The container separates two path concerns: the four live working folders
+  # (`filePaths`) the runtime reads, and the seven Excel-bridge sheet names
+  # (`excel`). The `excel` block is emitted only when the project actually
+  # carries Excel-bridge fields (an Excel side-car exists); a from-scratch JSON
+  # project omits it. The `name` / `description` metadata, `definitionsFolder`,
+  # and `defaultSimulationRunOptions` are emitted only when set, so an empty
+  # `Project$new()` still serializes a minimal, round-trippable file.
+  #
+  # `containerOnly` serializes none of the tree-owned sections: each is emitted
+  # in its canonical empty shape (the same shape an empty project would yield),
+  # because the `definitions/<kind>/` tree on disk owns every section and is
+  # authoritative on reload. This makes a container write O(container size)
+  # instead of O(sum of all section sizes).
+  excel <- .excelToJson(project)
+  sections <- if (containerOnly) {
+    .emptyTreeSectionsJson()
+  } else {
+    list(
+      observedData = .observedDataToJson(project),
+      outputPaths = .outputPathsToJson(project),
+      scenarios = if (includeScenarios) .scenariosToJson(project) else list(),
+      parameterSets = .parameterSetsToJson(project),
+      initialConditions = .initialConditionsToJson(project),
+      individuals = .individualsToJson(project),
+      populations = .populationsToJson(project),
+      applications = .applicationsToJson(project),
+      dataCombined = .dataCombinedSectionToJson(project),
+      plots = .plotsSectionToJson(project),
+      plotGrids = .plotGridsSectionToJson(project),
+      parameterIdentification = .parameterIdentificationToJson(project)
+    )
+  }
+  out <- c(
+    list(
+      # Default the version so an empty `Project$new()` serializes a file that
+      # `loadProject()` accepts (mirrors the Excel bridge in project-excel.R).
+      schemaVersion = project$schemaVersion %||% "2.0",
+      esqlabsRVersion = project$esqlabsRVersion,
+      name = project$name,
+      description = project$description,
+      definitionsFolder = project$definitionsFolder,
+      filePaths = .filePathsToJson(project),
+      defaultSimulationRunOptions = project$defaultSimulationRunOptions
+    ),
+    sections
+  )
+  if (length(excel) > 0L) {
+    out$excel <- excel
+  }
+  out
+}
+
+# The canonical empty-shape JSON value for every tree-owned section, in the
+# same key order `.projectToJson()` emits. Used by the container-only write
+# path so a `Project.json` container holds only the container itself, the
+# `definitions/<kind>/` tree owning the sections. Each value matches what the
+# section's serializer returns for an empty project: the array-shaped sections
+# (`observedData`, `scenarios`, `individuals`, `populations`) emit `[]`; the
+# map-shaped sections (`outputPaths`, `parameterSets`, `initialConditions`,
+# `applications`) emit `{}`; the sections that round-trip an absent key
+# (`dataCombined`, `plots`, `plotGrids`, `parameterIdentification`) emit `NULL`.
+#
+# @keywords internal
+# @noRd
+.emptyTreeSectionsJson <- function() {
+  emptyArray <- list()
+  emptyObject <- structure(list(), names = character(0L))
   list(
-    # Default the version so an empty `Project$new()` serializes a file that
-    # `loadProject()` accepts (mirrors the Excel bridge in project-excel.R).
-    schemaVersion = project$schemaVersion %||% "2.0",
-    esqlabsRVersion = project$esqlabsRVersion,
-    filePaths = .filePathsToJson(project),
-    observedData = .observedDataToJson(project),
-    outputPaths = .outputPathsToJson(project),
-    scenarios = .scenariosToJson(project),
-    modelParameterSets = .modelParameterSetsToJson(project),
-    individuals = .individualsToJson(project),
-    individualParameterSets = .individualParameterSetsToJson(project),
-    populations = .populationsToJson(project),
-    applications = .applicationsToJson(project),
-    applicationParameterSets = .applicationParameterSetsToJson(project),
-    plots = .plotsToJson(project),
-    parameterIdentification = .parameterIdentificationToJson(project)
+    observedData = emptyArray,
+    outputPaths = emptyObject,
+    scenarios = emptyArray,
+    parameterSets = emptyObject,
+    initialConditions = emptyObject,
+    individuals = emptyArray,
+    populations = emptyArray,
+    applications = emptyObject,
+    dataCombined = NULL,
+    plots = NULL,
+    plotGrids = NULL,
+    parameterIdentification = NULL
   )
 }
 
@@ -61,12 +143,25 @@
 #'
 #' @param project A `Project` (R6) instance.
 #' @param path Destination path. Parent directory must exist.
+#' @param includeScenarios Logical. Passed to `.projectToJson()`: `TRUE`
+#'   (default) inlines the scenarios array (snapshot shape); `FALSE` writes
+#'   the container shape with scenarios held as an entity tree alongside.
+#'   Ignored when `containerOnly` is `TRUE`.
+#' @param containerOnly Logical. Passed to `.projectToJson()`: `TRUE` writes
+#'   only the container (metadata, filePaths, defaultSimulationRunOptions,
+#'   excel) with every tree-owned section emptied; `FALSE` (default)
+#'   serializes the sections too.
 #'
 #' @return `path`, invisibly.
 #'
 #' @keywords internal
 #' @noRd
-.saveProjectJson <- function(project, path) {
+.saveProjectJson <- function(
+  project,
+  path,
+  includeScenarios = TRUE,
+  containerOnly = FALSE
+) {
   if (
     !is.character(path) || length(path) != 1L || is.na(path) || !nzchar(path)
   ) {
@@ -78,7 +173,11 @@
   }
 
   jsonlite::write_json(
-    .projectToJson(project),
+    .projectToJson(
+      project,
+      includeScenarios = includeScenarios,
+      containerOnly = containerOnly
+    ),
     path,
     auto_unbox = TRUE,
     null = "null",
@@ -96,8 +195,10 @@
 # move here from caller code (e.g. relative-path normalization, ID
 # dereferencing, unit conversions).
 
-# JSON object. Walks the raw `{value, description}` records in
-# `.getFilePathsData()` and emits a flat `{name: value}` map.
+# JSON object (the `filePaths` block). Walks the raw `{value, description}`
+# records in `.getFilePathsData()` (the four live working folders only) and
+# emits a flat `{name: value}` map. The Excel-bridge sheet names are emitted
+# separately by `.excelToJson()`.
 .filePathsToJson <- function(project) {
   data <- project$.getFilePathsData()
   if (length(data) == 0L) {
@@ -105,6 +206,20 @@
   }
   result <- lapply(data, function(entry) entry$value)
   .asJsonObject(result)
+}
+
+# JSON object (the `excel` block) or an empty list when the project has no
+# Excel side-car. Walks the raw `{value, description}` records in
+# `.getExcelData()` (the seven Excel-bridge sheet-name fields) and emits a flat
+# `{name: value}` map. Returns `list()` (length 0) when there are no fields, so
+# `.projectToJson()` can omit the `excel` key entirely for a from-scratch JSON
+# project.
+.excelToJson <- function(project) {
+  data <- project$.getExcelData()
+  if (length(data) == 0L) {
+    return(list())
+  }
+  lapply(data, function(entry) entry$value)
 }
 
 # JSON object (map of id → output path string). Coerces a named character
@@ -127,119 +242,136 @@
   .asJsonObject(outputPaths)
 }
 
-# JSON array of scenario objects. Reverses the parse-time
-# transformations: literal `outputPaths` rebuilt as `outputPathIds`
-# against the project lookup, parsed `simulationTime` rejoined to
-# `"a, b, c; d, e, f"`, base-unit `steadyStateTime` converted back to
-# its declared unit. Field order matches the example fixture so
-# round-trip diffs stay zero-noise.
+# JSON array of scenario objects. A thin wrapper over the per-scenario
+# serializer `.scenarioToJson()`; used by the monolithic snapshot
+# (`.projectToJson()`). The entity-files writer calls `.scenarioToJson()`
+# directly, one scenario per file.
 .scenariosToJson <- function(project) {
   scenarios <- project$scenarios
   if (is.null(scenarios) || length(scenarios) == 0L) {
     return(list())
   }
+  unname(lapply(scenarios, .scenarioToJson, outputPaths = project$outputPaths))
+}
 
-  unname(lapply(scenarios, function(sc) {
-    # Default to `list()` so the JSON output is `[]` when the scenario
-    # has no resolved paths (whether the JSON had `outputPathIds: []`,
-    # omitted the key, or `sc$outputPaths` was set to `NULL`
-    # programmatically). Round-trip preserves array-shape symmetry with
-    # the parser, which collapses absent and empty-array to `NULL`.
-    outputPathIds <- list()
-    if (!is.null(sc$outputPaths)) {
-      pathIds <- names(sc$outputPaths)
-      if (is.null(pathIds) || any(pathIds == "")) {
-        cli::cli_abort(
-          c(
-            "Scenario {.val {sc$scenarioName}} has {.field outputPaths} without ids.",
-            "i" = "Expected a named character vector: id-as-name, literal-path-as-value."
-          )
+# Serialize one `Scenario` record to its JSON object shape. Reverses the
+# parse-time transformations: the literal `outputPaths` record field rebuilt
+# as the `outputPaths` id array against the project lookup, parsed
+# `simulationTime` rejoined to `"a, b, c; d, e, f"`, base-unit
+# `steadyStateTime` converted
+# back to its declared unit. Field order matches the example fixture so
+# round-trip diffs stay zero-noise. The same object is one element of the
+# monolithic `scenarios` array and the entire content of one scenario
+# entity file.
+#
+# @keywords internal
+# @noRd
+.scenarioToJson <- function(sc, outputPaths) {
+  # Default to `list()` so the JSON output is `[]` when the scenario
+  # has no resolved paths (whether the JSON had `outputPaths: []`,
+  # omitted the key, or `sc$outputPaths` was set to `NULL`
+  # programmatically). Round-trip preserves array-shape symmetry with
+  # the parser, which collapses absent and empty-array to `NULL`.
+  outputPathIds <- list()
+  if (!is.null(sc$outputPaths)) {
+    pathIds <- names(sc$outputPaths)
+    if (is.null(pathIds) || any(pathIds == "")) {
+      cli::cli_abort(
+        c(
+          "Scenario {.val {sc$scenarioName}} has {.field outputPaths} without ids.",
+          "i" = "Expected a named character vector: id-as-name, literal-path-as-value."
         )
-      }
-      unknown <- setdiff(pathIds, names(project$outputPaths))
-      if (length(unknown) > 0) {
-        cli::cli_abort(
-          "Scenario {.val {sc$scenarioName}} references unknown outputPathIds: {.val {unknown}}."
-        )
-      }
-      outputPathIds <- as.list(pathIds)
-    }
-
-    simTimeStr <- NULL
-    if (!is.null(sc$simulationTime)) {
-      intervals <- vapply(
-        sc$simulationTime,
-        function(int) paste(int, collapse = ", "),
-        character(1)
       )
-      simTimeStr <- paste(intervals, collapse = "; ")
     }
+    # A dangling outputPathId (one not in the project lookup) is a
+    # referential issue caught lazily by the cross-reference validator,
+    # not a serialization error; the id round-trips verbatim.
+    outputPathIds <- as.list(pathIds)
+  }
 
-    if (sc$simulateSteadyState && is.null(sc$steadyStateTimeUnit)) {
-      cli::cli_abort(c(
-        "Scenario {.val {sc$scenarioName}} has {.field simulateSteadyState}=TRUE \\
-        but {.field steadyStateTimeUnit} is NULL.",
-        "i" = "Set {.field steadyStateTimeUnit} (e.g. {.val min}) so the value \\
-        can round-trip."
-      ))
-    }
-
-    list(
-      name = sc$scenarioName,
-      individualId = sc$individualId,
-      # Emit the populationId verbatim rather than keying off the derived
-      # `simulationType`, so a drifted record (populationId set while the
-      # type reads "Individual") does not silently lose its populationId.
-      populationId = sc$populationId,
-      readPopulationFromCSV = sc$readPopulationFromCSV,
-      # `as.list(NULL)` -> `list()`; this collapses both "key absent" and
-      # "empty array" in the parsed scenario to JSON `[]`. Matches the
-      # end-state serializer in `json-as-primary-input-v2`.
-      modelParameterSets = as.list(sc$modelParameterSets),
-      applicationProtocol = if (
-        is.null(sc$applicationProtocol) || is.na(sc$applicationProtocol)
-      ) {
-        NULL
-      } else {
-        sc$applicationProtocol
-      },
-      simulationTime = simTimeStr,
-      simulationTimeUnit = sc$simulationTimeUnit,
-      steadyState = sc$simulateSteadyState,
-      # Emit the steady-state time/unit whenever a unit is declared,
-      # independently of `simulateSteadyState`. A declared time with the
-      # flag off (e.g. `steadyState: false` plus a preset time) is valid
-      # JSON the parser reads back, so dropping it would lose data.
-      steadyStateTime = if (!is.null(sc$steadyStateTimeUnit)) {
-        ospsuite::toUnit(
-          quantityOrDimension = ospDimensions$Time,
-          values = sc$steadyStateTime,
-          targetUnit = sc$steadyStateTimeUnit
-        )
-      } else {
-        NULL
-      },
-      steadyStateTimeUnit = sc$steadyStateTimeUnit,
-      overwriteFormulasInSS = sc$overwriteFormulasInSS,
-      modelFile = sc$modelFile,
-      outputPathIds = outputPathIds
+  simTimeStr <- NULL
+  if (!is.null(sc$simulationTime)) {
+    intervals <- vapply(
+      sc$simulationTime,
+      function(int) paste(int, collapse = ", "),
+      character(1)
     )
-  }))
+    simTimeStr <- paste(intervals, collapse = "; ")
+  }
+
+  if (sc$simulateSteadyState && is.null(sc$steadyStateTimeUnit)) {
+    cli::cli_abort(c(
+      "Scenario {.val {sc$scenarioName}} has {.field simulateSteadyState}=TRUE \\
+      but {.field steadyStateTimeUnit} is NULL.",
+      "i" = "Set {.field steadyStateTimeUnit} (e.g. {.val min}) so the value \\
+      can round-trip."
+    ))
+  }
+
+  list(
+    name = sc$scenarioName,
+    individual = sc$individualId,
+    # Emit the population id verbatim rather than keying off the derived
+    # `simulationType`, so a drifted record (populationId set while the
+    # type reads "Individual") does not silently lose its population.
+    population = sc$populationId,
+    readPopulationFromCSV = sc$readPopulationFromCSV,
+    # `as.list(NULL)` -> `list()`; this collapses both "key absent" and
+    # "empty array" in the parsed scenario to JSON `[]`. Matches the
+    # end-state serializer in `json-as-primary-input-v2`.
+    parameterSets = as.list(sc$modelParameterSets),
+    initialConditions = as.list(sc$initialConditions),
+    application = if (
+      is.null(sc$applicationProtocol) || is.na(sc$applicationProtocol)
+    ) {
+      NULL
+    } else {
+      sc$applicationProtocol
+    },
+    simulationTime = simTimeStr,
+    simulationTimeUnit = sc$simulationTimeUnit,
+    steadyState = sc$simulateSteadyState,
+    # Emit the steady-state time/unit whenever a unit is declared,
+    # independently of `simulateSteadyState`. A declared time with the
+    # flag off (e.g. `steadyState: false` plus a preset time) is valid
+    # JSON the parser reads back, so dropping it would lose data.
+    steadyStateTime = if (!is.null(sc$steadyStateTimeUnit)) {
+      ospsuite::toUnit(
+        quantityOrDimension = ospDimensions$Time,
+        values = sc$steadyStateTime,
+        targetUnit = sc$steadyStateTimeUnit
+      )
+    } else {
+      NULL
+    },
+    steadyStateTimeUnit = sc$steadyStateTimeUnit,
+    overwriteFormulasInSS = sc$overwriteFormulasInSS,
+    modelFile = sc$modelFile,
+    outputPaths = outputPathIds
+  )
 }
 
-# JSON object (map of parameter-set name → array of parameter entries).
-.modelParameterSetsToJson <- function(project) {
-  .asJsonObject(project$modelParameterSets)
+# JSON object (map of parameter-set id → array of parameter entries). The
+# single unified parameter-set section; a scenario / individual / application
+# all reference into it.
+.parameterSetsToJson <- function(project) {
+  sets <- project$parameterSets
+  # Strip the `ParameterSet` class wrapper from each set's array-of-entries so
+  # it never reaches JSON (the wrapper exists only for the print method).
+  sets <- lapply(sets, unclass)
+  .asJsonObject(sets)
 }
 
-# JSON object (map of parameter-set name → array of parameter entries).
-.individualParameterSetsToJson <- function(project) {
-  .asJsonObject(project$individualParameterSets)
-}
-
-# JSON object (map of parameter-set name → array of parameter entries).
-.applicationParameterSetsToJson <- function(project) {
-  .asJsonObject(project$applicationParameterSets)
+# JSON object (map of initial-condition set id → array of `{path, value, unit}`
+# records). Applied to a scenario's simulation via its `initialConditions`
+# field.
+.initialConditionsToJson <- function(project) {
+  sets <- project$initialConditions
+  # Strip the `InitialConditionSet` class wrapper from each set's array-of-
+  # entries so it never reaches JSON (the wrapper exists only for the print
+  # method).
+  sets <- lapply(sets, unclass)
+  .asJsonObject(sets)
 }
 
 # JSON array of individual objects. The in-memory shape is a named list
@@ -295,24 +427,28 @@
   result
 }
 
-# JSON array of observed-data source entries.
+# JSON array of observed-data source entries. Strips the
+# `ObservedDataSource` class wrapper from each entry (carried only for the
+# print method) so it never reaches JSON.
 .observedDataToJson <- function(project) {
-  project$observedData
+  lapply(project$observedData, unclass)
 }
 
-# `.plotsToJson` and its data-shape helpers (`.dataCombinedToNestedJson`,
-# `.dataFrameToListOfLists`) live in R/plots.R alongside the plots section
-# parse + validate + mutation API.
+# The three plots-section serializers (`.dataCombinedSectionToJson`,
+# `.plotsSectionToJson`, `.plotGridsSectionToJson`) and their data-shape
+# helpers (`.dataCombinedToNestedJson`, `.plotEntriesToJson`) live in R/plots.R
+# alongside the plots-section parse + validate + mutation API.
 
 # Shape-coercion helper -------------------------------------------------------
 
 # `list()` is ambiguous in JSON: jsonlite renders an empty list as `[]`, but
 # the schema requires `{}` for the map-shaped sections (`filePaths`,
-# `outputPaths`, `applications`, `modelParameterSets`,
-# `individualParameterSets`, `applicationParameterSets`). Setting a
-# zero-length names attribute triggers jsonlite's named-list serialization
-# path.
+# `outputPaths`, `applications`, `parameterSets`). Setting a zero-length
+# names attribute triggers jsonlite's named-list serialization path.
 .asJsonObject <- function(x) {
+  # Strip the printable DefinitionList wrapper a section accessor adds on read,
+  # so the class never reaches the serialized JSON.
+  x <- .unwrapDefinitionList(x)
   if (length(x) == 0L) {
     return(structure(list(), names = character(0L)))
   }
@@ -363,8 +499,11 @@
   list(
     id = m$id,
     scenarios = as.list(m$scenarios),
-    outputPathId = m$outputPathId,
-    observedDataId = m$observedDataId,
+    # The on-disk JSON keys are suffixless (`outputPath` / `observedData`); the
+    # kept record fields keep their id-suffixed names, mirroring the parser
+    # (`.parsePIOutputMappings`) and the `PIOutputMapping()` mapping seam.
+    outputPath = m$outputPathId,
+    observedData = m$observedDataId,
     scaling = m$scaling,
     xOffset = m$xOffset,
     yOffset = m$yOffset,

--- a/R/project.R
+++ b/R/project.R
@@ -1,5 +1,23 @@
 # Project R6 class ----
 
+# The seven container path fields that belong to the Excel import/export
+# bridge (the `excel` block), as opposed to the four live working folders
+# (`modelFolder`, `dataFolder`, `outputFolder`, `populationsFolder`) that the
+# runtime reads (the `filePaths` block). A legacy `Project.json` carries all
+# eleven in one flat `filePaths` block; this fixed mapping is what splits them
+# on read and routes each to its own container block on write.
+.excelFilePathFields <- c(
+  "configurationsFolder",
+  "modelParamsFile",
+  "individualsFile",
+  "populationsFile",
+  "scenariosFile",
+  "applicationsFile",
+  "plotsFile",
+  "parameterIdentificationFile",
+  "initialConditionsFile"
+)
+
 #' @title Project
 #' @docType class
 #' @description An R6 class representing an esqlabsR project
@@ -12,6 +30,13 @@
 #'   programmatic observed data added via [addObservedData()] with a
 #'   `DataSet` object; those `ospsuite::DataSet` objects wrap external
 #'   handles and are shared by reference between a project and its clone.
+#'
+#'   A clone is also detached from the source on disk: it does not own the
+#'   source's entity tree, so its write-through mutations (`addScenario()`,
+#'   `removeScenario()`, and the other `add*` / `remove*` / `set*` helpers)
+#'   stay in memory only and never touch the source's `definitions/`
+#'   directory. Use [saveSnapshot()] to write the clone to a single-file
+#'   snapshot you can reload with [loadSnapshot()].
 #' @format NULL
 #' @import fs
 #' @export
@@ -42,16 +67,6 @@ Project <- R6::R6Class(
       private$.projectDirPath
     },
 
-    #' @field modified Read-only logical. `TRUE` if any configuration property
-    #'   has been modified since the project was loaded or saved. Cleared
-    #'   internally by [saveProject()].
-    modified = function(value) {
-      if (!missing(value)) {
-        cli::cli_abort("{.field modified} is readonly")
-      }
-      private$.modified
-    },
-
     #' @field validatedSinceMutation Read-only logical. `TRUE` if a full
     #'   [validateProject()] has succeeded since the last project mutation
     #'   or load. Cleared by any mutation. Used internally by automatic
@@ -64,24 +79,94 @@ Project <- R6::R6Class(
       private$.validatedSinceMutation
     },
 
+    #' @field name Human-readable project name (the `name` JSON field). May be
+    #'   `NULL` when the project declares no name. Writing persists the
+    #'   container for a bound project.
+    name = function(value) {
+      if (!missing(value)) {
+        private$.name <- value
+        private$.invalidateContainer()
+        return(invisible(value))
+      }
+      private$.name
+    },
+
+    #' @field description Optional free-text project description (the
+    #'   `description` JSON field). May be `NULL`. Writing persists the
+    #'   container for a bound project.
+    description = function(value) {
+      if (!missing(value)) {
+        private$.description <- value
+        private$.invalidateContainer()
+        return(invisible(value))
+      }
+      private$.description
+    },
+
+    #' @field definitionsFolder Name of the folder (relative to
+    #'   `projectDirPath`) that holds the project's authored entity-definition
+    #'   tree. Defaults to `"definitions"`. Writing persists the container for
+    #'   a bound project; changing it moves where future write-through edits
+    #'   are read from and written to.
+    definitionsFolder = function(value) {
+      if (!missing(value)) {
+        private$.definitionsFolder <- value
+        private$.invalidateContainer()
+        return(invisible(value))
+      }
+      private$.definitionsFolder %||% "definitions"
+    },
+
+    #' @field defaultSimulationRunOptions Named list of the project-level
+    #'   default simulation run options (the `defaultSimulationRunOptions` JSON
+    #'   field), or `NULL` when none are declared. Used by [runScenarios()] as
+    #'   the default `simulationRunOptions` when the caller does not pass one.
+    #'   Recognized fields: `numberOfCores`, `checkForNegativeValues`,
+    #'   `showProgress`. Writing persists the container for a bound project.
+    defaultSimulationRunOptions = function(value) {
+      if (!missing(value)) {
+        private$.defaultSimulationRunOptions <- value
+        private$.invalidateContainer()
+        return(invisible(value))
+      }
+      private$.defaultSimulationRunOptions
+    },
+
+    #' @field excel Read-only named list of the Excel import/export bridge
+    #'   sheet-name fields (`configurationsFolder`, `modelParamsFile`,
+    #'   `individualsFile`, `populationsFile`, `scenariosFile`,
+    #'   `applicationsFile`, `plotsFile`, `parameterIdentificationFile`).
+    #'   Returned verbatim as strings (no resolution). Empty for a from-scratch
+    #'   JSON project that has no Excel side-car.
+    excel = function(value) {
+      if (!missing(value)) {
+        cli::cli_abort("{.field excel} is readonly")
+      }
+      data <- private$.excelData
+      if (length(data) == 0L) {
+        return(structure(list(), names = character(0L)))
+      }
+      lapply(data, function(entry) entry$value)
+    },
+
     #' @field schemaVersion Schema version declared in the JSON. Always "2.0"
-    #'   for projects loaded by this parser. Writing marks the project as
-    #'   modified.
+    #'   for projects loaded by this parser. Writing persists the container
+    #'   for a bound project.
     schemaVersion = function(value) {
       if (!missing(value)) {
         private$.schemaVersion <- value
-        private$.invalidate()
+        private$.invalidateContainer()
         return(invisible(value))
       }
       private$.schemaVersion
     },
 
     #' @field esqlabsRVersion Informational version string from the JSON.
-    #'   Writing marks the project as modified.
+    #'   Writing persists the container for a bound project.
     esqlabsRVersion = function(value) {
       if (!missing(value)) {
         private$.esqlabsRVersion <- value
-        private$.invalidate()
+        private$.invalidateContainer()
         return(invisible(value))
       }
       private$.esqlabsRVersion
@@ -100,7 +185,7 @@ Project <- R6::R6Class(
     modelFolder = function(value) {
       if (!missing(value)) {
         private$.filePathsData$modelFolder$value <- value
-        private$.invalidate()
+        private$.invalidateContainer()
         return(invisible(value))
       }
       private$.clean_path(
@@ -110,100 +195,135 @@ Project <- R6::R6Class(
     },
 
     #' @field configurationsFolder Path to the folder containing configuration
-    #'   files. Used by the Excel import/export bridge.
+    #'   files. Part of the Excel import/export bridge (the `excel` container
+    #'   block).
     configurationsFolder = function(value) {
       if (!missing(value)) {
-        private$.filePathsData$configurationsFolder$value <- value
-        private$.invalidate()
+        private$.excelData$configurationsFolder$value <- value
+        private$.invalidateContainer()
         return(invisible(value))
       }
       private$.clean_path(
-        private$.filePathsData$configurationsFolder$value,
+        private$.excelData$configurationsFolder$value,
         self$projectDirPath
       )
     },
 
     #' @field modelParamsFile Path to the Excel file with global model
-    #'   parameterization. Used by the Excel import/export bridge.
+    #'   parameterization. Part of the Excel import/export bridge (the `excel`
+    #'   container block).
     modelParamsFile = function(value) {
       if (!missing(value)) {
-        private$.filePathsData$modelParamsFile$value <- value
-        private$.invalidate()
+        private$.excelData$modelParamsFile$value <- value
+        private$.invalidateContainer()
         return(invisible(value))
       }
       private$.clean_path(
-        private$.filePathsData$modelParamsFile$value,
+        private$.excelData$modelParamsFile$value,
         self$configurationsFolder
       )
     },
 
     #' @field individualsFile Path to the Excel file with individual-specific
-    #'   model parameterization. Used by the Excel import/export bridge.
+    #'   model parameterization. Part of the Excel import/export bridge (the
+    #'   `excel` container block).
     individualsFile = function(value) {
       if (!missing(value)) {
-        private$.filePathsData$individualsFile$value <- value
-        private$.invalidate()
+        private$.excelData$individualsFile$value <- value
+        private$.invalidateContainer()
         return(invisible(value))
       }
       private$.clean_path(
-        private$.filePathsData$individualsFile$value,
+        private$.excelData$individualsFile$value,
         self$configurationsFolder
       )
     },
 
     #' @field populationsFile Path to the Excel file with population
-    #'   information. Used by the Excel import/export bridge.
+    #'   information. Part of the Excel import/export bridge (the `excel`
+    #'   container block).
     populationsFile = function(value) {
       if (!missing(value)) {
-        private$.filePathsData$populationsFile$value <- value
-        private$.invalidate()
+        private$.excelData$populationsFile$value <- value
+        private$.invalidateContainer()
         return(invisible(value))
       }
       private$.clean_path(
-        private$.filePathsData$populationsFile$value,
+        private$.excelData$populationsFile$value,
         self$configurationsFolder
       )
     },
 
     #' @field scenariosFile Path to the Excel file with scenario definitions.
-    #'   Used by the Excel import/export bridge.
+    #'   Part of the Excel import/export bridge (the `excel` container block).
     scenariosFile = function(value) {
       if (!missing(value)) {
-        private$.filePathsData$scenariosFile$value <- value
-        private$.invalidate()
+        private$.excelData$scenariosFile$value <- value
+        private$.invalidateContainer()
         return(invisible(value))
       }
       private$.clean_path(
-        private$.filePathsData$scenariosFile$value,
+        private$.excelData$scenariosFile$value,
         self$configurationsFolder
       )
     },
 
     #' @field applicationsFile Path to the Excel file with scenario-specific
-    #'   parameters such as application protocol parameters. Used by the
-    #'   Excel import/export bridge.
+    #'   parameters such as application protocol parameters. Part of the Excel
+    #'   import/export bridge (the `excel` container block).
     applicationsFile = function(value) {
       if (!missing(value)) {
-        private$.filePathsData$applicationsFile$value <- value
-        private$.invalidate()
+        private$.excelData$applicationsFile$value <- value
+        private$.invalidateContainer()
         return(invisible(value))
       }
       private$.clean_path(
-        private$.filePathsData$applicationsFile$value,
+        private$.excelData$applicationsFile$value,
         self$configurationsFolder
       )
     },
 
-    #' @field plotsFile Path to the Excel file with plot definitions. Used by
-    #'   the Excel import/export bridge.
+    #' @field plotsFile Path to the Excel file with plot definitions. Part of
+    #'   the Excel import/export bridge (the `excel` container block).
     plotsFile = function(value) {
       if (!missing(value)) {
-        private$.filePathsData$plotsFile$value <- value
-        private$.invalidate()
+        private$.excelData$plotsFile$value <- value
+        private$.invalidateContainer()
         return(invisible(value))
       }
       private$.clean_path(
-        private$.filePathsData$plotsFile$value,
+        private$.excelData$plotsFile$value,
+        self$configurationsFolder
+      )
+    },
+
+    #' @field parameterIdentificationFile Name of the Excel workbook holding
+    #'   the parameter-identification sheets (`PITasks`, `PIParameters`,
+    #'   `PIOutputMappings`). Resolved relative to `configurationsFolder`.
+    parameterIdentificationFile = function(value) {
+      if (!missing(value)) {
+        private$.excelData$parameterIdentificationFile$value <- value
+        private$.invalidateContainer()
+        return(invisible(value))
+      }
+      private$.clean_path(
+        private$.excelData$parameterIdentificationFile$value,
+        self$configurationsFolder
+      )
+    },
+
+    #' @field initialConditionsFile Name of the Excel workbook holding the
+    #'   initial-condition (molecule start value) sheets, one sheet per set.
+    #'   Part of the Excel import/export bridge (the `excel` container block);
+    #'   resolved relative to `configurationsFolder`.
+    initialConditionsFile = function(value) {
+      if (!missing(value)) {
+        private$.excelData$initialConditionsFile$value <- value
+        private$.invalidateContainer()
+        return(invisible(value))
+      }
+      private$.clean_path(
+        private$.excelData$initialConditionsFile$value,
         self$configurationsFolder
       )
     },
@@ -214,7 +334,7 @@ Project <- R6::R6Class(
     populationsFolder = function(value) {
       if (!missing(value)) {
         private$.filePathsData$populationsFolder$value <- value
-        private$.invalidate()
+        private$.invalidateContainer()
         return(invisible(value))
       }
       private$.clean_path(
@@ -228,7 +348,7 @@ Project <- R6::R6Class(
     dataFolder = function(value) {
       if (!missing(value)) {
         private$.filePathsData$dataFolder$value <- value
-        private$.invalidate()
+        private$.invalidateContainer()
         return(invisible(value))
       }
       private$.clean_path(
@@ -242,7 +362,7 @@ Project <- R6::R6Class(
     outputFolder = function(value) {
       if (!missing(value)) {
         private$.filePathsData$outputFolder$value <- value
-        private$.invalidate()
+        private$.invalidateContainer()
         return(invisible(value))
       }
       private$.clean_path(
@@ -251,144 +371,177 @@ Project <- R6::R6Class(
       )
     },
 
-    # Section data. Each binding stores the section in a private backing
-    # field and invalidates on write, so any assignment (including
-    # subscript forms like `project$scenarios[[name]] <- sc`, which R
-    # desugars into a full read-modify-write through the setter) marks
-    # the project modified and clears `validatedSinceMutation`.
+    # Section data. Each accessor is READ-ONLY from the handle: the getter
+    # returns the section wrapped in a printable, read-only `DefinitionList`,
+    # and every assignment form (`project$x <- v`, `project$x[["id"]] <- v`,
+    # the nested `project$x[["id"]]$f <- v`, `project$x[-i] <- v`) aborts. The
+    # only sanctioned way to change a section is an authoring function
+    # (`addScenario()` / `setScenario()` / `removeScenario()` and their
+    # per-section siblings) or editing the definition's JSON file; those write
+    # through the internal `.setSection()` entry point, which structurally
+    # validates each changed entity, persists it to (or deletes it from) its
+    # `definitions/<kind>/` tree, and clears `validatedSinceMutation` so the
+    # next run/plot re-validates.
 
-    #' @field outputPaths Named list mapping output-path IDs to OSPS-notation
-    #'   path strings (e.g. `list(PVB = "Organism|...")`). A named character
-    #'   vector is also accepted on write and coerced to a list on save.
-    #'   Writing marks the project as modified.
+    #' @field outputPaths Read-only named list mapping output-path IDs to
+    #'   OSPS-notation path strings (e.g. `list(PVB = "Organism|...")`). To
+    #'   change it, use [addOutputPath()] / [setOutputPath()] /
+    #'   [removeOutputPath()] or edit the entity files under
+    #'   `definitions/output-paths/`; an authoring write persists each changed
+    #'   output path to (or deletes it from) its file.
     outputPaths = function(value) {
       if (!missing(value)) {
-        private$.outputPaths <- value
-        private$.invalidate()
-        return(invisible(value))
+        .definitionListReadOnlyError("outputPaths")
       }
-      private$.outputPaths
+      .asDefinitionList(private$.outputPaths, "outputPaths")
     },
 
-    #' @field scenarios Named list of `Scenario` records, keyed by scenario
-    #'   name. Entries are plain-data records with copy semantics; write a
-    #'   modified entry back (e.g. `project$scenarios[[name]] <- sc`) to
-    #'   mutate the project. Writing marks the project as modified.
+    #' @field scenarios Read-only named list of `Scenario` records, keyed by
+    #'   scenario name. To change it, use [addScenario()] / [setScenario()] /
+    #'   [removeScenario()] (or [renameScenario()] / [duplicateScenario()]), or
+    #'   edit the entity files under `definitions/scenarios/`. The canonical
+    #'   edit loop is read-modify-resubmit: read a record
+    #'   (`sc <- project$scenarios[["id"]]`), change the detached copy
+    #'   (`sc$modelFile <- ...`), then re-submit it
+    #'   (`setScenario(project, "id", ...)`). An authoring write structurally
+    #'   validates each changed scenario and persists it to (or deletes it from)
+    #'   its file; an in-memory project (no directory) holds scenarios in memory
+    #'   only.
     scenarios = function(value) {
       if (!missing(value)) {
-        private$.scenarios <- value
-        private$.invalidate()
-        return(invisible(value))
+        .definitionListReadOnlyError("scenarios")
       }
-      private$.scenarios
+      .asDefinitionList(private$.scenarios, "scenarios")
     },
 
-    #' @field modelParameterSets Named list of parameter structures, keyed by
-    #'   set name. Writing marks the project as modified.
-    modelParameterSets = function(value) {
+    #' @field parameterSets Read-only named list of parameter structures, keyed
+    #'   by set id. This single section holds every parameter set in the
+    #'   project: a scenario references the sets it applies through its
+    #'   `modelParameterSets` field, an individual or application through its
+    #'   `parameterSets` field; all three resolve against this one map. To
+    #'   change it, use [addParameterSet()] / [removeParameterSet()] /
+    #'   [addParameterEntry()] / [removeParameterEntry()] or edit the entity
+    #'   files under `definitions/parameter-sets/`.
+    parameterSets = function(value) {
       if (!missing(value)) {
-        private$.modelParameterSets <- value
-        private$.invalidate()
-        return(invisible(value))
+        .definitionListReadOnlyError("parameterSets")
       }
-      private$.modelParameterSets
+      .asDefinitionList(private$.parameterSets, "parameterSets")
     },
 
-    #' @field individualParameterSets Named list of parameter structures,
-    #'   keyed by set name. Writing marks the project as modified.
-    individualParameterSets = function(value) {
+    #' @field initialConditions Read-only named list of initial-condition sets,
+    #'   keyed by set id. Each set is a list of molecule start-value records
+    #'   (`path`, `value`, `unit`), applied to a scenario's simulation via its
+    #'   `initialConditions` field. To change it, use [addInitialConditions()] /
+    #'   [removeInitialConditions()] / [addInitialConditionEntry()] /
+    #'   [removeInitialConditionEntry()] or edit the entity files under
+    #'   `definitions/initial-conditions/`.
+    initialConditions = function(value) {
       if (!missing(value)) {
-        private$.individualParameterSets <- value
-        private$.invalidate()
-        return(invisible(value))
+        .definitionListReadOnlyError("initialConditions")
       }
-      private$.individualParameterSets
+      .asDefinitionList(private$.initialConditions, "initialConditions")
     },
 
-    #' @field applicationParameterSets Named list of parameter structures,
-    #'   keyed by set name. Writing marks the project as modified.
-    applicationParameterSets = function(value) {
-      if (!missing(value)) {
-        private$.applicationParameterSets <- value
-        private$.invalidate()
-        return(invisible(value))
-      }
-      private$.applicationParameterSets
-    },
-
-    #' @field individuals Named list of plain lists, keyed by individualId.
-    #'   Writing marks the project as modified.
+    #' @field individuals Read-only named list of plain lists, keyed by
+    #'   individualId. To change it, use [addIndividual()] / [setIndividual()] /
+    #'   [removeIndividual()] or edit the entity files under
+    #'   `definitions/individuals/`.
     individuals = function(value) {
       if (!missing(value)) {
-        private$.individuals <- value
-        private$.invalidate()
-        return(invisible(value))
+        .definitionListReadOnlyError("individuals")
       }
-      private$.individuals
+      .asDefinitionList(private$.individuals, "individuals")
     },
 
-    #' @field populations Named list of plain lists, keyed by populationId.
-    #'   Writing marks the project as modified.
+    #' @field populations Read-only named list of plain lists, keyed by
+    #'   populationId. To change it, use [addPopulation()] / [setPopulation()] /
+    #'   [removePopulation()] or edit the entity files under
+    #'   `definitions/populations/`.
     populations = function(value) {
       if (!missing(value)) {
-        private$.populations <- value
-        private$.invalidate()
-        return(invisible(value))
+        .definitionListReadOnlyError("populations")
       }
-      private$.populations
+      .asDefinitionList(private$.populations, "populations")
     },
 
-    #' @field applications Named list of parameter structures, keyed by
-    #'   protocol name. Writing marks the project as modified.
+    #' @field applications Read-only named list of parameter structures, keyed
+    #'   by protocol name. To change it, use [addApplication()] /
+    #'   [removeApplication()] or edit the entity files under
+    #'   `definitions/applications/`.
     applications = function(value) {
       if (!missing(value)) {
-        private$.applications <- value
-        private$.invalidate()
-        return(invisible(value))
+        .definitionListReadOnlyError("applications")
       }
-      private$.applications
+      .asDefinitionList(private$.applications, "applications")
     },
 
-    #' @field observedData List of observed data source declarations parsed
-    #'   from JSON. Writing marks the project as modified and resets the
-    #'   cached observed-data names.
+    #' @field observedData Read-only list of observed data source declarations.
+    #'   To change it, use [addObservedData()] / [removeObservedData()] or edit
+    #'   the entity files under `definitions/observed-data/` (one file per
+    #'   declaration).
     observedData = function(value) {
       if (!missing(value)) {
-        private$.observedData <- value
-        private$.observedDataNamesCache <- NULL
-        private$.invalidate()
-        return(invisible(value))
+        .definitionListReadOnlyError("observedData")
       }
-      private$.observedData
+      .asDefinitionList(private$.observedData, "observedData")
     },
 
-    #' @field plots List with 3 elements: `dataCombined`, `plotConfiguration`,
-    #'   `plotGrids`. Writing marks the project as modified.
+    #' @field dataCombined Read-only named list of `DataCombined` definitions,
+    #'   keyed by `dataCombinedId`. Each entry pairs simulated and/or observed
+    #'   curves. To change it, use [addDataCombined()] / [removeDataCombined()]
+    #'   or edit the entity files under `definitions/data-combined/`.
+    dataCombined = function(value) {
+      if (!missing(value)) {
+        .definitionListReadOnlyError("dataCombined")
+      }
+      .asDefinitionList(private$.dataCombined, "dataCombined")
+    },
+
+    #' @field plots Read-only named list of plot definitions, keyed by `plotId`.
+    #'   Each entry is a single plot's configuration (`dataCombinedId`,
+    #'   `plotType`, and styling fields). To change it, use [addPlot()] /
+    #'   [removePlot()] or edit the entity files under `definitions/plots/`.
     plots = function(value) {
       if (!missing(value)) {
-        private$.plots <- value
-        private$.invalidate()
-        return(invisible(value))
+        .definitionListReadOnlyError("plots")
       }
-      private$.plots
+      .asDefinitionList(private$.plots, "plots")
     },
 
-    #' @field parameterIdentification Named list keyed by PI task id; each
-    #'   entry is a `PITask` record. May be `NULL` or an empty list when
-    #'   the project declares no PI tasks. Writing marks the project as
-    #'   modified.
+    #' @field plotGrids Read-only named list of plot-grid definitions, keyed by
+    #'   `plotGridId`. Each entry lays out one or more plots. To change it, use
+    #'   [addPlotGrid()] / [removePlotGrid()] or edit the entity files under
+    #'   `definitions/plot-grids/`.
+    plotGrids = function(value) {
+      if (!missing(value)) {
+        .definitionListReadOnlyError("plotGrids")
+      }
+      .asDefinitionList(private$.plotGrids, "plotGrids")
+    },
+
+    #' @field parameterIdentification Read-only named list keyed by PI task id;
+    #'   each entry is a `PITask` record. May be `NULL` or an empty list when the
+    #'   project declares no PI tasks. To change it, use [addPITask()] /
+    #'   [removePITask()] (and the per-task [addPIParameter()] /
+    #'   [addPIOutputMapping()] and their removals) or edit the entity files
+    #'   under `definitions/parameter-identification/`.
     parameterIdentification = function(value) {
       if (!missing(value)) {
-        private$.parameterIdentification <- value
-        private$.invalidate()
-        return(invisible(value))
+        .definitionListReadOnlyError("parameterIdentification")
       }
-      private$.parameterIdentification
+      .asDefinitionList(
+        private$.parameterIdentification,
+        "parameterIdentification"
+      )
     },
 
-    #' @field filePaths Read-only named list of declared file/folder paths
-    #'   (the `filePaths` JSON section). Values are returned verbatim as
-    #'   strings; no resolution is performed at this stage.
+    #' @field filePaths Read-only named list of the project's working-folder
+    #'   paths (the `filePaths` JSON block): `modelFolder`, `dataFolder`,
+    #'   `outputFolder`, and `populationsFolder`. Values are returned verbatim
+    #'   as strings; no resolution is performed at this stage. The Excel-bridge
+    #'   sheet-name fields live in the separate `excel` block (`project$excel`),
+    #'   not here.
     filePaths = function(value) {
       if (!missing(value)) {
         cli::cli_abort("{.field filePaths} is readonly")
@@ -416,7 +569,6 @@ Project <- R6::R6Class(
     #' @param projectFilePath A string representing the path to the project
     #'   JSON file.
     initialize = function(projectFilePath = character()) {
-      private$.modified <- FALSE
       private$.validatedSinceMutation <- FALSE
       if (is.character(projectFilePath) && length(projectFilePath) == 0L) {
         private$.projectDirPath <- NULL
@@ -434,29 +586,21 @@ Project <- R6::R6Class(
       invisible(self)
     },
 
-    #' @description Internal method to clear the `modified` flag after saving.
-    #'   Saving is not a mutation, so it leaves `validatedSinceMutation`
-    #'   untouched: a project validated before a save stays validated, and
-    #'   a later `runScenarios()` / `createPlots()` need not re-validate.
-    #'   Not intended for end-user use.
-    #' @keywords internal
-    .markSaved = function() {
-      private$.modified <- FALSE
-      invisible(self)
-    },
-
     #' @description Internal method to rebind the project to a new file
-    #'   location after a save-as. Updates `projectFilePath` / `jsonPath`
-    #'   and `projectDirPath` (the base for relative-path resolution) so a
-    #'   subsequent bare `saveProject()` and any relative-path access target
-    #'   the new file. Not a mutation, so it leaves the flags untouched.
-    #'   Not intended for end-user use.
-    #' @param path Absolute or relative path the project was saved to.
+    #'   location. Updates `projectFilePath` / `jsonPath` and `projectDirPath`
+    #'   (the base for relative-path resolution) so any relative-path access
+    #'   targets the new file, and re-claims the entity tree so a clone bound to
+    #'   its own location becomes write-through there. Not a mutation, so it
+    #'   leaves the flags untouched. Not intended for end-user use.
+    #' @param path Absolute or relative path the project was bound to.
     #' @keywords internal
     .rebindPath = function(path) {
       path <- fs::path_abs(path)
       private$.projectFilePath <- path
       private$.projectDirPath <- dirname(path)
+      # Re-binding makes this instance the owner of the (new) entity tree, so a
+      # clone bound to its own location becomes write-through there.
+      private$.claimEntityTree()
       invisible(self)
     },
 
@@ -470,27 +614,94 @@ Project <- R6::R6Class(
     },
 
     #' @description Internal method invoked by mutators after a successful
-    #'   programmatic change. Sets the `modified` flag and clears the
-    #'   `validatedSinceMutation` flag. Not intended for end-user use.
+    #'   programmatic change. Clears the `validatedSinceMutation` flag so the
+    #'   next `runScenarios()` / `createPlots()` re-validates the project. Not
+    #'   intended for end-user use.
     #' @keywords internal
     .markModified = function() {
       private$.invalidate()
       invisible(self)
     },
 
-    #' @description Internal method to retrieve the raw filePaths metadata
-    #'   (a named list of `list(value, description)` entries). Not intended for
-    #'   end-user use; consumed by the Excel import/export bridge.
+    #' @description Internal read accessor for one definition section. Returns
+    #'   the plain backing list (NOT wrapped in the read-only `DefinitionList`
+    #'   the public `project$<section>` getter returns), so an authoring
+    #'   function may bind it to a local copy and subscript-assign that copy
+    #'   before re-submitting it via `.setSection()`. Not intended for end-user
+    #'   use; the public accessor is the read-only end-user surface.
+    #' @param kind Character scalar naming the section (e.g. `"scenarios"`).
+    #' @keywords internal
+    .getSection = function(kind) {
+      private[[private$.sectionField(kind)]]
+    },
+
+    #' @description Internal write entry point for one definition section. This
+    #'   is the only sanctioned way to change a section: it runs the same
+    #'   structural validation and write-through persistence the public
+    #'   active-binding setter used to, then stores the new list in the private
+    #'   backing field and invalidates the validation cache. The public
+    #'   `project$<section> <- ...` setter no longer writes (it aborts
+    #'   read-only); every `add*`/`set*`/`remove*` authoring function routes its
+    #'   write here. Accepts a plain list; a `DefinitionList` is unwrapped
+    #'   defensively. Not intended for end-user use.
+    #' @param kind Character scalar naming the section (e.g. `"scenarios"`).
+    #' @param value The new section list.
+    #' @keywords internal
+    .setSection = function(kind, value) {
+      field <- private$.sectionField(kind)
+      value <- .unwrapDefinitionList(value)
+      old <- private[[field]]
+      # Persist before updating the backing store, so a structural failure
+      # during serialization aborts the write and leaves disk and memory
+      # unchanged (the same ordering the active-binding setter relied on).
+      private$.persistSectionChanges(kind, old, value)
+      private[[field]] <- value
+      # Writing observed data invalidates the cached observed-data names, as
+      # the active-binding setter did.
+      if (identical(kind, "observedData")) {
+        private$.observedDataNamesCache <- NULL
+      }
+      private$.invalidate()
+      invisible(value)
+    },
+
+    #' @description Internal method to retrieve the raw working-folder metadata
+    #'   (the `filePaths` block: a named list of `list(value, description)`
+    #'   entries for the four live folders). Not intended for end-user use;
+    #'   consumed by the Excel import/export bridge.
     #' @keywords internal
     .getFilePathsData = function() {
       private$.filePathsData
     },
 
-    #' @description Check synchronization status of a Project.
+    #' @description Internal method to retrieve the raw Excel-bridge metadata
+    #'   (the `excel` block: a named list of `list(value, description)` entries
+    #'   for the seven sheet-name fields). Empty when the project has no Excel
+    #'   side-car. Not intended for end-user use; consumed by the Excel
+    #'   import/export bridge.
+    #' @keywords internal
+    .getExcelData = function() {
+      private$.excelData
+    },
+
+    #' @description Report whether the project's Excel side-car is in sync
+    #'   with its entity files. Every section is write-through to its
+    #'   `definitions/<kind>/` tree and the `Project.json` container is a
+    #'   derived snapshot, so the only drift that can still occur is between
+    #'   the project and a sibling `Project.xlsx` produced by
+    #'   [exportProjectToExcel()]. This method compares the two; it is
+    #'   read-only and never reconciles them (use [exportProjectToExcel()] or
+    #'   [importProjectFromExcel()] to do that).
     #' @param silent Logical. If `TRUE`, suppresses informational messages.
     #'   Defaults to `FALSE`.
-    sync = function(silent = FALSE) {
-      .projectSync(self, silent = silent)
+    #' @return Invisibly, a list with two components: `excel_in_sync` (a
+    #'   logical, or `NA` when there is no Excel side-car to compare against)
+    #'   and `details` (a list of the per-section differences, empty when in
+    #'   sync or when there is nothing to compare). This is the same shape the
+    #'   path-based [projectStatus()] returns; the two share one comparison
+    #'   builder.
+    syncStatus = function(silent = FALSE) {
+      .projectSyncStatus(self, silent = silent)
     },
 
     #' @description Print a summary of the Project.
@@ -502,6 +713,12 @@ Project <- R6::R6Class(
         ")\n",
         sep = ""
       )
+      if (!is.null(self$name)) {
+        cat("  name:            ", self$name, "\n", sep = "")
+      }
+      if (!is.null(self$description)) {
+        cat("  description:     ", self$description, "\n", sep = "")
+      }
       if (!is.null(self$jsonPath)) {
         cat("  jsonPath:        ", self$jsonPath, "\n", sep = "")
       }
@@ -540,20 +757,14 @@ Project <- R6::R6Class(
       cat("  individuals:     ", length(self$individuals), "\n", sep = "")
       cat("  populations:     ", length(self$populations), "\n", sep = "")
       cat(
-        "  modelParameterSets:       ",
-        length(self$modelParameterSets),
+        "  parameterSets:   ",
+        length(self$parameterSets),
         " set(s)\n",
         sep = ""
       )
       cat(
-        "  individualParameterSets:  ",
-        length(self$individualParameterSets),
-        " set(s)\n",
-        sep = ""
-      )
-      cat(
-        "  applicationParameterSets: ",
-        length(self$applicationParameterSets),
+        "  initialConditions: ",
+        length(self$initialConditions),
         " set(s)\n",
         sep = ""
       )
@@ -565,58 +776,283 @@ Project <- R6::R6Class(
         " source(s)\n",
         sep = ""
       )
-      if (is.null(self$plots)) {
-        cat("  plots:           (none)\n")
-      } else {
-        # plotConfiguration / plotGrids are data frames (one row per plot /
-        # grid), dataCombined is a named list; count rows or length
-        # accordingly so the summary reports plot counts, not column counts.
-        countSection <- function(x) {
-          if (is.data.frame(x)) nrow(x) else length(x %||% list())
-        }
-        cat(
-          "  plots:           ",
-          countSection(self$plots$dataCombined),
-          " dataCombined / ",
-          countSection(self$plots$plotConfiguration),
-          " plot(s) / ",
-          countSection(self$plots$plotGrids),
-          " grid(s)\n",
-          sep = ""
-        )
-      }
+      cat("  dataCombined:    ", length(self$dataCombined), "\n", sep = "")
+      cat("  plots:           ", length(self$plots), "\n", sep = "")
+      cat("  plotGrids:       ", length(self$plotGrids), "\n", sep = "")
+      cat(
+        "  parameterIdentification: ",
+        length(self$parameterIdentification),
+        " task(s)\n",
+        sep = ""
+      )
       invisible(self)
     }
   ),
   private = list(
     .projectFilePath = NULL,
     .projectDirPath = NULL,
-    .modified = FALSE,
     .validatedSinceMutation = FALSE,
+    # Disk-ownership token for the project's entity tree. A bound project
+    # (one loaded with `loadProject()` or saved with `saveSnapshot()`/a re-bind)
+    # records itself as the token's owner. R6's `clone()` copies private fields
+    # by value but shares this token environment by reference, so a clone is not
+    # the recorded owner; `.ownsEntityTree()` returns `FALSE` for it and its
+    # write-through becomes an in-memory no-op until a re-bind to a new location.
+    # This keeps a clone's on-disk state independent of the source it was cloned
+    # from.
+    .entityTreeOwnerToken = NULL,
+    # Working-folder paths (the `filePaths` block): the four live folders the
+    # runtime reads (`modelFolder`, `dataFolder`, `outputFolder`,
+    # `populationsFolder`).
     .filePathsData = list(),
+    # Excel import/export bridge sheet names (the `excel` block): the seven
+    # vestigial fields only the Excel bridge reads. Empty for a from-scratch
+    # JSON project with no Excel side-car, in which case no `excel` block is
+    # written to `Project.json`.
+    .excelData = list(),
     .programmaticDataSets = list(),
     .observedDataNamesCache = NULL,
 
-    # Backing stores for the section-data active bindings. The parser
-    # writes these directly so loading does not flip `modified`.
+    # Backing stores for the container metadata + the section-data active
+    # bindings. The parser writes these directly so loading does not invalidate
+    # the validation cache.
     .schemaVersion = NULL,
     .esqlabsRVersion = NULL,
+    .name = NULL,
+    .description = NULL,
+    .definitionsFolder = NULL,
+    .defaultSimulationRunOptions = NULL,
     .outputPaths = NULL,
     .scenarios = NULL,
-    .modelParameterSets = NULL,
-    .individualParameterSets = NULL,
-    .applicationParameterSets = NULL,
+    .parameterSets = NULL,
+    .initialConditions = NULL,
     .individuals = NULL,
     .populations = NULL,
     .applications = NULL,
     .observedData = NULL,
+    .dataCombined = NULL,
     .plots = NULL,
-    .parameterIdentification = list(),
+    .plotGrids = NULL,
+    .parameterIdentification = NULL,
 
+    # Resolve a section kind to its private backing-field name (`.<kind>`),
+    # aborting on an unknown kind. Each section maps one-to-one onto a private
+    # backing field named `.<kind>` and onto its `definitions/<kind>/` tree. The
+    # set of valid kinds is the single source of truth `.entityKindNames()`
+    # (derived from the entity-tree specs), so a typo cannot silently create a
+    # stray `private$.<typo>` field and the kind list is not duplicated here.
+    .sectionField = function(kind) {
+      if (
+        !is.character(kind) ||
+          length(kind) != 1L ||
+          !(kind %in% .entityKindNames())
+      ) {
+        cli::cli_abort("Unknown project section {.val {kind}}.")
+      }
+      paste0(".", kind)
+    },
+
+    # Invalidate the validation cache. Any mutation clears
+    # `validatedSinceMutation` so the next `runScenarios()` / `createPlots()`
+    # re-validates the new shape.
     .invalidate = function() {
-      private$.modified <- TRUE
       private$.validatedSinceMutation <- FALSE
       invisible(self)
+    },
+
+    # Container-metadata edit: invalidate the validation cache, then write the
+    # container through to `Project.json` so the metadata (schema/version, file
+    # paths, folders) is persisted immediately, just as every section is.
+    .invalidateContainer = function() {
+      private$.invalidate()
+      private$.persistContainer()
+      invisible(self)
+    },
+
+    # Write the `Project.json` container (every inline section emptied, the
+    # tree owns them) to the project's own location, when this instance owns
+    # its entity tree. A NULL directory (in-memory project) or a non-owning
+    # clone is a silent no-op (its container edits stay in memory until it is
+    # bound to its own location).
+    .persistContainer = function() {
+      if (is.null(private$.projectFilePath) || !private$.ownsEntityTree()) {
+        return(invisible(NULL))
+      }
+      .saveProjectJson(
+        self,
+        private$.projectFilePath,
+        containerOnly = TRUE
+      )
+      invisible(NULL)
+    },
+
+    # Record this instance as the owner of its entity tree. Called whenever
+    # the project binds to a directory (`.read_json`, `.rebindPath`).
+    .claimEntityTree = function() {
+      private$.entityTreeOwnerToken <- new.env(parent = emptyenv())
+      private$.entityTreeOwnerToken$owner <- self
+      invisible(self)
+    },
+
+    # TRUE only when this instance recorded itself as the entity-tree owner.
+    # A clone shares the token by reference (its `owner` is the source), so it
+    # is not the owner until a re-bind to its own location.
+    .ownsEntityTree = function() {
+      token <- private$.entityTreeOwnerToken
+      !is.null(token) && identical(token$owner, self)
+    },
+
+    # Write-through for one project section: persist only what changed to its
+    # `definitions/<kind>/` tree. Every section now maps one-to-one onto a kind
+    # (the plots trio was split into three top-level sections
+    # `dataCombined` / `plots` / `plotGrids`, each its own keyed kind).
+    .persistSectionChanges = function(kind, old, new) {
+      private$.persistKindChanges(kind, old, new)
+    },
+
+    # Persist one kind's changes (the unit a single `definitions/<kind>/` tree
+    # owns). Persist only what changed between the old and new section value.
+    #
+    # An in-memory project (no directory) is a silent no-op, and so is a clone
+    # that does not own the tree (its mutations stay in memory until a re-bind
+    # to its own location). The caller invokes this before it updates the
+    # in-memory backing store, so a structural failure during serialization
+    # aborts the write and leaves both disk and memory unchanged.
+    #
+    # First write into a project whose `definitions/<kind>/` directory does not
+    # yet exist (a snapshot-loaded project, whose sections were inlined in
+    # `Project.json` with no tree on disk) takes a full-materialize path: the
+    # diff-only path would write just the changed entity and assume the
+    # untouched siblings already exist as files, but they do not, so on the
+    # next load the now-present tree would win and the inline siblings would be
+    # lost. `new` is the authoritative full set to write; the dir was absent,
+    # so there is nothing stale to remove.
+    .persistKindChanges = function(kind, old, new) {
+      spec <- .entityTreeSpec(kind)
+      dir <- .entityKindDir(
+        private$.projectDirPath,
+        spec$kind,
+        self$definitionsFolder
+      )
+      if (is.null(dir)) {
+        return(invisible(NULL))
+      }
+      if (!private$.ownsEntityTree()) {
+        return(invisible(NULL))
+      }
+
+      # First write into a not-yet-materialized tree writes the full set.
+      if (!dir.exists(dir)) {
+        .writeEntityTree(new, kind, self, private$.projectDirPath)
+        return(invisible(NULL))
+      }
+
+      old <- old %||% list()
+      new <- new %||% list()
+
+      # A keyed kind is a named map whose names are the entity ids (which equal
+      # the on-disk filenames). For such a kind the diff is computed directly on
+      # the in-memory maps (by key presence and per-entity value identity) and
+      # only the entities that actually changed are serialized and written, so a
+      # single mutation costs O(changed entities), not O(section size). The
+      # plots `plotConfiguration` / `plotGrids` parts are keyed lists, so they
+      # take this fast path too. An `observedData` section is an unnamed list
+      # keyed by a derived id (its `names()` are not the on-disk ids), so it
+      # cannot be diffed by name and falls back to the whole-section serialize
+      # diff below (it is small and never a buildup hot path).
+      keyed <- !is.data.frame(new) &&
+        !is.data.frame(old) &&
+        (length(new) == 0L || !is.null(names(new)))
+      if (keyed && (length(old) == 0L || !is.null(names(old)))) {
+        newNames <- names(new)
+        oldNames <- names(old)
+        # Added ids are new keys absent from old; removed ids are old keys
+        # absent from new (both via cheap name set ops, no value comparison).
+        # An id present in both whose value object is not the very same record
+        # (an in-place edit) is changed. `match()` aligns the common keys so
+        # only those need the per-entity `identical()` check, keeping the diff
+        # proportional to the number of common keys without re-checking added
+        # ones.
+        inOld <- newNames %in% oldNames
+        addedIds <- newNames[!inOld]
+        commonIds <- newNames[inOld]
+        # Extract the common-key sublists once (C-level subset) and compare them
+        # as whole objects first: an unchanged element shares its record object
+        # with the old list (an `[[<-` mutation does not copy untouched
+        # siblings), so when nothing in the common set changed this single
+        # `identical()` short-circuits on reference equality with no R-level
+        # per-element loop. Only when some common entity did change (an in-place
+        # edit) do we fall back to a per-element scan to find which one(s).
+        nc <- new[commonIds]
+        oc <- old[commonIds]
+        changedCommon <- character()
+        if (length(commonIds) > 0L && !identical(nc, oc)) {
+          changedCommon <- commonIds[
+            !vapply(
+              seq_along(commonIds),
+              function(i) identical(nc[[i]], oc[[i]]),
+              logical(1),
+              USE.NAMES = FALSE
+            )
+          ]
+        }
+        changedIds <- c(addedIds, changedCommon)
+        # Serialize only the changed entities (validating each), in memory and
+        # before writing any file, so a serializer-hostile record aborts the
+        # whole write and leaves the tree (and the not-yet-updated in-memory
+        # store) unchanged. The serializer also enforces that each key is a
+        # canonical (lowercase, safe) id, so two keys can never collide on a
+        # case-insensitive filesystem.
+        if (length(changedIds) > 0L) {
+          serializedChanged <- spec$serialize(new[changedIds], self)
+          for (id in names(serializedChanged)) {
+            .writeEntityJson(serializedChanged[[id]], .entityFilePath(dir, id))
+          }
+        }
+        # A genuinely-removed entity's on-disk id is its serialized key; for a
+        # keyed kind that equals the map key, so the removed files can be deleted
+        # without serializing.
+        #
+        # Stale removal is reconciled against the previous in-memory section
+        # (`old`), not against the directory listing. So a file created
+        # out-of-band on disk (an orphan with no in-memory entity, e.g. one a
+        # concurrent process or a hand-edit dropped in) is not deleted by an
+        # unrelated mutation here; it survives until the next `loadProject()`,
+        # which re-reads the whole tree and re-derives the section from what is
+        # actually on disk. This is deliberate: the in-memory diff cannot tell an
+        # orphan from a sibling it simply did not load, and reconciling against
+        # the directory on every write would couple each mutation to a directory
+        # scan for no data-safety gain (no entity is lost; the orphan is just
+        # picked up, or ignored, on the next load).
+        for (id in oldNames[!(oldNames %in% newNames)]) {
+          f <- .entityFilePath(dir, id)
+          if (file.exists(f)) {
+            file.remove(f)
+          }
+        }
+        return(invisible(NULL))
+      }
+
+      # Fallback for a kind whose on-disk id is derived rather than the map key
+      # (the unnamed `observedData` list): serialize the full old and new
+      # sections to their `id -> record` maps in memory before writing any file
+      # (same atomicity guarantee), then diff on the derived ids.
+      serializedNew <- spec$serialize(new, self)
+      serializedOld <- spec$serialize(old, self)
+      changed <- Filter(
+        function(id) !identical(serializedNew[[id]], serializedOld[[id]]),
+        names(serializedNew)
+      )
+      for (id in changed) {
+        .writeEntityJson(serializedNew[[id]], .entityFilePath(dir, id))
+      }
+      for (id in setdiff(names(serializedOld), names(serializedNew))) {
+        f <- .entityFilePath(dir, id)
+        if (file.exists(f)) {
+          file.remove(f)
+        }
+      }
+      invisible(NULL)
     },
 
     .replace_env_var = function(path) {
@@ -689,36 +1125,84 @@ Project <- R6::R6Class(
       }
       private$.schemaVersion <- jsonData$schemaVersion
       private$.esqlabsRVersion <- jsonData$esqlabsRVersion
+      private$.name <- jsonData$name
+      private$.description <- jsonData$description
+      private$.definitionsFolder <- jsonData$definitionsFolder
+      private$.defaultSimulationRunOptions <- jsonData$defaultSimulationRunOptions
       private$.projectFilePath <- jsonPath
       private$.projectDirPath <- dirname(jsonPath)
+      private$.claimEntityTree()
 
+      # The container separates two concerns: the four live working folders
+      # (the `filePaths` block) the runtime reads, and the seven Excel-bridge
+      # sheet-name fields (the `excel` block) only the Excel bridge reads. A
+      # legacy project carries all eleven in one flat `filePaths` block; split
+      # it on read so both on-disk shapes load (the field-to-block mapping is
+      # fixed, so the partition is deterministic). A new-shape project reads
+      # each block from its own key; any Excel field that still appears in
+      # `filePaths` (e.g. a hand-edited file) is routed to the Excel store too.
       fp <- jsonData$filePaths %||% list()
+      excel <- jsonData$excel %||% list()
       private$.filePathsData <- list()
+      private$.excelData <- list()
       for (n in names(fp)) {
-        private$.filePathsData[[n]] <- list(value = fp[[n]], description = "")
+        if (n %in% .excelFilePathFields) {
+          private$.excelData[[n]] <- list(value = fp[[n]], description = "")
+        } else {
+          private$.filePathsData[[n]] <- list(value = fp[[n]], description = "")
+        }
+      }
+      for (n in names(excel)) {
+        private$.excelData[[n]] <- list(value = excel[[n]], description = "")
       }
 
-      private$.outputPaths <- jsonData$outputPaths %||% list()
-      private$.modelParameterSets <- jsonData$modelParameterSets %||% list()
-      private$.individualParameterSets <- jsonData$individualParameterSets %||%
-        list()
-      private$.applicationParameterSets <- jsonData$applicationParameterSets %||%
-        list()
-      private$.individuals <- .parseIndividuals(jsonData$individuals)
-      private$.populations <- .parsePopulations(jsonData$populations)
-      private$.applications <- .parseApplications(jsonData$applications)
-      private$.scenarios <- .parseScenarios(
-        jsonData$scenarios,
-        private$.outputPaths
+      # Every authored section is an entity tree under `definitions/<kind>/`; a
+      # single-file snapshot with no tree falls back to the inline section in
+      # `Project.json`. `.loadEntityTree()` resolves tree-vs-inline per kind and
+      # the kind's spec parses the raw records into the in-memory shape. Output
+      # paths load before scenarios because scenarios dereference their
+      # `outputPathIds` against the project-level `outputPaths` map. The
+      # `parameterSets` inline fallback merges any legacy three-section
+      # `Project.json` into the one map (a clash aborts the load).
+      private$.outputPaths <- private$.loadSection("outputPaths", jsonData)
+      private$.parameterSets <- private$.loadSection("parameterSets", jsonData)
+      private$.initialConditions <- private$.loadSection(
+        "initialConditions",
+        jsonData
       )
-      private$.observedData <- jsonData$observedData %||% list()
-      private$.plots <- .parsePlots(jsonData$plots)
-      private$.parameterIdentification <- .parsePITasks(
-        jsonData$parameterIdentification
+      private$.individuals <- private$.loadSection("individuals", jsonData)
+      private$.populations <- private$.loadSection("populations", jsonData)
+      private$.applications <- private$.loadSection("applications", jsonData)
+      private$.scenarios <- private$.loadSection("scenarios", jsonData)
+      private$.observedData <- private$.loadSection("observedData", jsonData)
+      # The plots concern is three independent top-level sections, each its own
+      # keyed kind: `dataCombined` (`definitions/data-combined/`), `plots`
+      # (`definitions/plots/`, the plot list), and `plotGrids`
+      # (`definitions/plot-grids/`). Each loads from its own tree (or its own
+      # top-level inline snapshot section as the fallback).
+      private$.dataCombined <- private$.loadSection("dataCombined", jsonData)
+      private$.plots <- private$.loadSection("plots", jsonData)
+      private$.plotGrids <- private$.loadSection("plotGrids", jsonData)
+      private$.parameterIdentification <- private$.loadSection(
+        "parameterIdentification",
+        jsonData
       )
 
-      private$.modified <- FALSE
       private$.validatedSinceMutation <- FALSE
+    },
+
+    # Load one section: read its `definitions/<kind>/` tree (or the inline
+    # snapshot fallback) and parse the raw records into the in-memory shape via
+    # the kind's spec.
+    .loadSection = function(kind, jsonData) {
+      spec <- .entityTreeSpec(kind)
+      records <- .loadEntityTree(
+        private$.projectDirPath,
+        kind,
+        spec$inline(jsonData),
+        self$definitionsFolder
+      )
+      spec$parse(records, self)
     }
   )
 )

--- a/tests/testthat/_snaps/project.md
+++ b/tests/testthat/_snaps/project.md
@@ -1,3 +1,44 @@
+# a whole-section assignment through a section accessor is rejected
+
+    Code
+      project$scenarios <- list()
+    Condition
+      Error:
+      ! scenarios is read-only and cannot be assigned into.
+      i To change a definition, edit its '.json' file or use an authoring function (e.g. `addScenario()` / `setScenario()` / `removeScenario()` and their per-section siblings).
+      i To edit one record, read it, change the copy, then re-submit it with an authoring function: `sc <- project$scenarios[["id"]]; sc$field <- value; setScenario(project, "id", ...)`.
+
+# a subscript assignment through a section accessor is rejected
+
+    Code
+      project$scenarios[["aciclovir_iv"]] <- Scenario(scenarioName = "aciclovir_iv",
+        modelFile = "m.pkml")
+    Condition
+      Error in `[[<-`:
+      ! scenarios is read-only and cannot be assigned into.
+      i To change a definition, edit its '.json' file or use an authoring function (e.g. `addScenario()` / `setScenario()` / `removeScenario()` and their per-section siblings).
+      i To edit one record, read it, change the copy, then re-submit it with an authoring function: `sc <- project$scenarios[["id"]]; sc$field <- value; setScenario(project, "id", ...)`.
+
+# a nested field assignment through a section accessor is rejected
+
+    Code
+      project$scenarios[["testscenario"]]$individualId <- "indiv1"
+    Condition
+      Error in `[[<-`:
+      ! scenarios is read-only and cannot be assigned into.
+      i To change a definition, edit its '.json' file or use an authoring function (e.g. `addScenario()` / `setScenario()` / `removeScenario()` and their per-section siblings).
+      i To edit one record, read it, change the copy, then re-submit it with an authoring function: `sc <- project$scenarios[["id"]]; sc$field <- value; setScenario(project, "id", ...)`.
+
+# a negative-index assignment through a section accessor is rejected
+
+    Code
+      project$scenarios[-1] <- list()
+    Condition
+      Error in `[<-`:
+      ! scenarios is read-only and cannot be assigned into.
+      i To change a definition, edit its '.json' file or use an authoring function (e.g. `addScenario()` / `setScenario()` / `removeScenario()` and their per-section siblings).
+      i To edit one record, read it, change the copy, then re-submit it with an authoring function: `sc <- project$scenarios[["id"]]; sc$field <- value; setScenario(project, "id", ...)`.
+
 # jsonPath is read-only and aliases projectFilePath
 
     Code
@@ -5,4 +46,60 @@
     Condition
       Error:
       ! jsonPath is readonly
+
+# a section accessor prints a count and the definition names
+
+    Code
+      print(project$individuals)
+    Output
+      <DefinitionList>
+      individuals (1 definition):
+        * indiv1
+
+---
+
+    Code
+      print(project$parameterSets)
+    Output
+      <DefinitionList>
+      parameterSets (4 definitions):
+        * aciclovir
+        * aciclovir_iv_250mg_default
+        * global
+        * indiv1_default
+
+# an empty section accessor prints zero definitions
+
+    Code
+      print(project$individuals)
+    Output
+      <DefinitionList>
+      individuals (0 definitions):
+
+# the three plots sections each print a count and ids
+
+    Code
+      print(project$plots)
+    Output
+      <DefinitionList>
+      plots (1 definition):
+        * p1
+
+---
+
+    Code
+      print(project$plotGrids)
+    Output
+      <DefinitionList>
+      plotGrids (1 definition):
+        * individual_diagnostics
+
+---
+
+    Code
+      print(project$dataCombined)
+    Output
+      <DefinitionList>
+      dataCombined (1 definition):
+        * aciclovir_individual
 

--- a/tests/testthat/test-project-to-json.R
+++ b/tests/testthat/test-project-to-json.R
@@ -13,22 +13,66 @@ test_that(".projectToJson() returns a JSON-shaped list with the canonical top-le
     c(
       "schemaVersion",
       "esqlabsRVersion",
+      "name",
+      "description",
+      "definitionsFolder",
       "filePaths",
+      "defaultSimulationRunOptions",
       "observedData",
       "outputPaths",
       "scenarios",
-      "modelParameterSets",
+      "parameterSets",
+      "initialConditions",
       "individuals",
-      "individualParameterSets",
       "populations",
       "applications",
-      "applicationParameterSets",
+      "dataCombined",
       "plots",
-      "parameterIdentification"
+      "plotGrids",
+      "parameterIdentification",
+      # The Excel-bridge block is emitted only when the project carries
+      # Excel-bridge fields (the bundled example does).
+      "excel"
     ),
     ignore.order = TRUE
   )
   expect_identical(tree$schemaVersion, "2.0")
+})
+
+test_that(".projectToJson() splits the container path fields into filePaths and excel", {
+  project <- exampleProject()
+  tree <- esqlabsR:::.projectToJson(project)
+
+  # The four live working folders stay in `filePaths`.
+  expect_named(
+    tree$filePaths,
+    c("modelFolder", "populationsFolder", "dataFolder", "outputFolder"),
+    ignore.order = TRUE
+  )
+  # The seven Excel-bridge sheet names move to the `excel` block.
+  expect_named(
+    tree$excel,
+    c(
+      "configurationsFolder",
+      "modelParamsFile",
+      "individualsFile",
+      "populationsFile",
+      "scenariosFile",
+      "applicationsFile",
+      "plotsFile"
+    ),
+    ignore.order = TRUE
+  )
+})
+
+test_that(".projectToJson() omits the excel block for a from-scratch project", {
+  project <- Project$new()
+  tree <- esqlabsR:::.projectToJson(project)
+
+  expect_false("excel" %in% names(tree))
+  expect_null(tree$name)
+  expect_null(tree$description)
+  expect_null(tree$defaultSimulationRunOptions)
 })
 
 test_that(".projectToJson() rejects non-Project input", {
@@ -89,16 +133,8 @@ test_that("round-trip is structurally identical for the bundled example", {
   expect_identical(reloaded$filePaths, project$filePaths)
   expect_identical(reloaded$outputPaths, project$outputPaths)
   expect_identical(
-    reloaded$modelParameterSets,
-    project$modelParameterSets
-  )
-  expect_identical(
-    reloaded$individualParameterSets,
-    project$individualParameterSets
-  )
-  expect_identical(
-    reloaded$applicationParameterSets,
-    project$applicationParameterSets
+    reloaded$parameterSets,
+    project$parameterSets
   )
   expect_identical(reloaded$individuals, project$individuals)
   expect_identical(reloaded$populations, project$populations)
@@ -119,17 +155,17 @@ test_that("round-trip is structurally identical for the bundled example", {
   )
 })
 
-test_that(".dataCombinedToNestedJson re-adds the name field and drops empty sublists", {
+test_that(".dataCombinedToNestedJson re-adds the id field and drops empty sublists", {
   parsed <- list(
     DC1 = list(simulated = list(list(label = "a")), observed = list()),
     DC2 = list(simulated = list(), observed = list(list(label = "b")))
   )
   json <- esqlabsR:::.dataCombinedToNestedJson(parsed)
   expect_length(json, 2)
-  expect_equal(json[[1]]$name, "DC1")
+  expect_equal(json[[1]]$dataCombinedId, "DC1")
   expect_equal(json[[1]]$simulated[[1]]$label, "a")
   expect_null(json[[1]]$observed) # empty observed dropped
-  expect_equal(json[[2]]$name, "DC2")
+  expect_equal(json[[2]]$dataCombinedId, "DC2")
   expect_null(json[[2]]$simulated)
   expect_equal(json[[2]]$observed[[1]]$label, "b")
 })
@@ -139,20 +175,33 @@ test_that(".dataCombinedToNestedJson handles NULL and empty input", {
   expect_identical(esqlabsR:::.dataCombinedToNestedJson(NULL), list())
 })
 
-test_that(".dataFrameToListOfLists drops NA cells per row", {
-  df <- data.frame(
-    plotId = c("P1", "P2"),
-    plotType = c("individual", "population"),
-    title = c("T1", NA),
-    stringsAsFactors = FALSE
+test_that(".plotEntriesToJson strips the entry class and drops the list name", {
+  entries <- list(
+    P1 = structure(
+      list(plotId = "P1", plotType = "individual", title = "T1"),
+      class = c("Plot", "list")
+    ),
+    P2 = structure(
+      list(plotId = "P2", plotType = "population"),
+      class = c("Plot", "list")
+    )
   )
-  result <- esqlabsR:::.dataFrameToListOfLists(df)
+  result <- esqlabsR:::.plotEntriesToJson(entries)
+  # A plain unnamed array of records, with the Plot class stripped so it never
+  # leaks into JSON.
+  expect_null(names(result))
   expect_length(result, 2)
+  expect_identical(class(result[[1]]), "list")
   expect_equal(result[[1]]$title, "T1")
-  expect_null(result[[2]]$title) # NA dropped
+  expect_false("title" %in% names(result[[2]]))
 })
 
-test_that(".plotsToJson returns NULL when project has no plots section", {
+test_that(".plotEntriesToJson returns an empty list for NULL or empty", {
+  expect_identical(esqlabsR:::.plotEntriesToJson(NULL), list())
+  expect_identical(esqlabsR:::.plotEntriesToJson(list()), list())
+})
+
+test_that("the plots-section serializers return NULL when empty", {
   tmp <- withr::local_tempfile(fileext = ".json")
   jsonlite::write_json(
     list(schemaVersion = "2.0", esqlabsRVersion = "6.0.0"),
@@ -160,7 +209,9 @@ test_that(".plotsToJson returns NULL when project has no plots section", {
     auto_unbox = TRUE
   )
   project <- loadProject(tmp)
-  expect_null(esqlabsR:::.plotsToJson(project))
+  expect_null(esqlabsR:::.dataCombinedSectionToJson(project))
+  expect_null(esqlabsR:::.plotsSectionToJson(project))
+  expect_null(esqlabsR:::.plotGridsSectionToJson(project))
 })
 
 test_that("round-trip preserves length-1 arrays as arrays, not scalars", {
@@ -169,12 +220,12 @@ test_that("round-trip preserves length-1 arrays as arrays, not scalars", {
   esqlabsR:::.saveProjectJson(project, out)
 
   raw <- jsonlite::fromJSON(out, simplifyVector = FALSE)
-  # outputPathIds for Aciclovir_iv has one entry; auto_unbox must
+  # outputPaths for Aciclovir_iv has one entry; auto_unbox must
   # not collapse it to a scalar string.
-  ids <- raw$scenarios[[1L]]$outputPathIds
+  ids <- raw$scenarios[[1L]]$outputPaths
   expect_type(ids, "list")
   expect_length(ids, 1L)
-  expect_identical(ids[[1L]], "Aciclovir_PVB")
+  expect_identical(ids[[1L]], "aciclovir_pvb")
 })
 
 test_that("round-trip preserves NULL fields", {
@@ -183,10 +234,10 @@ test_that("round-trip preserves NULL fields", {
   esqlabsR:::.saveProjectJson(project, out)
 
   raw <- jsonlite::fromJSON(out, simplifyVector = FALSE)
-  # The first scenario has populationId: null and steadyStateTime: null.
+  # The first scenario has population: null and steadyStateTime: null.
   # Without `null = "null"`, jsonlite would drop them; the field would be
   # absent on reload, breaking equality.
-  expect_null(raw$scenarios[[1L]]$populationId)
+  expect_null(raw$scenarios[[1L]]$population)
   expect_null(raw$scenarios[[1L]]$steadyStateTime)
 })
 
@@ -242,9 +293,8 @@ test_that("empty map sections serialize as JSON objects, not arrays", {
   expect_match(text, '"filePaths":\\s*\\{\\s*\\}')
   expect_match(text, '"outputPaths":\\s*\\{\\s*\\}')
   expect_match(text, '"applications":\\s*\\{\\s*\\}')
-  expect_match(text, '"modelParameterSets":\\s*\\{\\s*\\}')
-  expect_match(text, '"individualParameterSets":\\s*\\{\\s*\\}')
-  expect_match(text, '"applicationParameterSets":\\s*\\{\\s*\\}')
+  expect_match(text, '"parameterSets":\\s*\\{\\s*\\}')
+  expect_match(text, '"initialConditions":\\s*\\{\\s*\\}')
   expect_match(text, '"scenarios":\\s*\\[\\s*\\]')
   expect_match(text, '"individuals":\\s*\\[\\s*\\]')
   expect_match(text, '"populations":\\s*\\[\\s*\\]')
@@ -268,13 +318,17 @@ test_that("empty map sections survive a round-trip as empty named lists", {
   # sections that way), so jsonlite returns a *named* empty list. The
   # contract is that this representation is stable: a second save/reload
   # produces an identical structure.
+  # Section accessors wrap the stored list in a printable DefinitionList; unwrap
+  # to assert the underlying named-empty shape.
   empty_named <- structure(list(), names = character(0L))
   expect_identical(reloaded$filePaths, empty_named)
-  expect_identical(reloaded$outputPaths, empty_named)
-  expect_identical(reloaded$applications, empty_named)
-  expect_identical(reloaded$modelParameterSets, empty_named)
-  expect_identical(reloaded$individualParameterSets, empty_named)
-  expect_identical(reloaded$applicationParameterSets, empty_named)
+  expect_identical(.unwrapDefinitionList(reloaded$outputPaths), empty_named)
+  expect_identical(.unwrapDefinitionList(reloaded$applications), empty_named)
+  expect_identical(.unwrapDefinitionList(reloaded$parameterSets), empty_named)
+  expect_identical(
+    .unwrapDefinitionList(reloaded$initialConditions),
+    empty_named
+  )
 
   # And the round-trip is stable from there: re-saving and re-loading does
   # not drift further.
@@ -285,16 +339,39 @@ test_that("empty map sections survive a round-trip as empty named lists", {
   expect_identical(reloaded2$outputPaths, reloaded$outputPaths)
   expect_identical(reloaded2$applications, reloaded$applications)
   expect_identical(
-    reloaded2$modelParameterSets,
-    reloaded$modelParameterSets
+    reloaded2$parameterSets,
+    reloaded$parameterSets
   )
-  expect_identical(
-    reloaded2$individualParameterSets,
-    reloaded$individualParameterSets
+})
+
+test_that("a populated initialConditions section round-trips through a snapshot", {
+  # An inline snapshot with one initial-condition set. Loading it, saving a
+  # snapshot, and reloading yields an identical section (a fixed point).
+  src <- withr::local_tempfile(fileext = ".json")
+  jsonlite::write_json(
+    list(
+      schemaVersion = "2.0",
+      esqlabsRVersion = "6.0.0",
+      initialConditions = list(
+        testinitialset = list(
+          list(path = "Organism|A|Concentration", value = 1.5, unit = "mg/l"),
+          list(path = "Organism|B|Concentration", value = 0.5, unit = "µmol/l")
+        )
+      )
+    ),
+    src,
+    auto_unbox = TRUE
   )
+  project <- loadProject(src)
+  expect_named(project$initialConditions, "testinitialset")
+  expect_length(project$initialConditions$testinitialset, 2L)
+
+  out <- withr::local_tempfile(fileext = ".json")
+  esqlabsR:::.saveProjectJson(project, out)
+  reloaded <- loadProject(out)
   expect_identical(
-    reloaded2$applicationParameterSets,
-    reloaded$applicationParameterSets
+    reloaded$initialConditions,
+    project$initialConditions
   )
 })
 
@@ -305,7 +382,7 @@ test_that("round-trip preserves a steady-state scenario including unit conversio
 
   raw <- jsonlite::fromJSON(out, simplifyVector = FALSE)
   ss <- Filter(
-    function(s) s$name == "Aciclovir_iv_steadystate",
+    function(s) s$name == "aciclovir_iv_steadystate",
     raw$scenarios
   )[[1L]]
 
@@ -317,22 +394,22 @@ test_that("round-trip preserves a steady-state scenario including unit conversio
   expect_identical(ss$steadyStateTimeUnit, "h")
 })
 
-test_that("round-trip preserves outputPathIds order", {
+test_that("round-trip preserves outputPaths order", {
   project <- exampleProject()
   out <- withr::local_tempfile(fileext = ".json")
   esqlabsR:::.saveProjectJson(project, out)
 
   raw <- jsonlite::fromJSON(out, simplifyVector = FALSE)
   ss <- Filter(
-    function(s) s$name == "Aciclovir_iv_steadystate",
+    function(s) s$name == "aciclovir_iv_steadystate",
     raw$scenarios
   )[[1L]]
 
   # JSON declared fat_cell, PVB (non-alphabetical). The order must be
   # preserved through parse -> serialize.
   expect_identical(
-    ss$outputPathIds,
-    list("Aciclovir_fat_cell", "Aciclovir_PVB")
+    ss$outputPaths,
+    list("aciclovir_fat_cell", "aciclovir_pvb")
   )
 })
 
@@ -340,7 +417,7 @@ test_that("steadyState=false with a declared time and unit round-trips", {
   raw <- list(
     list(
       name = "S",
-      individualId = "I",
+      individual = "I",
       modelFile = "m.pkml",
       steadyState = FALSE,
       steadyStateTime = 2,
@@ -369,7 +446,7 @@ test_that("a standalone simulationTimeUnit round-trips when simulationTime is nu
   raw <- list(
     list(
       name = "S",
-      individualId = "I",
+      individual = "I",
       modelFile = "m.pkml",
       simulationTimeUnit = "h"
     )
@@ -385,7 +462,7 @@ test_that("a standalone simulationTimeUnit round-trips when simulationTime is nu
   expect_identical(out$simulationTimeUnit, "h")
 })
 
-test_that("populationId is emitted even when simulationType has drifted", {
+test_that("population is emitted even when simulationType has drifted", {
   sc <- Scenario(
     scenarioName = "S",
     modelFile = "m.pkml",
@@ -397,7 +474,7 @@ test_that("populationId is emitted even when simulationType has drifted", {
 
   project <- .fakeProject(scenarios = list(S = sc))
   out <- esqlabsR:::.scenariosToJson(project)[[1L]]
-  expect_identical(out$populationId, "Pop")
+  expect_identical(out$population, "Pop")
 })
 
 test_that(".validateScenarios warns on populationId / simulationType drift", {
@@ -409,28 +486,24 @@ test_that(".validateScenarios warns on populationId / simulationType drift", {
   expect_true(any(grepl("populationId but simulationType", msgs)))
 })
 
-test_that(".scenariosToJson errors when scenario outputPaths reference unknown ids", {
-  project <- exampleProject()
-  # Mutate the first scenario to add a named path whose id is not in
-  # project$outputPaths. (Parser would have rejected this, but a Chapter
-  # 7+ programmatic mutation could land us here.)
-  project$scenarios[[1L]]$outputPaths <- c(
-    project$scenarios[[1L]]$outputPaths,
-    c(UnknownId = "Organism|NotDeclared|Path")
-  )
+test_that(".scenariosToJson keeps unknown outputPaths (referential, lazy)", {
+  # An unknown outputPathId is a referential issue caught lazily by the
+  # cross-reference validator, not a serialization error: the id round-trips
+  # verbatim so a transiently-dangling reference is not lost on save.
+  sc <- Scenario(scenarioName = "S", modelFile = "m.pkml")
+  sc$outputPaths <- c(UnknownId = "Organism|NotDeclared|Path")
+  project <- .fakeProject(scenarios = list(S = sc))
 
-  expect_error(
-    esqlabsR:::.projectToJson(project),
-    "unknown outputPathIds.*UnknownId"
-  )
+  out <- esqlabsR:::.scenariosToJson(project)[[1L]]
+  expect_identical(out$outputPaths, list("UnknownId"))
 })
 
 test_that(".scenariosToJson errors when outputPaths has unnamed elements", {
-  project <- exampleProject()
-  # Strip names to simulate a programmatic mutation that violates the invariant.
-  project$scenarios[[1L]]$outputPaths <- unname(
-    project$scenarios[[1L]]$outputPaths
-  )
+  # Build the bad state on an in-memory project so the serializer guard is
+  # exercised directly (a tree-backed project would fail-fast at write).
+  sc <- Scenario(scenarioName = "S", modelFile = "m.pkml")
+  sc$outputPaths <- unname(c(PVB = "Organism|PVB|Drug"))
+  project <- .fakeProject(scenarios = list(S = sc))
 
   expect_error(
     esqlabsR:::.projectToJson(project),
@@ -439,21 +512,24 @@ test_that(".scenariosToJson errors when outputPaths has unnamed elements", {
 })
 
 test_that(".scenariosToJson errors when simulateSteadyState is TRUE without a unit", {
-  project <- exampleProject()
-  # Aciclovir_iv has simulateSteadyState=FALSE and no unit.
-  # Flip the flag without setting the unit — the round-trip cannot
-  # carry the steady-state time, so the serializer must reject it.
-  project$scenarios[["Aciclovir_iv"]]$simulateSteadyState <- TRUE
+  # The round-trip cannot carry the steady-state time without a unit, so the
+  # serializer must reject it. Built on an in-memory project to exercise the
+  # serializer guard directly.
+  sc <- Scenario(scenarioName = "S", modelFile = "m.pkml")
+  sc$simulateSteadyState <- TRUE
+  project <- .fakeProject(scenarios = list(S = sc))
 
   expect_error(
     esqlabsR:::.projectToJson(project),
-    "Aciclovir_iv.*simulateSteadyState=TRUE.*steadyStateTimeUnit"
+    "S.*simulateSteadyState=TRUE.*steadyStateTimeUnit"
   )
 })
 
 test_that("round-trip preserves empty modelParameterSets as a JSON array", {
   project <- exampleProject()
-  project$scenarios[["Aciclovir_iv"]]$modelParameterSets <- character(0)
+  scenarios <- project$.getSection("scenarios")
+  scenarios[["aciclovir_iv"]]$modelParameterSets <- character(0)
+  project$.setSection("scenarios", scenarios)
 
   out <- withr::local_tempfile(fileext = ".json")
   esqlabsR:::.saveProjectJson(project, out)
@@ -461,21 +537,23 @@ test_that("round-trip preserves empty modelParameterSets as a JSON array", {
 
   # Empty modelParameterSets must serialise as `[]`, not `null`, so the
   # JSON shape stays an array.
-  mp <- raw$scenarios[[1L]]$modelParameterSets
+  mp <- raw$scenarios[[1L]]$parameterSets
   expect_type(mp, "list")
   expect_length(mp, 0L)
 })
 
-test_that("round-trip preserves empty outputPathIds as a JSON array", {
+test_that("round-trip preserves empty outputPaths as a JSON array", {
   project <- exampleProject()
-  project$scenarios[["Aciclovir_iv"]]$outputPaths <- NULL
+  scenarios <- project$.getSection("scenarios")
+  scenarios[["aciclovir_iv"]]$outputPaths <- NULL
+  project$.setSection("scenarios", scenarios)
 
   out <- withr::local_tempfile(fileext = ".json")
   esqlabsR:::.saveProjectJson(project, out)
   raw <- jsonlite::fromJSON(out, simplifyVector = FALSE)
 
   # Absent / empty outputPaths must serialise as `[]`, not `null`.
-  ids <- raw$scenarios[[1L]]$outputPathIds
+  ids <- raw$scenarios[[1L]]$outputPaths
   expect_type(ids, "list")
   expect_length(ids, 0L)
 })
@@ -492,11 +570,11 @@ test_that(".scenariosToJson preserves both ids when two ids map to the same lite
     },
     "scenarios": [{
       "name": "S",
-      "individualId": "I",
-      "populationId": null,
+      "individual": "I",
+      "population": null,
       "readPopulationFromCSV": false,
-      "modelParameterSets": [],
-      "applicationProtocol": null,
+      "parameterSets": [],
+      "application": null,
       "simulationTime": null,
       "simulationTimeUnit": null,
       "steadyState": false,
@@ -504,7 +582,7 @@ test_that(".scenariosToJson preserves both ids when two ids map to the same lite
       "steadyStateTimeUnit": null,
       "overwriteFormulasInSS": false,
       "modelFile": "M.pkml",
-      "outputPathIds": ["primary", "alias"]
+      "outputPaths": ["primary", "alias"]
     }],
     "modelParameterSets": {},
     "individuals": [],
@@ -518,5 +596,5 @@ test_that(".scenariosToJson preserves both ids when two ids map to the same lite
   project <- suppressWarnings(loadProject(jsonPath))
   rebuilt <- esqlabsR:::.scenariosToJson(project)
 
-  expect_equal(rebuilt[[1]]$outputPathIds, list("primary", "alias"))
+  expect_equal(rebuilt[[1]]$outputPaths, list("primary", "alias"))
 })

--- a/tests/testthat/test-project.R
+++ b/tests/testthat/test-project.R
@@ -3,7 +3,6 @@ test_that("Project$new() creates an empty in-memory project", {
   expect_s3_class(project, "Project")
   expect_null(project$projectFilePath)
   expect_null(project$projectDirPath)
-  expect_false(project$modified)
   expect_false(project$validatedSinceMutation)
 })
 
@@ -13,14 +12,7 @@ test_that("Project$new(path) loads a v2.0 JSON file", {
   )
   expect_s3_class(project, "Project")
   expect_equal(project$schemaVersion, "2.0")
-  expect_false(project$modified)
-})
-
-test_that("Excel-bridge file fields can be set and clear modified flag accordingly", {
-  project <- Project$new()
-  expect_false(project$modified)
-  project$modelParamsFile <- "X.xlsx"
-  expect_true(project$modified)
+  expect_false(project$validatedSinceMutation)
 })
 
 test_that("asList round-trips with .projectToJson", {
@@ -124,19 +116,11 @@ test_that("project$dataFolder is NULL when filePaths.dataFolder is unset", {
 })
 
 test_that("project path fields are writable after the merger", {
-  project <- loadProject(
-    system.file(
-      "extdata",
-      "projects",
-      "Example",
-      "Project.json",
-      package = "esqlabsR",
-      mustWork = TRUE
-    )
-  )
-  expect_false(project$modified)
+  tmp <- saveSnapshot(testProject(), local_projectPath())
+  project <- loadProject(tmp)
+
   project$modelFolder <- "AnotherModels"
-  expect_true(project$modified)
+  expect_match(project$modelFolder, "AnotherModels$")
 })
 
 test_that(".clean_path expands env vars (other than PATH) and resolves to absolute", {
@@ -209,8 +193,9 @@ test_that("loadProject() exposes filePaths verbatim", {
 
   expect_type(project$filePaths, "list")
   expect_identical(project$filePaths$modelFolder, "Models/Simulations/")
-  expect_identical(project$filePaths$configurationsFolder, "Configurations/")
   expect_identical(project$filePaths$dataFolder, "Data/")
+  # The Excel-bridge sheet names live in the separate `excel` block now.
+  expect_identical(project$excel$configurationsFolder, "Configurations/")
 })
 
 test_that("loadProject() preserves outputPaths as a named list", {
@@ -219,11 +204,11 @@ test_that("loadProject() preserves outputPaths as a named list", {
   expect_type(project$outputPaths, "list")
   expect_named(
     project$outputPaths,
-    c("Aciclovir_PVB", "Aciclovir_fat_cell"),
+    c("aciclovir_pvb", "aciclovir_fat_cell"),
     ignore.order = TRUE
   )
   expect_identical(
-    project$outputPaths$Aciclovir_PVB,
+    project$outputPaths$aciclovir_pvb,
     "Organism|PeripheralVenousBlood|Aciclovir|Plasma (Peripheral Venous Blood)"
   )
 })
@@ -235,74 +220,85 @@ test_that("loadProject() parses scenarios into Scenario objects keyed by name", 
   expect_length(project$scenarios, 3L)
   expect_named(
     project$scenarios,
-    c("Aciclovir_iv", "Aciclovir_iv_population", "Aciclovir_iv_steadystate")
+    c("aciclovir_iv", "aciclovir_iv_population", "aciclovir_iv_steadystate")
   )
 
-  first <- project$scenarios[["Aciclovir_iv"]]
+  first <- project$scenarios[["aciclovir_iv"]]
   expect_s3_class(first, "Scenario")
-  expect_identical(first$scenarioName, "Aciclovir_iv")
-  expect_identical(first$individualId, "Adult_male")
+  expect_identical(first$scenarioName, "aciclovir_iv")
+  expect_identical(first$individualId, "adult_male")
   expect_null(first$populationId)
-  expect_identical(first$modelParameterSets, c("Global", "Aciclovir"))
+  expect_identical(first$modelParameterSets, c("global", "aciclovir"))
 })
 
-test_that("loadProject() preserves modelParameterSets as a named list of sets", {
+test_that("loadProject() preserves parameterSets as a single named list of sets", {
   project <- exampleProject()
 
+  # The three former parameter-set kinds (model / individual / application)
+  # now share one `parameterSets` map keyed by set id.
   expect_named(
-    project$modelParameterSets,
-    c("Global", "Aciclovir"),
+    project$parameterSets,
+    c(
+      "global",
+      "aciclovir",
+      "adult_male_default",
+      "aciclovir_iv_250mg_default"
+    ),
     ignore.order = TRUE
   )
-  expect_length(project$modelParameterSets$Global, 1L)
+  expect_length(project$parameterSets$global, 1L)
   expect_identical(
-    project$modelParameterSets$Global[[1L]]$parameterName,
+    project$parameterSets$global[[1L]]$parameterName,
     "EHC continuous fraction"
   )
-})
-
-test_that("loadProject() preserves individualParameterSets as a named list of sets", {
-  project <- exampleProject()
-
-  expect_named(project$individualParameterSets, "Adult_male_default")
-  expect_length(project$individualParameterSets$Adult_male_default, 1L)
   expect_identical(
-    project$individualParameterSets$Adult_male_default[[1L]]$parameterName,
+    project$parameterSets$adult_male_default[[1L]]$parameterName,
     "GFR"
   )
-})
-
-test_that("loadProject() preserves applicationParameterSets as a named list of sets", {
-  project <- exampleProject()
-
-  expect_named(project$applicationParameterSets, "Aciclovir_iv_250mg_default")
-  expect_length(
-    project$applicationParameterSets$Aciclovir_iv_250mg_default,
-    1L
-  )
   expect_identical(
-    project$applicationParameterSets$Aciclovir_iv_250mg_default[[
-      1L
-    ]]$parameterName,
+    project$parameterSets$aciclovir_iv_250mg_default[[1L]]$parameterName,
     "Dose"
   )
+})
+
+test_that("loadProject() reads initialConditions and the binding is read-only", {
+  project <- testProject()
+  # The TestProject fixture carries one initial-condition set referenced by a
+  # scenario; the binding surfaces it keyed by set id.
+  expect_true("testinitialset" %in% names(project$initialConditions))
+  set <- project$initialConditions$testinitialset
+  expect_s3_class(set, "InitialConditionSet")
+  expect_identical(set[[1L]]$path, "Organism|VenousBlood|Plasma|Aciclovir")
+
+  expect_error(project$initialConditions <- list(), "read-only")
+})
+
+test_that("a project with no initial-conditions tree surfaces an empty section", {
+  blank <- loadProject(system.file(
+    "extdata",
+    "projects",
+    "Blank",
+    "Project.json",
+    package = "esqlabsR"
+  ))
+  expect_identical(.unwrapDefinitionList(blank$initialConditions), list())
 })
 
 test_that("loadProject() preserves individuals as a named list keyed by individualId", {
   project <- exampleProject()
 
-  expect_named(project$individuals, "Adult_male")
-  ind <- project$individuals[["Adult_male"]]
+  expect_named(project$individuals, "adult_male")
+  ind <- project$individuals[["adult_male"]]
   expect_s3_class(ind, "Individual")
   expect_identical(ind$gender, "MALE")
-  expect_identical(ind$parameterSets, "Adult_male_default")
+  expect_identical(ind$parameterSets, "adult_male_default")
 })
 
 test_that("loadProject() preserves populations as a named list keyed by populationId", {
   project <- exampleProject()
 
-  expect_named(project$populations, "European_adults")
-  pop <- project$populations[["European_adults"]]
+  expect_named(project$populations, "european_adults")
+  pop <- project$populations[["european_adults"]]
   expect_s3_class(pop, "Population")
   expect_identical(pop$numberOfIndividuals, 50)
 })
@@ -310,10 +306,10 @@ test_that("loadProject() preserves populations as a named list keyed by populati
 test_that("loadProject() preserves applications as a named list keyed by protocol name", {
   project <- exampleProject()
 
-  expect_named(project$applications, "Aciclovir_iv_250mg")
-  app <- project$applications[["Aciclovir_iv_250mg"]]
+  expect_named(project$applications, "aciclovir_iv_250mg")
+  app <- project$applications[["aciclovir_iv_250mg"]]
   expect_s3_class(app, "Application")
-  expect_identical(app$parameterSets, "Aciclovir_iv_250mg_default")
+  expect_identical(app$parameterSets, "aciclovir_iv_250mg_default")
 })
 
 test_that("loadProject() preserves the observedData section", {
@@ -326,28 +322,26 @@ test_that("loadProject() preserves the observedData section", {
   expect_identical(source$sheets, list("Laskin 1982.Group A"))
 })
 
-test_that("loadProject() parses plots into the asymmetric in-memory shape", {
+test_that("loadProject() parses plots into three top-level keyed sections", {
   project <- exampleProject()
 
-  expect_type(project$plots, "list")
-  expect_named(
-    project$plots,
-    c("dataCombined", "plotConfiguration", "plotGrids"),
-    ignore.order = TRUE
-  )
-  # dataCombined: named list keyed by name (no `name` field on entries)
-  expect_named(project$plots$dataCombined, "Aciclovir_individual")
-  dc <- project$plots$dataCombined$Aciclovir_individual
+  # dataCombined: named list keyed by id (no `dataCombinedId` field on entries)
+  expect_named(project$dataCombined, "aciclovir_individual")
+  dc <- project$dataCombined$aciclovir_individual
   expect_named(dc, c("simulated", "observed"), ignore.order = TRUE)
   expect_length(dc$simulated, 1L)
   expect_length(dc$observed, 1L)
-  # plotConfiguration / plotGrids: data.frames
-  expect_s3_class(project$plots$plotConfiguration, "data.frame")
-  expect_s3_class(project$plots$plotGrids, "data.frame")
-  expect_equal(nrow(project$plots$plotConfiguration), 1L)
-  expect_equal(nrow(project$plots$plotGrids), 1L)
-  expect_true("plotId" %in% names(project$plots$plotConfiguration))
-  expect_true("name" %in% names(project$plots$plotGrids))
+  # plots / plotGrids: keyed lists, each entry a classed named list of its
+  # rationalized fields.
+  expect_named(project$plots, "p1")
+  expect_named(project$plotGrids, "individual_diagnostics")
+  p1 <- project$plots$p1
+  expect_s3_class(p1, "Plot")
+  expect_identical(p1$plotId, "p1")
+  expect_identical(p1$dataCombinedId, "aciclovir_individual")
+  grid <- project$plotGrids$individual_diagnostics
+  expect_s3_class(grid, "PlotGrid")
+  expect_identical(grid$plotGridId, "individual_diagnostics")
 })
 
 test_that("loadProject() rejects a missing schemaVersion", {
@@ -418,27 +412,28 @@ test_that("loadProject() defaults missing optional sections to empty lists", {
 
   project <- loadProject(tmp)
 
+  # Section accessors wrap the stored list in a printable DefinitionList; unwrap
+  # to assert the underlying absent-vs-empty shape the parser produced.
   expect_identical(project$filePaths, structure(list(), names = character(0L)))
-  expect_identical(project$outputPaths, list())
-  expect_identical(project$scenarios, list())
-  expect_identical(project$modelParameterSets, list())
-  expect_identical(project$individualParameterSets, list())
-  expect_identical(project$applicationParameterSets, list())
-  expect_identical(project$individuals, list())
-  expect_identical(project$populations, list())
+  expect_identical(.unwrapDefinitionList(project$outputPaths), list())
+  expect_identical(.unwrapDefinitionList(project$scenarios), list())
+  expect_identical(.unwrapDefinitionList(project$parameterSets), list())
+  expect_identical(.unwrapDefinitionList(project$individuals), list())
+  expect_identical(.unwrapDefinitionList(project$populations), list())
   expect_identical(
-    project$applications,
+    .unwrapDefinitionList(project$applications),
     structure(list(), names = character(0L))
   )
-  expect_identical(project$observedData, list())
-  expect_null(project$plots)
+  expect_identical(.unwrapDefinitionList(project$observedData), list())
+  expect_identical(.unwrapDefinitionList(project$dataCombined), list())
+  expect_identical(.unwrapDefinitionList(project$plots), list())
+  expect_identical(.unwrapDefinitionList(project$plotGrids), list())
 })
 
 test_that("Project lifecycle fields are read-only", {
   project <- exampleProject()
 
   expect_error(project$validatedSinceMutation <- TRUE, "readonly")
-  expect_error(project$modified <- TRUE, "readonly")
 })
 
 test_that("Project$print() summarises section counts", {
@@ -449,77 +444,413 @@ test_that("Project$print() summarises section counts", {
   expect_output(print(project), "scenarios:\\s+3")
   expect_output(print(project), "individuals:\\s+1")
   expect_output(print(project), "populations:\\s+1")
-  # plotConfiguration is a 1-row, 15-column data frame: report 1 plot,
-  # not the column count.
+  # The three plots-related sections each report their entry count.
+  expect_output(print(project), "dataCombined:\\s+1")
+  expect_output(print(project), "plots:\\s+1")
+  expect_output(print(project), "plotGrids:\\s+1")
+})
+
+# Container rework: metadata, definitionsFolder, the filePaths/excel split,
+# and defaultSimulationRunOptions.
+
+test_that("loadProject() exposes name and description metadata", {
+  project <- exampleProject()
+  expect_identical(project$name, "Example")
+  expect_identical(project$description, "Aciclovir IV PK example project")
+})
+
+test_that("name and description are writable and persist write-through", {
+  project <- exampleProject()
+  project$name <- "Renamed"
+  project$description <- "A new description"
+  expect_identical(project$name, "Renamed")
+  expect_identical(project$description, "A new description")
+
+  reloaded <- loadProject(project$jsonPath)
+  expect_identical(reloaded$name, "Renamed")
+  expect_identical(reloaded$description, "A new description")
+})
+
+test_that("filePaths holds only the four live working folders", {
+  project <- exampleProject()
+  expect_named(
+    project$filePaths,
+    c("modelFolder", "populationsFolder", "dataFolder", "outputFolder"),
+    ignore.order = TRUE
+  )
+})
+
+test_that("excel exposes the seven Excel-bridge sheet-name fields", {
+  project <- exampleProject()
+  expect_named(
+    project$excel,
+    c(
+      "configurationsFolder",
+      "modelParamsFile",
+      "individualsFile",
+      "populationsFile",
+      "scenariosFile",
+      "applicationsFile",
+      "plotsFile"
+    ),
+    ignore.order = TRUE
+  )
+  expect_identical(project$excel$modelParamsFile, "ModelParameters.xlsx")
+})
+
+test_that("excel is read-only", {
+  project <- exampleProject()
+  expect_error(project$excel <- list(), "readonly")
+})
+
+test_that("a from-scratch project carries no excel block", {
+  project <- Project$new()
+  expect_length(project$excel, 0L)
+})
+
+test_that("definitionsFolder defaults to 'definitions' and is reported", {
+  project <- exampleProject()
+  expect_identical(project$definitionsFolder, "definitions")
+})
+
+test_that("a legacy flat-filePaths Project.json loads and splits the fields", {
+  tmp <- withr::local_tempfile(fileext = ".json")
+  jsonlite::write_json(
+    list(
+      schemaVersion = "2.0",
+      esqlabsRVersion = "6.0.0",
+      filePaths = list(
+        modelFolder = "Models/",
+        configurationsFolder = "Configurations/",
+        modelParamsFile = "ModelParameters.xlsx",
+        dataFolder = "Data/",
+        outputFolder = "Results/"
+      ),
+      outputPaths = structure(list(), names = character(0)),
+      scenarios = list()
+    ),
+    tmp,
+    auto_unbox = TRUE,
+    null = "null"
+  )
+  project <- loadProject(tmp)
+
+  expect_named(
+    project$filePaths,
+    c("modelFolder", "dataFolder", "outputFolder"),
+    ignore.order = TRUE
+  )
+  expect_named(
+    project$excel,
+    c("configurationsFolder", "modelParamsFile"),
+    ignore.order = TRUE
+  )
+})
+
+test_that("definitionsFolder honors a non-default tree location", {
+  # Write a tree project under a custom definitions folder, then load it.
+  src <- exampleProject()
+  scratch <- src$clone()
+  scratch$definitionsFolder <- "defs"
+  dir <- withr::local_tempdir("custom_defs_")
+  esqlabsR:::.writeProjectTree(scratch, dir)
+
+  expect_true(dir.exists(file.path(dir, "defs", "scenarios")))
+  expect_false(dir.exists(file.path(dir, "definitions")))
+
+  reloaded <- loadProject(file.path(dir, "Project.json"))
+  expect_identical(reloaded$definitionsFolder, "defs")
+  expect_length(reloaded$scenarios, 3L)
+})
+
+test_that("the tree wins over a conflicting non-empty inline Project.json section", {
+  # A tree project never writes an inline copy of a section, so a non-empty
+  # inline section that disagrees with the tree can only arise from hand-editing
+  # the Project.json. Construct that conflicting state directly and assert the
+  # loader takes the tree value and ignores the stale inline copy.
+  project <- testProject()
+  jsonPath <- project$jsonPath
+  treeDir <- file.path(dirname(jsonPath), "definitions", "scenarios")
+  expect_true(dir.exists(treeDir))
+
+  raw <- jsonlite::fromJSON(jsonPath, simplifyVector = FALSE)
+  expect_length(raw$scenarios, 0L)
+
+  # Inject a conflicting inline scenario for an id that also lives in the tree,
+  # giving it a different modelFile than the tree entity carries.
+  treeModelFile <- project$scenarios[["testscenario"]]$modelFile
+  raw$scenarios <- list(
+    list(
+      name = "testscenario",
+      modelFile = "INLINE_SHOULD_NOT_WIN.pkml"
+    )
+  )
+  writeLines(
+    jsonlite::toJSON(raw, auto_unbox = TRUE, null = "null", pretty = TRUE),
+    jsonPath
+  )
+
+  reloaded <- loadProject(jsonPath)
+  expect_identical(
+    reloaded$scenarios[["testscenario"]]$modelFile,
+    treeModelFile
+  )
+  expect_false(
+    identical(
+      reloaded$scenarios[["testscenario"]]$modelFile,
+      "INLINE_SHOULD_NOT_WIN.pkml"
+    )
+  )
+})
+
+test_that("a container-field write empties sections in Project.json yet the tree restores them on reload", {
+  treeSections <- c(
+    "scenarios",
+    "individuals",
+    "populations",
+    "parameterSets",
+    "applications",
+    "outputPaths",
+    "observedData",
+    "dataCombined",
+    "plots",
+    "plotGrids",
+    "parameterIdentification"
+  )
+  project <- exampleProject()
+  before <- vapply(treeSections, \(s) length(project[[s]]), integer(1))
+  expect_gt(sum(before), 0L)
+
+  # A container-metadata write persists only the container; the tree owns the
+  # sections, so they must not be re-inlined into Project.json.
+  project$name <- "RenamedX"
+  onDisk <- jsonlite::fromJSON(project$jsonPath, simplifyVector = FALSE)
+  expect_identical(onDisk$name, "RenamedX")
+  expect_false(is.null(onDisk$filePaths))
+  for (s in treeSections) {
+    expect_length(onDisk[[s]], 0L)
+  }
+
+  # Reload restores every section from the tree, and the metadata edit stuck.
+  reloaded <- loadProject(project$jsonPath)
+  after <- vapply(treeSections, \(s) length(reloaded[[s]]), integer(1))
+  expect_identical(after, before)
+  expect_identical(reloaded$name, "RenamedX")
+})
+
+test_that("Project$print() shows name and description", {
+  project <- exampleProject()
+  expect_output(print(project), "name:\\s+Example")
   expect_output(
     print(project),
-    "1 dataCombined / 1 plot\\(s\\) / 1 grid\\(s\\)"
+    "description:\\s+Aciclovir IV PK example project"
   )
 })
 
-test_that(".markSaved clears modified but leaves validatedSinceMutation set", {
+test_that("defaultSimulationRunOptions round-trips and defaults to NULL", {
+  project <- exampleProject()
+  expect_null(project$defaultSimulationRunOptions)
+
+  project$defaultSimulationRunOptions <- list(
+    numberOfCores = 2,
+    checkForNegativeValues = TRUE
+  )
+  reloaded <- loadProject(project$jsonPath)
+  expect_equal(reloaded$defaultSimulationRunOptions$numberOfCores, 2)
+  expect_true(reloaded$defaultSimulationRunOptions$checkForNegativeValues)
+})
+
+test_that("an Excel-bridge file field write targets the excel block", {
+  project <- Project$new()
+  project$modelParamsFile <- "X.xlsx"
+  expect_match(project$modelParamsFile, "X\\.xlsx$")
+  expect_identical(project$excel$modelParamsFile, "X.xlsx")
+})
+
+test_that(".markValidated leaves the validation cache set until the next mutation", {
   project <- testProject()
-  # A mutation marks the project modified and clears the validation flag.
+  project$.markValidated()
+  expect_true(project$validatedSinceMutation)
+
+  # A mutation clears the validation cache so runScenarios()/createPlots()
+  # re-validate the new shape.
   project$.markModified()
-  expect_true(project$modified)
-
-  # Validating sets the flag; a subsequent save must not clear it.
-  project$.markValidated()
-  project$.markSaved()
-
-  expect_false(project$modified)
-  # Saving is not a mutation, so a project validated before the save stays
-  # validated after it; runScenarios()/createPlots() need not re-validate.
-  expect_true(project$validatedSinceMutation)
-})
-
-test_that("a fresh project starts unmodified and unvalidated", {
-  project <- testProject()
-  expect_false(project$modified)
   expect_false(project$validatedSinceMutation)
 })
 
-test_that("a direct write to a section field invalidates the project", {
+test_that("a fresh project starts unvalidated", {
   project <- testProject()
-  project$.markValidated()
-  expect_false(project$modified)
-  expect_true(project$validatedSinceMutation)
-
-  project$scenarios[["New"]] <- Scenario(
-    scenarioName = "New",
-    modelFile = "m.pkml"
-  )
-
-  expect_true(project$modified)
   expect_false(project$validatedSinceMutation)
 })
 
-test_that("the documented c() attach idiom invalidates the project", {
+test_that("addScenario() invalidates the validation cache", {
   project <- testProject()
-  scenarios <- list(Attached = Scenario(scenarioName = "Attached"))
+  project$.markValidated()
+  expect_true(project$validatedSinceMutation)
 
-  project$scenarios <- c(project$scenarios, scenarios)
+  addScenario(project, "new", modelFile = "m.pkml")
 
-  expect_true(project$modified)
-  expect_s3_class(project$scenarios[["Attached"]], "Scenario")
+  expect_false(project$validatedSinceMutation)
 })
 
-test_that("nested subscript-assignment on a section entry invalidates the project", {
+test_that("setScenario() invalidates the validation cache", {
   project <- testProject()
-  project$individuals[["Indiv1"]]$weight <- 81
+  project$.markValidated()
 
-  expect_true(project$modified)
-  expect_identical(project$individuals[["Indiv1"]]$weight, 81)
+  setScenario(project, "testscenario", modelFile = "Aciclovir.pkml")
+
+  expect_false(project$validatedSinceMutation)
+  expect_s3_class(project$scenarios[["testscenario"]], "Scenario")
+})
+
+test_that("a section-entry authoring write invalidates the validation cache", {
+  project <- testProject()
+  project$.markValidated()
+  setIndividual(project, "indiv1", weight = 81)
+
+  expect_false(project$validatedSinceMutation)
+  expect_identical(project$individuals[["indiv1"]]$weight, 81)
 })
 
 test_that("an extracted Scenario is a copy and cannot mutate the project silently", {
   project <- testProject()
-  sc <- project$scenarios[["TestScenario"]]
+  project$.markValidated()
+  sc <- project$scenarios[["testscenario"]]
   sc$modelFile <- "HIJACKED.pkml"
 
-  expect_false(project$modified)
+  # Reading and mutating a copy is not a project mutation.
+  expect_true(project$validatedSinceMutation)
   expect_false(
-    identical(project$scenarios[["TestScenario"]]$modelFile, "HIJACKED.pkml")
+    identical(project$scenarios[["testscenario"]]$modelFile, "HIJACKED.pkml")
+  )
+})
+
+# Section accessors are read-only ----
+
+test_that("a whole-section assignment through a section accessor is rejected", {
+  project <- testProject()
+  expect_snapshot(error = TRUE, project$scenarios <- list())
+})
+
+test_that("a subscript assignment through a section accessor is rejected", {
+  project <- testProject()
+  expect_snapshot(
+    error = TRUE,
+    project$scenarios[["aciclovir_iv"]] <- Scenario(
+      scenarioName = "aciclovir_iv",
+      modelFile = "m.pkml"
+    )
+  )
+})
+
+test_that("a nested field assignment through a section accessor is rejected", {
+  project <- testProject()
+  # The most insidious form: `project$scenarios[["x"]]$field <- v` desugars to
+  # the same read-modify-write the subscript form does, so it is rejected too.
+  expect_snapshot(
+    error = TRUE,
+    project$scenarios[["testscenario"]]$individualId <- "indiv1"
+  )
+})
+
+test_that("a negative-index assignment through a section accessor is rejected", {
+  project <- testProject()
+  expect_snapshot(error = TRUE, project$scenarios[-1] <- list())
+})
+
+test_that("the read-only block applies to every section accessor", {
+  project <- testProject()
+  sections <- c(
+    "outputPaths",
+    "scenarios",
+    "parameterSets",
+    "initialConditions",
+    "individuals",
+    "populations",
+    "applications",
+    "observedData",
+    "dataCombined",
+    "plots",
+    "plotGrids",
+    "parameterIdentification"
+  )
+  for (section in sections) {
+    expect_error(
+      eval(bquote(project[[.(section)]] <- list())),
+      "read-only"
+    )
+  }
+})
+
+test_that("sub-element and negative-index assignment are rejected on every section accessor", {
+  project <- testProject()
+  # The scenarios section is covered by its own dedicated blocks above; the
+  # DefinitionList replacement methods (`[[<-`/`[<-`/`$<-`) dispatch purely on
+  # the shared wrapper class (the kind only feeds the message text), so a loop
+  # over the other ten sections asserts they traverse the same read-only path.
+  sections <- c(
+    "outputPaths",
+    "parameterSets",
+    "initialConditions",
+    "individuals",
+    "populations",
+    "applications",
+    "observedData",
+    "dataCombined",
+    "plots",
+    "plotGrids",
+    "parameterIdentification"
+  )
+  for (section in sections) {
+    expect_error(
+      eval(bquote(project[[.(section)]][["new_id"]] <- list())),
+      "read-only"
+    )
+    expect_error(
+      eval(bquote(project[[.(section)]][-1] <- list())),
+      "read-only"
+    )
+  }
+})
+
+test_that("reading a record, editing the copy, and re-submitting it is the supported edit loop", {
+  project <- testProject()
+  # The canonical edit loop: the accessor returns a detached copy; mutating it
+  # does not touch the project, and the change lands only when re-submitted
+  # through an authoring function.
+  sc <- project$scenarios[["testscenario"]]
+  sc$modelFile <- "Edited.pkml"
+  expect_false(
+    identical(project$scenarios[["testscenario"]]$modelFile, "Edited.pkml")
+  )
+  setScenario(project, "testscenario", modelFile = "Edited.pkml")
+  expect_identical(
+    project$scenarios[["testscenario"]]$modelFile,
+    "Edited.pkml"
+  )
+})
+
+# The sanctioned write path (the authoring functions, funneling through the
+# internal .setSection() entry point) must reject a structurally bad record,
+# not silently persist it: a wrong-typed reference field and an unknown field
+# both abort. (Regression guard for the write-path validation gap.)
+test_that("the write path rejects a wrong-typed scalar reference field", {
+  project <- testProject()
+  scenarios <- project$.getSection("scenarios")
+  scenarios[["testscenario"]]$individualId <- list(a = 1)
+  expect_error(
+    project$.setSection("scenarios", scenarios),
+    "individualId.*single string"
+  )
+})
+
+test_that("the write path rejects an unknown field on a record", {
+  project <- testProject()
+  scenarios <- project$.getSection("scenarios")
+  scenarios[["testscenario"]]$totallyBogusField <- "nonsense"
+  expect_error(
+    project$.setSection("scenarios", scenarios),
+    "unknown field"
   )
 })
 
@@ -529,17 +860,20 @@ test_that("jsonPath is read-only and aliases projectFilePath", {
   expect_snapshot(error = TRUE, project$jsonPath <- "elsewhere.json")
 })
 
-test_that("sync() reports a direct section-field write as unsaved changes", {
-  tmp <- withr::local_tempfile(fileext = ".json")
-  saveProject(testProject(), tmp)
+test_that("syncStatus() reports NA when there is no Excel side-car", {
+  tmp <- saveSnapshot(testProject(), local_projectPath())
   project <- loadProject(tmp)
 
-  project$scenarios[["TestScenario"]]$modelFile <- "Changed.pkml"
+  # Every section is write-through, so the project and its entity files never
+  # diverge; with no Project.xlsx alongside there is nothing to compare.
+  status <- project$syncStatus(silent = TRUE)
+  expect_identical(status$excel_in_sync, NA)
+  expect_identical(status$details, list())
+})
 
-  status <- project$sync(silent = TRUE)
-  expect_true(status$unsaved_changes)
-  expect_false(status$json_modified)
-  expect_false(status$in_sync)
+test_that("syncStatus() reports NA for an in-memory project", {
+  status <- Project$new()$syncStatus(silent = TRUE)
+  expect_identical(status$excel_in_sync, NA)
 })
 
 # Clone safety ----
@@ -548,14 +882,14 @@ test_that("mutating a clone's scenario leaves the source untouched", {
   project <- testProject()
   clone <- project$clone()
 
-  clone$scenarios[["TestScenario"]]$modelFile <- "OnlyOnClone.pkml"
+  setScenario(clone, "testscenario", modelFile = "OnlyOnClone.pkml")
 
   expect_identical(
-    clone$scenarios[["TestScenario"]]$modelFile,
+    clone$scenarios[["testscenario"]]$modelFile,
     "OnlyOnClone.pkml"
   )
   expect_false(
-    identical(project$scenarios[["TestScenario"]]$modelFile, "OnlyOnClone.pkml")
+    identical(project$scenarios[["testscenario"]]$modelFile, "OnlyOnClone.pkml")
   )
 })
 
@@ -564,31 +898,94 @@ test_that("adding a scenario to a clone leaves the source untouched", {
   clone <- project$clone()
   before <- length(project$scenarios)
 
-  clone$scenarios[["Fresh"]] <- Scenario(scenarioName = "Fresh")
+  addScenario(clone, "fresh", modelFile = "Aciclovir.pkml")
 
   expect_length(project$scenarios, before)
-  expect_false("Fresh" %in% names(project$scenarios))
+  expect_false("fresh" %in% names(project$scenarios))
 })
 
 test_that("mutating a clone's nested individual entry leaves the source untouched", {
   project <- testProject()
   clone <- project$clone()
 
-  clone$individuals[["Indiv1"]]$weight <- 99
+  setIndividual(clone, "indiv1", weight = 99)
 
-  expect_identical(clone$individuals[["Indiv1"]]$weight, 99)
-  expect_false(identical(project$individuals[["Indiv1"]]$weight, 99))
+  expect_identical(clone$individuals[["indiv1"]]$weight, 99)
+  expect_false(identical(project$individuals[["indiv1"]]$weight, 99))
 })
 
-test_that("clone modified/validated flags are independent of the source", {
+test_that("clone validated flag is independent of the source", {
   project <- testProject()
   project$.markValidated()
   clone <- project$clone()
 
-  clone$scenarios[["TestScenario"]]$modelFile <- "Changed.pkml"
+  setScenario(clone, "testscenario", modelFile = "Changed.pkml")
 
-  expect_true(clone$modified)
+  # Mutating the clone clears only the clone's validation cache; the source's
+  # cache is untouched.
   expect_false(clone$validatedSinceMutation)
-  expect_false(project$modified)
   expect_true(project$validatedSinceMutation)
+})
+
+# DefinitionList section-accessor printing ----
+
+test_that("a section accessor prints a count and the definition names", {
+  project <- testProject()
+  withr::local_options(cli.unicode = FALSE)
+  local_reproducible_output()
+  expect_snapshot(print(project$individuals))
+  expect_snapshot(print(project$parameterSets))
+})
+
+test_that("an empty section accessor prints zero definitions", {
+  project <- .fakeProject()
+  withr::local_options(cli.unicode = FALSE)
+  local_reproducible_output()
+  expect_snapshot(print(project$individuals))
+})
+
+test_that("print on a section accessor returns the value invisibly", {
+  project <- testProject()
+  expect_invisible(print(project$individuals))
+  returned <- withr::with_output_sink(
+    withr::local_tempfile(),
+    print(project$individuals)
+  )
+  expect_s3_class(returned, "DefinitionList")
+})
+
+test_that("a wrapped section accessor still behaves as a list", {
+  project <- testProject()
+  indivs <- project$individuals
+  expect_type(indivs, "list")
+  expect_length(indivs, 1L)
+  expect_named(indivs, "indiv1")
+  expect_s3_class(indivs[["indiv1"]], "Individual")
+  # c() and named extraction are transparent.
+  expect_length(c(indivs, list(extra = 1)), 2L)
+})
+
+test_that("the stored section stays a plain list (no DefinitionList class)", {
+  project <- testProject()
+  # Reading wraps, but the backing private store is plain: a round-trip
+  # through a mutator persists and reloads identically.
+  stored <- .unwrapDefinitionList(project$individuals)
+  expect_false(inherits(stored, "DefinitionList"))
+
+  addIndividual(project, "extra", species = "Human", gender = "MALE")
+  reloaded <- loadProject(project$jsonPath)
+  expect_true("extra" %in% names(reloaded$individuals))
+  expect_false(inherits(
+    .unwrapDefinitionList(reloaded$individuals),
+    "DefinitionList"
+  ))
+})
+
+test_that("the three plots sections each print a count and ids", {
+  project <- exampleProject()
+  withr::local_options(cli.unicode = FALSE)
+  local_reproducible_output()
+  expect_snapshot(print(project$plots))
+  expect_snapshot(print(project$plotGrids))
+  expect_snapshot(print(project$dataCombined))
 })


### PR DESCRIPTION
Full context: https://github.com/esqLABS/esqlabsR/issues/1088

This PR reshapes the in-memory `Project` R6 class onto PR1's entity-file persistence engine. Every section accessor becomes a write-through active binding (reading returns the section; assigning validates structurally and persists to the tree, while a write on a clone stays in memory), the old `saveProject`/`modified`/`sync` surface is replaced by `syncStatus` plus the class-side `saveSnapshot`/`loadSnapshot` verbs, and the `Project.json` container is split into live working folders and an optional Excel-bridge block. It also adds project metadata (`name`, `description`), a configurable `definitionsFolder`, and `defaultSimulationRunOptions`, and carries the JSON (de)serializer that produces the inlined snapshot. It sits directly on PR1 because the class binds to PR1's tree engine.

## Project class

`R/project.R` gains per-section private stores backed by write-through active bindings for all nine sections, with the public accessors locked read-only so mutation routes through the authoring functions / `.setSection` rather than direct binding writes. The container path fields are split into live working folders (`modelFolder`, `dataFolder`, `outputFolder`, `populationsFolder`) versus the optional Excel-bridge block. `syncStatus` replaces the removed `modified`/`sync()`/`unsaved_changes` surface (an Excel-vs-entity-files comparison), and `name`, `description`, `definitionsFolder` (default `definitions/`), and `defaultSimulationRunOptions` are surfaced in `print(project)`. Because the whole file is owned here, its net delta also carries the parameter-set-unify binding change, the plots-trio to three-top-level-section binding split, the initial-conditions fields, and the `DefinitionList` wrap-on-read getter as riders.

## JSON snapshot serializer

`R/project-to-json.R` carries the snapshot / inlined-container (de)serializer. It emits the split container, the unified `parameterSets`, the three top-level plots sections, and the initial-conditions data.

## Tests and snapshots

`tests/testthat/test-project.R` and `tests/testthat/test-project-to-json.R` cover the reshaped class and serializer; `tests/testthat/_snaps/project.md` captures the print output. Note that some of the print snapshot reflects the `DefinitionList` and per-definition print methods authored in a later stacked PR (this PR only carries the wrap-on-read getter that calls them), so the captured output is the final rendering rather than code present on this branch.

## Stacking notes

Stacked on `pr01-persistence-engine`; this PR is intentionally not CI-green in isolation, since the section authoring bodies and the print method definitions land in later stacked PRs. `man/` and `NAMESPACE` regenerate in PR13 because this PR changes roxygen source.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project export now supports a cleaner v2.0 JSON structure, including separate container metadata and optional Excel-related settings.
  * Section views are now read-only and display clearer counts and names when printed.

* **Bug Fixes**
  * Improved scenario and output-path serialization for more consistent saved projects.
  * Fixed handling of empty or missing sections so projects reload more reliably.
  * Updated clone and save behavior to avoid unintended writes between project copies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->