### PR TITLE
Make Project$print() snapshot deterministic across OSes

### DIFF
--- a/tests/testthat/_snaps/project.md
+++ b/tests/testthat/_snaps/project.md
@@ -8,20 +8,15 @@
         * Description: Aciclovir IV PK example project
         * Schema Version: 2.0
         * esqlabsR Version: 6.0.0
-        * JSON Path:
-      <tmp>/Project.json
+        * JSON Path: <tmp>/Project.json
       
-      -- Paths -----------------------------------------------------------------------
-        * Simulations Folder:
-      <tmp>/Models/Simulations
-        * Data Folder:
-      <tmp>/Data
-        * Populations Folder:
-      <tmp>/Populations
-        * Output Folder:
-      <tmp>/Results
+      -- Paths ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+        * Simulations Folder: <tmp>/Models/Simulations
+        * Data Folder: <tmp>/Data
+        * Populations Folder: <tmp>/Populations
+        * Output Folder: <tmp>/Results
       
-      -- Definitions -----------------------------------------------------------------
+      -- Definitions ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
         * Scenarios: 3
         * Individuals: 1
         * Populations: 1
@@ -35,7 +30,7 @@
         * Plot Grids: 1
         * Parameter Identification: 1
       
-      -- Excel -----------------------------------------------------------------------
+      -- Excel ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
         * Configurations Folder: Configurations/
         * Model Parameters File: ModelParameters.xlsx
         * Individuals File: Individuals.xlsx

--- a/tests/testthat/test-project.R
+++ b/tests/testthat/test-project.R
@@ -439,13 +439,27 @@ test_that("Project lifecycle fields are read-only", {
 test_that("Project$print() renders the example project through ospPrint*", {
   project <- exampleProject()
 
-  # The example project is loaded from a throwaway temp-dir copy, so its
-  # `JSON Path` and the resolved `Paths` values carry a machine-specific
-  # absolute prefix. Redact everything up to and including the temp copy's
-  # `Example_<hash>` directory so the snapshot stays portable while the
-  # section structure and folder labels remain reviewable.
+  # `expect_snapshot()` fixes the console width at 80 columns via
+  # `local_reproducible_output()`. The project is loaded from a temp copy, so
+  # each `* Label: <path>` item carries an absolute path whose length depends on
+  # the OS temp base (`/var/folders/...` on macOS is far longer than
+  # `/tmp/Rtmp...` on Linux). At 80 columns that difference flips whether the
+  # item wraps onto a second line, so the same print produces a different line
+  # count on macOS versus Linux CI. Widen the reproducible-output width for this
+  # snapshot so every item stays on one line regardless of the path length,
+  # making the layout OS-independent (the path text is redacted below). The
+  # section rules render at this width, which is why the snapshot's rules are
+  # wide.
+  testthat::local_reproducible_output(width = 300L)
+
+  # Redact the absolute path segment up to and including the temp copy's
+  # `Example_<hash>` directory so the snapshot stays portable while the section
+  # structure and folder labels remain reviewable. Anchor on the path itself (a
+  # leading `/` run ending in `Example_<hash>`) rather than a greedy `.*`, so a
+  # `* Label: <path>` item rendered on one line keeps its label; only the path
+  # is replaced.
   redactTempPaths <- function(lines) {
-    gsub(".*(Example_[^/]+)", "<tmp>", lines)
+    gsub("/[^[:space:]]*Example_[^/[:space:]]+", "<tmp>", lines)
   }
 
   expect_snapshot(print(project), transform = redactTempPaths)


### PR DESCRIPTION
Makes the `Project$print()` snapshot test deterministic across operating systems. The test renders a project loaded from a temp copy, so its `JSON Path` and `Paths` items carry an absolute path whose length depends on the OS temp base (`/var/folders/...` on macOS is far longer than `/tmp/Rtmp...` on Linux). `expect_snapshot()` fixes the console width at 80 columns, and at that width the longer macOS path pushes `* JSON Path: <path>` onto a second line while the shorter Linux path stays on one, so the same print produced a different line count on macOS versus Linux CI and the snapshot comparison failed on Linux while passing on macOS. This is a pre-existing cross-OS flake, unrelated to any single feature branch.

## Fix

The print test now widens its reproducible-output width (`testthat::local_reproducible_output(width = 300)`) so every `* Label: value` item stays on one line regardless of the path length, making the layout OS-independent. Its path-redaction transform is also corrected to anchor on the absolute path segment (a leading `/` run ending in `Example_<hash>`) instead of a greedy `.*`, so an item rendered on one line keeps its label and only the path text is replaced. The snapshot is re-recorded in the resulting one-line form; the wider width is why the section rules in the snapshot render wide.

Impact not shown as a reprex: this is a test-infrastructure change with no user-facing surface.
