### PR TITLE
Resolve OSP dependencies from the R-universe (Additional_repositories, drop Remotes)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -75,4 +75,6 @@ Remotes:
     ospsuite.utils=Open-Systems-Pharmacology/OSPSuite.RUtils,
     tlf=Open-Systems-Pharmacology/TLF-Library,
     ospsuite.parameteridentification=Open-Systems-Pharmacology/OSPSuite.ParameterIdentification
+Additional_repositories:
+    https://open-systems-pharmacology.r-universe.dev
 Config/roxygen2/version: 8.0.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -70,11 +70,6 @@ Config/rcmdcheck/ignore-inconsequential-notes: true
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
-Remotes:
-    ospsuite=Open-Systems-Pharmacology/OSPSuite-R,
-    ospsuite.utils=Open-Systems-Pharmacology/OSPSuite.RUtils,
-    tlf=Open-Systems-Pharmacology/TLF-Library,
-    ospsuite.parameteridentification=Open-Systems-Pharmacology/OSPSuite.ParameterIdentification
 Additional_repositories:
     https://open-systems-pharmacology.r-universe.dev
 Config/roxygen2/version: 8.0.0


### PR DESCRIPTION
Experimental branch to make the esqLABS R-universe build resolve the OSP dependencies (`ospsuite`, `ospsuite.utils`, `tlf`, `ospsuite.parameteridentification`) from the Open-Systems-Pharmacology R-universe instead of reinstalling them from GitHub.

## Changes

- Add `Additional_repositories` pointing at `https://open-systems-pharmacology.r-universe.dev`, so R-universe's build adds that universe to the repos it resolves from.
- Remove the `Remotes` field, so the R-universe build does not reinstall the OSP dependencies from GitHub (their release tags currently lack the graceful-load fix and fail to load on the runtime-less build machine, which otherwise cascades into "ospsuite is not available").

Opened primarily to observe CI behaviour (including how `sync-remotes` reacts to a missing `Remotes` field). Not necessarily intended to merge as-is.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package repository configuration to use the Open Systems Pharmacology R-universe repository.
  * Removed the previous list of individual external package sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->