### PR TITLE
Show project-relative paths in Project$print()

### DIFF
--- a/R/project.R
+++ b/R/project.R
@@ -728,6 +728,22 @@ Project <- R6::R6Class(
     print = function(...) {
       ospsuite.utils::ospPrintClass(self)
 
+      # Show file locations relative to the project directory rather than as
+      # absolute paths. The absolute prefix is machine-specific (and, for a
+      # project loaded from a temp copy, varies in length by OS), so printing it
+      # is both noisy for the user and a source of non-reproducible output. The
+      # container is shown as its basename (`JSON File`); the working folders are
+      # made relative to `projectDirPath`. Falls back to the raw value when there
+      # is no project directory (an in-memory project), matching the already
+      # project-relative Excel block below.
+      relToProject <- function(path) {
+        dir <- self$projectDirPath
+        if (is.null(path) || is.null(dir)) {
+          return(path)
+        }
+        as.character(fs::path_rel(path, start = dir))
+      }
+
       # Metadata bullets. `print_empty = FALSE` drops the NULL/empty entries
       # (e.g. `jsonPath` for an in-memory project), so no explicit filtering
       # is needed here.
@@ -737,20 +753,23 @@ Project <- R6::R6Class(
           "Description" = self$description,
           "Schema Version" = self$schemaVersion,
           "esqlabsR Version" = self$esqlabsRVersion,
-          "JSON Path" = self$jsonPath
+          "JSON File" = if (!is.null(self$jsonPath)) {
+            fs::path_file(self$jsonPath)
+          }
         )
       )
 
-      # Paths section: only the four live working folders. `configurationsFolder`
-      # and the workbook file fields belong to the Excel block, not here. Drop
-      # unset (NULL) folders and omit the header when none is set.
+      # Paths section: only the four live working folders, shown relative to the
+      # project directory. `configurationsFolder` and the workbook file fields
+      # belong to the Excel block, not here. Drop unset (NULL) folders and omit
+      # the header when none is set.
       paths <- Filter(
         Negate(is.null),
         list(
-          "Simulations Folder" = self$modelFolder,
-          "Data Folder" = self$dataFolder,
-          "Populations Folder" = self$populationsFolder,
-          "Output Folder" = self$outputFolder
+          "Simulations Folder" = relToProject(self$modelFolder),
+          "Data Folder" = relToProject(self$dataFolder),
+          "Populations Folder" = relToProject(self$populationsFolder),
+          "Output Folder" = relToProject(self$outputFolder)
         )
       )
       if (length(paths) > 0L) {

--- a/tests/testthat/_snaps/project.md
+++ b/tests/testthat/_snaps/project.md
@@ -8,18 +8,13 @@
         * Description: Aciclovir IV PK example project
         * Schema Version: 2.0
         * esqlabsR Version: 6.0.0
-        * JSON Path:
-      <tmp>/Project.json
+        * JSON File: Project.json
       
       -- Paths -----------------------------------------------------------------------
-        * Simulations Folder:
-      <tmp>/Models/Simulations
-        * Data Folder:
-      <tmp>/Data
-        * Populations Folder:
-      <tmp>/Populations
-        * Output Folder:
-      <tmp>/Results
+        * Simulations Folder: Models/Simulations
+        * Data Folder: Data
+        * Populations Folder: Populations
+        * Output Folder: Results
       
       -- Definitions -----------------------------------------------------------------
         * Scenarios: 3

--- a/tests/testthat/test-project.R
+++ b/tests/testthat/test-project.R
@@ -439,16 +439,10 @@ test_that("Project lifecycle fields are read-only", {
 test_that("Project$print() renders the example project through ospPrint*", {
   project <- exampleProject()
 
-  # The example project is loaded from a throwaway temp-dir copy, so its
-  # `JSON Path` and the resolved `Paths` values carry a machine-specific
-  # absolute prefix. Redact everything up to and including the temp copy's
-  # `Example_<hash>` directory so the snapshot stays portable while the
-  # section structure and folder labels remain reviewable.
-  redactTempPaths <- function(lines) {
-    gsub(".*(Example_[^/]+)", "<tmp>", lines)
-  }
-
-  expect_snapshot(print(project), transform = redactTempPaths)
+  # `print()` shows file locations relative to the project directory, so the
+  # output carries no machine-specific absolute path and needs no redaction or
+  # width override to stay reproducible across operating systems.
+  expect_snapshot(print(project))
 })
 
 # Container rework: metadata, definitionsFolder, the filePaths/excel split,


### PR DESCRIPTION
Refines the `Project$print()` method introduced in #1109 so it shows file locations relative to the project directory instead of as absolute paths. The absolute prefix is machine-specific, and for a project loaded from a temp copy its length varies by operating system, which made the print snapshot wrap differently on macOS versus Linux CI (a post-render redaction transform could not converge the two, since the wrap is decided before redaction runs). Showing relative paths removes the machine-specific string at the source, so the output is reproducible across operating systems with no redaction or width override, and it is easier to read.

## Print method

`Project$print()` now renders the four working folders (`modelFolder`, `dataFolder`, `populationsFolder`, `outputFolder`) relative to `projectDirPath`, and the JSON container as its basename under a `JSON File` label. For an in-memory project with no directory the raw value is shown unchanged. This matches the `Excel` section, which already prints project-relative values (`Configurations/`, `ModelParameters.xlsx`).

## Tests

The example-project print snapshot no longer needs a width override or a path-redaction transform, since the output carries no machine path; both are removed and the snapshot is re-recorded in the relative form.

## Example

Impact not shown as a reprex: `Project$print()` renders a live project loaded from disk, which needs a project fixture rather than a self-contained snippet. The print output changes from an absolute `JSON Path: /var/folders/.../Example_<hash>/Project.json` and absolute folder paths to `JSON File: Project.json` and relative folders such as `Simulations Folder: Models/Simulations`.
