### PR TITLE
Add AGENTS.md and CLAUDE.md contributor/agent guide

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -53,4 +53,5 @@ _\.new\.png$
 ^[.]?air[.]toml$
 ^\.vscode$
 ^AGENTS\.md$
+^CLAUDE\.md$
 ^.cursor/.

--- a/.gitignore
+++ b/.gitignore
@@ -58,4 +58,3 @@ tests/testthat/Rplots.pdf
 docs
 pkgdown
 .cursor/*
-AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,11 +43,13 @@ The target reader of all user-facing documentation (roxygen `@description`, `@pa
 - Describe behavior by **what the user sees and does**, not by mechanism. Prefer "Only files with actual changes are re-written, so `git diff` shows exactly the definitions you edited" over "write-if-different reconciliation".
 - Say things plainly: "idempotent no-op" → "saving repeatedly is always safe"; "orphan deletion" → "if you removed a scenario, its file is deleted".
 - State what a function does *not* do and what to call instead (e.g. saving does not update the Excel files; use `exportProjectToExcel()`).
+- Document important APIs in the vignettes, with a description of what they do and when to use them.
 - Internal comments and `@keywords internal` docs may stay technical — this rule is about what package users read.
 
 ## Pull requests
 
 - Open new PRs as **draft (WIP)**.
+- Add one `NEWS.md` bullet per PR with user-facing changes, summarizing them for the end user. Skip the bullet when a PR has none.
 
 ## Documentation / Rd files
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# esqlabsR — agent & contributor guide
+
+Guidance for working in this repository with coding agents (Claude Code, Copilot, CodeRabbit, …). Tool-neutral; `CLAUDE.md` points here.
+
+## File naming
+
+Follows the [OSPSuite-R](https://github.com/Open-Systems-Pharmacology/OSPSuite-R) pattern:
+
+- All files in `R/` use **kebab-case**: `scenario-configuration.R`, `sensitivity-calculation.R`, `validation-scenarios.R`.
+- Files are organized by domain/functionality, not by class hierarchy.
+- Helper collections use a `utilities-` prefix: `utilities-data.R`, `utilities-file.R`, `utilities-scenarios.R`.
+- Tests mirror their source file: `R/scenario-configuration.R` → `tests/testthat/test-scenario-configuration.R`.
+
+## User-visible documentation
+
+The target reader of all user-facing documentation (roxygen `@description`, `@param`, `@details`, vignettes, messages) is a **modeling expert, not a coder or data scientist**. They know PBPK/QSP modeling, scenarios, individuals, and populations; they do not know software-engineering vocabulary.
+
+- Do **not** use developer jargon: "reconcile", "authoring", "orphan", "idempotent", "in-memory vs. on-disk tree", "bound/unbound", "no-op", "side-car", "mutate".
+- Describe behavior by **what the user sees and does**, not by mechanism. Prefer "Only files with actual changes are re-written, so `git diff` shows exactly the definitions you edited" over "write-if-different reconciliation".
+- Say things plainly: "idempotent no-op" → "saving repeatedly is always safe"; "orphan deletion" → "if you removed a scenario, its file is deleted".
+- State what a function does *not* do and what to call instead (e.g. saving does not update the Excel files; use `exportProjectToExcel()`).
+- Internal comments and `@keywords internal` docs may stay technical — this rule is about what package users read.
+
+## Pull requests
+
+- Open new PRs as **draft (WIP)**.
+
+## Documentation / Rd files
+
+- When updating roxygen documentation, do **not** automatically re-generate the `man/*.Rd` files (`devtools::document()`). Rd generation is done once at the end of the work, before the PR is marked ready for review.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,30 @@ Follows the [OSPSuite-R](https://github.com/Open-Systems-Pharmacology/OSPSuite-R
 - Helper collections use a `utilities-` prefix: `utilities-data.R`, `utilities-file.R`, `utilities-scenarios.R`.
 - Tests mirror their source file: `R/scenario-configuration.R` → `tests/testthat/test-scenario-configuration.R`.
 
+## OSP ecosystem dependencies
+
+esqlabsR builds on the Open Systems Pharmacology ecosystem. When unsure about an API, inspect the source code of the dependency and its official vignettes instead of guessing:
+
+- [`ospsuite`](https://github.com/Open-Systems-Pharmacology/OSPSuite-R) — core PBPK simulation interface
+- [`ospsuite.utils`](https://github.com/Open-Systems-Pharmacology/OSPSuite.RUtils) — validation and utility helpers
+- [`tlf`](https://github.com/Open-Systems-Pharmacology/TLF-Library) — plotting
+- [`ospsuite.parameteridentification`](https://github.com/Open-Systems-Pharmacology/OSPSuite.ParameterIdentification) — parameter identification
+
+## Coding conventions
+
+- Type checking: use `ospsuite.utils::validateIsOfType()` / `ospsuite.utils::isOfType()` instead of native `inherits()` checks.
+- All user-facing messages, warnings, and errors live in `R/messages.R` as dedicated functions using `ospsuite.utils::cliFormat()` with cli markup (`{.val {x}}`, `{.arg {name}}`). Never inline message strings or build them with `paste()`.
+- Use explicit `package::function()` for functions from other packages. Never use `library()` or `require()` in package code. In tests, call esqlabsR's own functions directly, without a namespace prefix.
+- Use vectorized operations for simple vector math. For complex operations, prefer explicit `for` loops over `apply()`/`purrr::map()`.
+
+## Testing
+
+- Test whole structures in one assertion: `expect_equal(result, expected)` over multiple partial checks.
+- Compare against independently constructed expected values — never re-use the output of the function under test as the oracle.
+- Test errors and warnings against the specific message, preferably with `expect_snapshot(error = TRUE)`.
+- Do not add tests that cannot fail for a real defect; avoid trivial assertions.
+- Use meaningful, domain-specific test data; avoid unexplained literals like `42` or `"foo"`.
+
 ## User-visible documentation
 
 The target reader of all user-facing documentation (roxygen `@description`, `@param`, `@details`, vignettes, messages) is a **modeling expert, not a coder or data scientist**. They know PBPK/QSP modeling, scenarios, individuals, and populations; they do not know software-engineering vocabulary.
@@ -27,4 +51,6 @@ The target reader of all user-facing documentation (roxygen `@description`, `@pa
 
 ## Documentation / Rd files
 
+- Exported functions need complete roxygen2 docs: `@title`, `@param` (with types and defaults), `@return`, `@examples`.
+- Internal functions need minimal documentation plus `@keywords internal` and `@noRd`.
 - When updating roxygen documentation, do **not** automatically re-generate the `man/*.Rd` files (`devtools::document()`). Rd generation is done once at the end of the work, before the PR is marked ready for review.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+Agent & contributor guidance for this repository lives in @AGENTS.md.


### PR DESCRIPTION
Fixes #986

## Summary

Adds an agent & contributor guide following the [OSPSuite-R](https://github.com/Open-Systems-Pharmacology/OSPSuite-R) pattern: tool-neutral guidance in `AGENTS.md`, with `CLAUDE.md` as a one-line pointer to it.

The guide covers:

- **File naming** — kebab-case `R/` files organized by domain, `utilities-` prefix for helper collections, `test-<file>.R` mirroring.
- **User-visible documentation style** — the target reader is a modeling expert, not a coder: no developer jargon (reconcile, orphan, idempotent, …), describe behavior by what the user sees rather than by mechanism.
- **PR workflow** — new PRs open as draft (WIP).
- **Rd files** — don't regenerate `man/*.Rd` while iterating on docs; document once at the end of the work.

Housekeeping: removes the `AGENTS.md` entry from `.gitignore` (it was treated as a local-only file) and adds `CLAUDE.md` to `.Rbuildignore` (`AGENTS.md` was already listed there).

Note: the file-naming examples describe `main` as it is today; the project-refactor branch (#1110 line) renames helper files to a `-utils.R` suffix, so that line will need a one-word update when the refactor merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
  - Added/expanded repository guidance with contributor workflow tips, file naming conventions, testing expectations, and user-focused documentation rules.
  - Updated the repository’s AI guidance to point to the centralized contributor documentation.
  - Clarified documentation generation expectations and update requirements for user-facing changes.

- **Chores**
  - Updated build ignore rules to exclude the AI guidance file during package builds.
  - Adjusted version-control ignore settings so the contributor guide file is no longer excluded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->