### PR TITLE
Apply StartValue before validating PI parameter bounds

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 - `sensitivityCalculation()` now aligns baseline values by output path when computing percent change and sensitivity, fixing possible misalignment with multiple output paths (#1056).
 - `sensitivityCalculation()` no longer errors when all runs for a parameter fail; it now warns and omits that parameter from the results (#1056).
 - `sensitivityTornadoPlot()` now matches the `parameterFactor` and its reciprocal against the analysis results with a numerical tolerance, so user supplied reciprocal factors are no longer rejected due to floating point representation (#1056).
+- `createPITasks()` no longer rejects parameter bounds that exclude the model's current value, applying the sheet `StartValue` before validating them (#1140).
 
 # esqlabsR 5.7.0
 

--- a/R/utilities-pi.R
+++ b/R/utilities-pi.R
@@ -295,11 +295,18 @@ runPI <- function(piTasks) {
       }
     )
 
-    # Assign startValue first: the minValue/maxValue setters validate against
-    # the current start value, which the constructor seeds from the model.
+    # The setters validate startValue and each bound against the other,
+    # model-seeded fields. Set startValue first, then the bounds in whichever
+    # order keeps each step valid. The sheet guarantees Min <= Start <= Max,
+    # so one order always works.
     piParam$startValue <- firstRow$StartValue
-    piParam$minValue <- firstRow$MinValue
-    piParam$maxValue <- firstRow$MaxValue
+    if (firstRow$MinValue >= piParam$maxValue) {
+      piParam$maxValue <- firstRow$MaxValue
+      piParam$minValue <- firstRow$MinValue
+    } else {
+      piParam$minValue <- firstRow$MinValue
+      piParam$maxValue <- firstRow$MaxValue
+    }
 
     piParams[[i]] <- piParam
   }

--- a/R/utilities-pi.R
+++ b/R/utilities-pi.R
@@ -295,9 +295,11 @@ runPI <- function(piTasks) {
       }
     )
 
+    # Assign startValue first: the minValue/maxValue setters validate against
+    # the current start value, which the constructor seeds from the model.
+    piParam$startValue <- firstRow$StartValue
     piParam$minValue <- firstRow$MinValue
     piParam$maxValue <- firstRow$MaxValue
-    piParam$startValue <- firstRow$StartValue
 
     piParams[[i]] <- piParam
   }

--- a/tests/testthat/test-utilities-pi.R
+++ b/tests/testthat/test-utilities-pi.R
@@ -157,6 +157,35 @@ test_that("createPITasks throws error when parameter bounds are invalid", {
   )
 })
 
+test_that("createPITasks applies StartValue before validating bounds (#1135)", {
+  temp_project <- with_temp_project()
+  projectConfigurationLocal <- temp_project$config
+
+  # Bounds are internally valid (Min <= Start <= Max) but do NOT bracket the
+  # model's current Lipophilicity value (about -0.1), which is what the
+  # constructor seeds as the provisional start value.
+  sheets <- createValidPISheets()
+  sheets$PIParameters$MinValue <- 5
+  sheets$PIParameters$StartValue <- 7
+  sheets$PIParameters$MaxValue <- 10
+
+  .writeExcel(
+    data = sheets,
+    path = projectConfigurationLocal$parameterIdentificationFile
+  )
+
+  piTaskConfigurations <- readPITaskConfigurationFromExcel(
+    projectConfiguration = projectConfigurationLocal
+  )
+
+  expect_no_error(piTasks <- createPITasks(piTaskConfigurations))
+
+  firstParam <- piTasks[[1]]$parameters[[1]]
+  expect_equal(firstParam$startValue, 7)
+  expect_equal(firstParam$minValue, 5)
+  expect_equal(firstParam$maxValue, 10)
+})
+
 test_that("Same parameter across scenarios with different bounds in same group fails", {
   temp_project <- with_temp_project()
   projectConfigurationLocal <- temp_project$config


### PR DESCRIPTION
- In `.createPIParametersFromConfig()` (`R/utilities-pi.R`), assign the sheet's `StartValue` to the `PIParameters` object before `minValue` and `maxValue`, so the bounds setters validate against the `ParameterIdentification.xlsx` start value instead of the parameter's pre-existing value in the loaded model
- Add a regression test in `tests/testthat/test-utilities-pi.R` covering a full Excel round-trip with bounds that do not bracket the model's current value

Closes #1135


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted PI parameter initialization so the configured sheet start value is applied before validating minimum and maximum bounds.
  * PI task creation no longer rejects configurations where the provided start value lies within the specified bounds, preserving the configured min/start/max values.
* **Tests**
  * Added coverage to confirm `createPITasks()` uses `StartValue` before bounds validation and keeps the provided values.
* **Documentation**
  * Updated the development notes to reflect the minor improvement and bug fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->