### PR TITLE
Collapse _impl error-attribution boilerplate; drop redundant .markModified() in plots

### DIFF
--- a/R/applications.R
+++ b/R/applications.R
@@ -47,10 +47,8 @@ addApplication <- function(project, id, parameterSets = NULL) {
 #
 # @keywords internal
 # @noRd
-.addApplication_impl <- function(self, private, id, parameterSets = NULL) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.addApplication_impl <- function(self, private, id, parameterSets = NULL, .call) {
+  rlang::local_error_call(.call)
   .assertIdVector(id)
   id <- .canonicalizeId(id)
   n <- length(id)
@@ -61,7 +59,7 @@ addApplication <- function(project, id, parameterSets = NULL) {
   if (length(clash) > 0L) {
     cli::cli_abort("application {.val {clash}} already exists")
   }
-  call <- rlang::caller_env(2)
+  call <- .call
   apps <- .collectCanonicalizedRefs(lapply(seq_len(n), function(i) {
     .buildApplicationEntry(self, perId[[i]], call = call)
   }))
@@ -95,10 +93,8 @@ removeApplication <- function(project, id) {
 #
 # @keywords internal
 # @noRd
-.removeApplication_impl <- function(self, private, id) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.removeApplication_impl <- function(self, private, id, .call) {
+  rlang::local_error_call(.call)
   .assertIdVector(id)
   id <- .canonicalizeId(id)
 
@@ -151,11 +147,10 @@ setApplicationParameterSets <- function(
   self,
   private,
   id,
-  parameterSets
+  parameterSets,
+  .call
 ) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+  rlang::local_error_call(.call)
   .assertIdVector(id)
   id <- .canonicalizeId(id)
   n <- length(id)
@@ -165,7 +160,7 @@ setApplicationParameterSets <- function(
   }
   perId <- .wholeField(parameterSets, n)
 
-  call <- rlang::caller_env(2)
+  call <- .call
   resolved <- .collectCanonicalizedRefs(lapply(seq_len(n), function(i) {
     .resolveParameterSetRefs(self, perId[[i]], call = call)
   }))

--- a/R/individuals.R
+++ b/R/individuals.R
@@ -158,10 +158,8 @@ addIndividual <- function(project, id, species, ...) {
 #
 # @keywords internal
 # @noRd
-.addIndividual_impl <- function(self, private, id, species, ...) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.addIndividual_impl <- function(self, private, id, species, ..., .call) {
+  rlang::local_error_call(.call)
   .assertIdVector(id)
   id <- .canonicalizeId(id)
   n <- length(id)
@@ -184,7 +182,7 @@ addIndividual <- function(project, id, species, ...) {
   if (length(clash) > 0L) {
     cli::cli_abort("individual {.val {clash}} already exists")
   }
-  call <- rlang::caller_env(2)
+  call <- .call
   entries <- .collectCanonicalizedRefs(lapply(seq_len(n), function(i) {
     .buildIndividualEntry(self, id[[i]], perDefinition[[i]], call = call)
   }))
@@ -347,10 +345,8 @@ removeIndividual <- function(project, id) {
 #
 # @keywords internal
 # @noRd
-.removeIndividual_impl <- function(self, private, id) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.removeIndividual_impl <- function(self, private, id, .call) {
+  rlang::local_error_call(.call)
   .assertIdVector(id)
   id <- .canonicalizeId(id)
 
@@ -410,10 +406,8 @@ setIndividual <- function(project, id, ...) {
 #
 # @keywords internal
 # @noRd
-.setIndividual_impl <- function(self, private, id, ...) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.setIndividual_impl <- function(self, private, id, ..., .call) {
+  rlang::local_error_call(.call)
   .assertIdVector(id)
   id <- .canonicalizeId(id)
   n <- length(id)
@@ -437,7 +431,7 @@ setIndividual <- function(project, id, ...) {
   # update); the engine carries every supplied field for each definition.
   suppliedNames <- names(dots)
 
-  call <- rlang::caller_env(2)
+  call <- .call
   entries <- .collectCanonicalizedRefs(lapply(seq_len(n), function(i) {
     .setOneIndividual(
       self,

--- a/R/observed-data.R
+++ b/R/observed-data.R
@@ -233,10 +233,8 @@ loadObservedData <- function(project) {
 #
 # @keywords internal
 # @noRd
-.loadObservedData_impl <- function(self, private) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.loadObservedData_impl <- function(self, private, .call) {
+  rlang::local_error_call(.call)
   if (
     is.null(self$definitions$observedData) ||
       length(self$definitions$observedData) == 0
@@ -304,14 +302,13 @@ getObservedDataNames <- function(project) {
 #
 # @keywords internal
 # @noRd
-.getObservedDataNames_impl <- function(self, private) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.getObservedDataNames_impl <- function(self, private, .call) {
+  rlang::local_error_call(.call)
   if (!is.null(private$.observedDataNamesCache)) {
     return(private$.observedDataNamesCache)
   }
-  .loadObservedData_impl(self, private)
+  # Reentrant call: pass the attribution call on rather than re-resolving it.
+  .loadObservedData_impl(self, private, .call = .call)
   private$.observedDataNamesCache %||% character(0)
 }
 
@@ -339,13 +336,12 @@ addObservedData <- function(project, entry) {
 #
 # @keywords internal
 # @noRd
-.addObservedData_impl <- function(self, private, entry) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.addObservedData_impl <- function(self, private, entry, .call) {
+  rlang::local_error_call(.call)
   if (inherits(entry, "DataSet")) {
     name <- entry$name
-    existingNames <- .getObservedDataNames_impl(self, private)
+    # Reentrant call: pass the attribution call on rather than re-resolving it.
+    existingNames <- .getObservedDataNames_impl(self, private, .call = .call)
     if (name %in% existingNames) {
       cli::cli_abort(
         "observedData entry with name {.val {name}} already exists"
@@ -452,10 +448,8 @@ removeObservedData <- function(project, id) {
 #
 # @keywords internal
 # @noRd
-.removeObservedData_impl <- function(self, private, id) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.removeObservedData_impl <- function(self, private, id, .call) {
+  rlang::local_error_call(.call)
   .assertIdVector(id)
   observedData <- private$.getSection("observedData")
 

--- a/R/output-paths.R
+++ b/R/output-paths.R
@@ -33,10 +33,8 @@ addOutputPath <- function(project, id, path) {
 #
 # @keywords internal
 # @noRd
-.addOutputPath_impl <- function(self, private, id, path) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.addOutputPath_impl <- function(self, private, id, path, .call) {
+  rlang::local_error_call(.call)
   # Route the id-vector check through the shared helper every sibling add* uses,
   # then canonicalize and guard against an in-batch duplicate id (which would
   # otherwise silently overwrite an earlier entry keyed by the same id).
@@ -97,10 +95,8 @@ removeOutputPath <- function(project, id) {
 #
 # @keywords internal
 # @noRd
-.removeOutputPath_impl <- function(self, private, id) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.removeOutputPath_impl <- function(self, private, id, .call) {
+  rlang::local_error_call(.call)
   .assertIdVector(id)
   id <- .canonicalizeId(id)
 
@@ -153,10 +149,8 @@ setOutputPath <- function(project, id, path) {
 #
 # @keywords internal
 # @noRd
-.setOutputPath_impl <- function(self, private, id, path) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.setOutputPath_impl <- function(self, private, id, path, .call) {
+  rlang::local_error_call(.call)
   .assertIdVector(id)
   id <- .canonicalizeId(id)
   n <- length(id)

--- a/R/parameter-identification.R
+++ b/R/parameter-identification.R
@@ -1122,11 +1122,10 @@ addPITask <- function(
   scenarios,
   parameters,
   outputMappings,
-  configuration = list()
+  configuration = list(),
+  .call
 ) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+  rlang::local_error_call(.call)
   errors <- character()
   if (!is.character(id) || length(id) != 1L || is.na(id) || nchar(id) == 0) {
     errors <- c(errors, "id must be a non-empty string")
@@ -1223,10 +1222,8 @@ removePITask <- function(project, id) {
 #
 # @keywords internal
 # @noRd
-.removePITask_impl <- function(self, private, id) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.removePITask_impl <- function(self, private, id, .call) {
+  rlang::local_error_call(.call)
   .assertIdVector(id)
   id <- .canonicalizeId(id)
   missingIds <- setdiff(id, names(self$definitions$parameterIdentification))
@@ -1325,11 +1322,10 @@ addPIParameter <- function(
   maxValue,
   startValue,
   units = NULL,
-  id = NULL
+  id = NULL,
+  .call
 ) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+  rlang::local_error_call(.call)
   task <- .canonicalizeId(task)
   if (!(task %in% names(self$definitions$parameterIdentification))) {
     cli::cli_abort("PI task {.val {task}} not found")
@@ -1389,10 +1385,8 @@ removePIParameter <- function(project, task, id) {
 #
 # @keywords internal
 # @noRd
-.removePIParameter_impl <- function(self, private, task, id) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.removePIParameter_impl <- function(self, private, task, id, .call) {
+  rlang::local_error_call(.call)
   task <- .canonicalizeId(task)
   if (!(task %in% names(self$definitions$parameterIdentification))) {
     cli::cli_abort("PI task {.val {task}} not found")
@@ -1481,11 +1475,10 @@ addPIOutputMapping <- function(
   xFactor = 1,
   yFactor = 1,
   weight = NULL,
-  id = NULL
+  id = NULL,
+  .call
 ) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+  rlang::local_error_call(.call)
   task <- .canonicalizeId(task)
   if (!(task %in% names(self$definitions$parameterIdentification))) {
     cli::cli_abort("PI task {.val {task}} not found")
@@ -1553,10 +1546,8 @@ removePIOutputMapping <- function(project, task, id) {
 #
 # @keywords internal
 # @noRd
-.removePIOutputMapping_impl <- function(self, private, task, id) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.removePIOutputMapping_impl <- function(self, private, task, id, .call) {
+  rlang::local_error_call(.call)
   task <- .canonicalizeId(task)
   if (!(task %in% names(self$definitions$parameterIdentification))) {
     cli::cli_abort("PI task {.val {task}} not found")

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -744,10 +744,8 @@ addParameterSet <- function(project, id) {
 #
 # @keywords internal
 # @noRd
-.addParameterSet_impl <- function(self, private, id) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.addParameterSet_impl <- function(self, private, id, .call) {
+  rlang::local_error_call(.call)
   .assertIdVector(id)
   id <- .canonicalizeId(id)
   .assertNoDuplicateIds(id, "parameter set")
@@ -783,10 +781,8 @@ removeParameterSet <- function(project, id) {
 #
 # @keywords internal
 # @noRd
-.removeParameterSet_impl <- function(self, private, id) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.removeParameterSet_impl <- function(self, private, id, .call) {
+  rlang::local_error_call(.call)
   .assertIdVector(id)
   id <- .canonicalizeId(id)
   missingIds <- setdiff(id, names(self$definitions$parameterSets))
@@ -852,11 +848,10 @@ addParameterEntry <- function(
   containerPath,
   parameterName,
   value,
-  units
+  units,
+  .call
 ) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+  rlang::local_error_call(.call)
   if (!is.character(id) || length(id) != 1L || is.na(id) || nchar(id) == 0) {
     cli::cli_abort("{.arg id} must be a non-empty string")
   }
@@ -928,11 +923,10 @@ removeParameterEntry <- function(
   private,
   id,
   containerPath,
-  parameterName
+  parameterName,
+  .call
 ) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+  rlang::local_error_call(.call)
   if (!is.character(id) || length(id) != 1L || is.na(id) || nchar(id) == 0) {
     cli::cli_abort("{.arg id} must be a non-empty string")
   }
@@ -1233,10 +1227,8 @@ addInitialConditions <- function(project, id) {
 #
 # @keywords internal
 # @noRd
-.addInitialConditions_impl <- function(self, private, id) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.addInitialConditions_impl <- function(self, private, id, .call) {
+  rlang::local_error_call(.call)
   .assertIdVector(id)
   id <- .canonicalizeId(id)
   .assertNoDuplicateIds(id, "initial-condition set")
@@ -1273,10 +1265,8 @@ removeInitialConditions <- function(project, id) {
 #
 # @keywords internal
 # @noRd
-.removeInitialConditions_impl <- function(self, private, id) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.removeInitialConditions_impl <- function(self, private, id, .call) {
+  rlang::local_error_call(.call)
   .assertIdVector(id)
   id <- .canonicalizeId(id)
   missingIds <- setdiff(id, names(self$definitions$initialConditions))
@@ -1335,11 +1325,10 @@ addInitialConditionEntry <- function(project, id, path, value, unit) {
   id,
   path,
   value,
-  unit
+  unit,
+  .call
 ) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+  rlang::local_error_call(.call)
   if (!is.character(id) || length(id) != 1L || is.na(id) || nchar(id) == 0) {
     cli::cli_abort("{.arg id} must be a non-empty string")
   }
@@ -1394,10 +1383,8 @@ removeInitialConditionEntry <- function(project, id, path) {
 #
 # @keywords internal
 # @noRd
-.removeInitialConditionEntry_impl <- function(self, private, id, path) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.removeInitialConditionEntry_impl <- function(self, private, id, path, .call) {
+  rlang::local_error_call(.call)
   if (!is.character(id) || length(id) != 1L || is.na(id) || nchar(id) == 0) {
     cli::cli_abort("{.arg id} must be a non-empty string")
   }

--- a/R/plots.R
+++ b/R/plots.R
@@ -831,7 +831,6 @@ addPlot <- function(project, id, dataCombined, plotType, ...) {
     )
   }
   private$.setSection("plots", plotConfig)
-  private$.markModified()
   invisible(self)
 }
 
@@ -908,7 +907,6 @@ removePlot <- function(project, id) {
 
   plotConfig[toRemove] <- NULL
   private$.setSection("plots", plotConfig)
-  private$.markModified()
   invisible(self)
 }
 
@@ -1011,7 +1009,6 @@ addPlotGrid <- function(project, id, plots, ...) {
     plotGrids[[id[[i]]]] <- entry
   }
   private$.setSection("plotGrids", plotGrids)
-  private$.markModified()
   invisible(self)
 }
 
@@ -1055,7 +1052,6 @@ removePlotGrid <- function(project, id) {
 
   plotGrids[toRemove] <- NULL
   private$.setSection("plotGrids", plotGrids)
-  private$.markModified()
   invisible(self)
 }
 
@@ -1158,7 +1154,6 @@ addDataCombined <- function(
     dataCombined[[id[[i]]]] <- entry
   }
   private$.setSection("dataCombined", dataCombined)
-  private$.markModified()
   invisible(self)
 }
 
@@ -1236,6 +1231,5 @@ removeDataCombined <- function(project, id) {
 
   dataCombined[toRemove] <- NULL
   private$.setSection("dataCombined", dataCombined)
-  private$.markModified()
   invisible(self)
 }

--- a/R/plots.R
+++ b/R/plots.R
@@ -786,10 +786,8 @@ addPlot <- function(project, id, dataCombined, plotType, ...) {
 #
 # @keywords internal
 # @noRd
-.addPlot_impl <- function(self, private, id, dataCombined, plotType, ...) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.addPlot_impl <- function(self, private, id, dataCombined, plotType, ..., .call) {
+  rlang::local_error_call(.call)
   .requireNonEmptyStringVector(id, "id")
   id <- .canonicalizeId(id)
   n <- length(id)
@@ -873,10 +871,8 @@ removePlot <- function(project, id) {
 #
 # @keywords internal
 # @noRd
-.removePlot_impl <- function(self, private, id) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.removePlot_impl <- function(self, private, id, .call) {
+  rlang::local_error_call(.call)
   .requireNonEmptyStringVector(id, "id")
   id <- .canonicalizeId(id)
 
@@ -948,10 +944,8 @@ addPlotGrid <- function(project, id, plots, ...) {
 #
 # @keywords internal
 # @noRd
-.addPlotGrid_impl <- function(self, private, id, plots, ...) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.addPlotGrid_impl <- function(self, private, id, plots, ..., .call) {
+  rlang::local_error_call(.call)
   .requireNonEmptyStringVector(id, "id")
   id <- .canonicalizeId(id)
   n <- length(id)
@@ -1032,10 +1026,8 @@ removePlotGrid <- function(project, id) {
 #
 # @keywords internal
 # @noRd
-.removePlotGrid_impl <- function(self, private, id) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.removePlotGrid_impl <- function(self, private, id, .call) {
+  rlang::local_error_call(.call)
   .requireNonEmptyStringVector(id, "id")
   id <- .canonicalizeId(id)
 
@@ -1098,11 +1090,10 @@ addDataCombined <- function(
   private,
   id,
   simulated = list(),
-  observed = list()
+  observed = list(),
+  .call
 ) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+  rlang::local_error_call(.call)
   .requireNonEmptyStringVector(id, "id")
   id <- .canonicalizeId(id)
   n <- length(id)
@@ -1194,10 +1185,8 @@ removeDataCombined <- function(project, id) {
 #
 # @keywords internal
 # @noRd
-.removeDataCombined_impl <- function(self, private, id) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.removeDataCombined_impl <- function(self, private, id, .call) {
+  rlang::local_error_call(.call)
   .requireNonEmptyStringVector(id, "id")
   id <- .canonicalizeId(id)
 

--- a/R/populations.R
+++ b/R/populations.R
@@ -383,11 +383,10 @@ addPopulation <- function(
   id,
   species,
   numberOfIndividuals,
-  ...
+  ...,
+  .call
 ) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+  rlang::local_error_call(.call)
   .assertIdVector(id)
   id <- .canonicalizeId(id)
   n <- length(id)
@@ -405,7 +404,7 @@ addPopulation <- function(
   if (length(clash) > 0L) {
     cli::cli_abort("population {.val {clash}} already exists")
   }
-  call <- rlang::caller_env(2)
+  call <- .call
   entries <- lapply(seq_len(n), function(i) {
     .buildPopulationEntry(id[[i]], perDefinition[[i]], call = call)
   })
@@ -550,10 +549,8 @@ removePopulation <- function(project, id) {
 #
 # @keywords internal
 # @noRd
-.removePopulation_impl <- function(self, private, id) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.removePopulation_impl <- function(self, private, id, .call) {
+  rlang::local_error_call(.call)
   .assertIdVector(id)
   id <- .canonicalizeId(id)
 
@@ -614,10 +611,8 @@ setPopulation <- function(project, id, ...) {
 #
 # @keywords internal
 # @noRd
-.setPopulation_impl <- function(self, private, id, ...) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.setPopulation_impl <- function(self, private, id, ..., .call) {
+  rlang::local_error_call(.call)
   .assertIdVector(id)
   id <- .canonicalizeId(id)
   n <- length(id)
@@ -633,7 +628,7 @@ setPopulation <- function(project, id, ...) {
   perDefinition <- .alignAuthoringArgs(id, scalarFields = dots)
   suppliedNames <- names(dots)
 
-  call <- rlang::caller_env(2)
+  call <- .call
   entries <- lapply(seq_len(n), function(i) {
     .setOnePopulation(
       self,

--- a/R/project-lifecycle.R
+++ b/R/project-lifecycle.R
@@ -104,10 +104,8 @@ saveProject <- function(project) {
 #
 # @keywords internal
 # @noRd
-.saveProject_impl <- function(self, private) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.saveProject_impl <- function(self, private, .call) {
+  rlang::local_error_call(.call)
   if (is.null(self$info$projectFilePath)) {
     cli::cli_abort(messages$saveProjectNoTree())
   }
@@ -163,10 +161,8 @@ reloadProject <- function(project) {
 #
 # @keywords internal
 # @noRd
-.reloadProject_impl <- function(self, private) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.reloadProject_impl <- function(self, private, .call) {
+  rlang::local_error_call(.call)
   if (is.null(self$info$projectFilePath)) {
     cli::cli_abort(messages$reloadProjectNoTree())
   }

--- a/R/project.R
+++ b/R/project.R
@@ -267,9 +267,8 @@ Project <- R6::R6Class(
       overwriteFormulasInSS = FALSE,
       readPopulationFromCSV = FALSE
     ) {
-      .addScenario_impl(
-        self,
-        private,
+      private$.impl(
+        .addScenario_impl,
         id,
         modelFile,
         individual,
@@ -290,101 +289,101 @@ Project <- R6::R6Class(
 
     #' @description Remove scenarios. See [removeScenario()].
     removeScenario = function(id) {
-      .removeScenario_impl(self, private, id)
+      private$.impl(.removeScenario_impl, id)
     },
 
     #' @description Modify fields of existing scenarios. See [setScenario()].
     #'   The `...` carries only the fields to change (partial update); a field
     #'   passed as `NULL` is cleared, an omitted field is left untouched.
     setScenario = function(id, ...) {
-      .setScenario_impl(self, private, id, ...)
+      private$.impl(.setScenario_impl, id, ...)
     },
 
     #' @description Rename a scenario. See [renameScenario()].
     renameScenario = function(id, newId) {
-      .renameScenario_impl(self, private, id, newId)
+      private$.impl(.renameScenario_impl, id, newId)
     },
 
     #' @description Duplicate a scenario. See [duplicateScenario()].
     duplicateScenario = function(id, newId) {
-      .duplicateScenario_impl(self, private, id, newId)
+      private$.impl(.duplicateScenario_impl, id, newId)
     },
 
     #' @description Create scenarios from PKML model files. See
     #'   [createScenariosFromPKML()].
     createScenariosFromPKML = function(pkmlFilePaths, ...) {
-      .createScenariosFromPKML_impl(self, private, pkmlFilePaths, ...)
+      private$.impl(.createScenariosFromPKML_impl, pkmlFilePaths, ...)
     },
 
     #' @description Add an individual. See [addIndividual()].
     addIndividual = function(...) {
-      .addIndividual_impl(self, private, ...)
+      private$.impl(.addIndividual_impl, ...)
     },
 
     #' @description Remove individuals. See [removeIndividual()].
     removeIndividual = function(id) {
-      .removeIndividual_impl(self, private, id)
+      private$.impl(.removeIndividual_impl, id)
     },
 
     #' @description Modify an existing individual. See [setIndividual()].
     setIndividual = function(...) {
-      .setIndividual_impl(self, private, ...)
+      private$.impl(.setIndividual_impl, ...)
     },
 
     #' @description Add a population. See [addPopulation()].
     addPopulation = function(...) {
-      .addPopulation_impl(self, private, ...)
+      private$.impl(.addPopulation_impl, ...)
     },
 
     #' @description Remove populations. See [removePopulation()].
     removePopulation = function(id) {
-      .removePopulation_impl(self, private, id)
+      private$.impl(.removePopulation_impl, id)
     },
 
     #' @description Modify an existing population. See [setPopulation()].
     setPopulation = function(...) {
-      .setPopulation_impl(self, private, ...)
+      private$.impl(.setPopulation_impl, ...)
     },
 
     #' @description Add an application. See [addApplication()].
     addApplication = function(id, parameterSets = NULL) {
-      .addApplication_impl(self, private, id, parameterSets)
+      private$.impl(.addApplication_impl, id, parameterSets)
     },
 
     #' @description Remove applications. See [removeApplication()].
     removeApplication = function(id) {
-      .removeApplication_impl(self, private, id)
+      private$.impl(.removeApplication_impl, id)
     },
 
     #' @description Set an application's parameter sets. See
     #'   [setApplicationParameterSets()].
     setApplicationParameterSets = function(id, parameterSets) {
-      .setApplicationParameterSets_impl(self, private, id, parameterSets)
+      private$.impl(.setApplicationParameterSets_impl, id, parameterSets)
     },
 
     #' @description Add an output path. See [addOutputPath()].
     addOutputPath = function(id, path) {
-      .addOutputPath_impl(self, private, id, path)
+      private$.impl(.addOutputPath_impl, id, path)
     },
 
     #' @description Remove output paths. See [removeOutputPath()].
     removeOutputPath = function(id) {
-      .removeOutputPath_impl(self, private, id)
+      private$.impl(.removeOutputPath_impl, id)
     },
 
     #' @description Modify an existing output path. See [setOutputPath()].
     setOutputPath = function(id, path) {
-      .setOutputPath_impl(self, private, id, path)
+      private$.impl(.setOutputPath_impl, id, path)
     },
 
     #' @description Add a parameter set. See [addParameterSet()].
     addParameterSet = function(id) {
-      .addParameterSet_impl(self, private, id)
+      private$.impl(.addParameterSet_impl, id)
     },
 
     #' @description Remove parameter sets. See [removeParameterSet()].
     removeParameterSet = function(id) {
-      .removeParameterSet_impl(self, private, id)
+      private$.impl(.removeParameterSet_impl, id)
     },
 
     #' @description Add an entry to a parameter set. See [addParameterEntry()].
@@ -395,9 +394,8 @@ Project <- R6::R6Class(
       value,
       units
     ) {
-      .addParameterEntry_impl(
-        self,
-        private,
+      private$.impl(
+        .addParameterEntry_impl,
         id,
         containerPath,
         parameterName,
@@ -409,9 +407,8 @@ Project <- R6::R6Class(
     #' @description Remove an entry from a parameter set. See
     #'   [removeParameterEntry()].
     removeParameterEntry = function(id, containerPath, parameterName) {
-      .removeParameterEntry_impl(
-        self,
-        private,
+      private$.impl(
+        .removeParameterEntry_impl,
         id,
         containerPath,
         parameterName
@@ -420,76 +417,76 @@ Project <- R6::R6Class(
 
     #' @description Add an initial-conditions set. See [addInitialConditions()].
     addInitialConditions = function(id) {
-      .addInitialConditions_impl(self, private, id)
+      private$.impl(.addInitialConditions_impl, id)
     },
 
     #' @description Remove initial-conditions sets. See
     #'   [removeInitialConditions()].
     removeInitialConditions = function(id) {
-      .removeInitialConditions_impl(self, private, id)
+      private$.impl(.removeInitialConditions_impl, id)
     },
 
     #' @description Add an entry to an initial-conditions set. See
     #'   [addInitialConditionEntry()].
     addInitialConditionEntry = function(id, path, value, unit) {
-      .addInitialConditionEntry_impl(self, private, id, path, value, unit)
+      private$.impl(.addInitialConditionEntry_impl, id, path, value, unit)
     },
 
     #' @description Remove an entry from an initial-conditions set. See
     #'   [removeInitialConditionEntry()].
     removeInitialConditionEntry = function(id, path) {
-      .removeInitialConditionEntry_impl(self, private, id, path)
+      private$.impl(.removeInitialConditionEntry_impl, id, path)
     },
 
     #' @description Add a plot. See [addPlot()].
     addPlot = function(...) {
-      .addPlot_impl(self, private, ...)
+      private$.impl(.addPlot_impl, ...)
     },
 
     #' @description Remove plots. See [removePlot()].
     removePlot = function(id) {
-      .removePlot_impl(self, private, id)
+      private$.impl(.removePlot_impl, id)
     },
 
     #' @description Add a plot grid. See [addPlotGrid()].
     addPlotGrid = function(...) {
-      .addPlotGrid_impl(self, private, ...)
+      private$.impl(.addPlotGrid_impl, ...)
     },
 
     #' @description Remove plot grids. See [removePlotGrid()].
     removePlotGrid = function(id) {
-      .removePlotGrid_impl(self, private, id)
+      private$.impl(.removePlotGrid_impl, id)
     },
 
     #' @description Add a data-combined entry. See [addDataCombined()].
     addDataCombined = function(id, simulated = list(), observed = list()) {
-      .addDataCombined_impl(self, private, id, simulated, observed)
+      private$.impl(.addDataCombined_impl, id, simulated, observed)
     },
 
     #' @description Remove data-combined entries. See [removeDataCombined()].
     removeDataCombined = function(id) {
-      .removeDataCombined_impl(self, private, id)
+      private$.impl(.removeDataCombined_impl, id)
     },
 
     #' @description Add observed data. See [addObservedData()].
     addObservedData = function(entry) {
-      .addObservedData_impl(self, private, entry)
+      private$.impl(.addObservedData_impl, entry)
     },
 
     #' @description Remove observed data. See [removeObservedData()].
     removeObservedData = function(id) {
-      .removeObservedData_impl(self, private, id)
+      private$.impl(.removeObservedData_impl, id)
     },
 
     #' @description Load the project's observed data. See [loadObservedData()].
     loadObservedData = function() {
-      .loadObservedData_impl(self, private)
+      private$.impl(.loadObservedData_impl)
     },
 
     #' @description Names of the project's observed data. See
     #'   [getObservedDataNames()].
     getObservedDataNames = function() {
-      .getObservedDataNames_impl(self, private)
+      private$.impl(.getObservedDataNames_impl)
     },
 
     #' @description Add a parameter-identification task. See [addPITask()].
@@ -500,9 +497,8 @@ Project <- R6::R6Class(
       outputMappings,
       configuration = list()
     ) {
-      .addPITask_impl(
-        self,
-        private,
+      private$.impl(
+        .addPITask_impl,
         id,
         scenarios,
         parameters,
@@ -513,7 +509,7 @@ Project <- R6::R6Class(
 
     #' @description Remove parameter-identification tasks. See [removePITask()].
     removePITask = function(id) {
-      .removePITask_impl(self, private, id)
+      private$.impl(.removePITask_impl, id)
     },
 
     #' @description Add a parameter to a PI task. See [addPIParameter()].
@@ -527,9 +523,8 @@ Project <- R6::R6Class(
       units = NULL,
       id = NULL
     ) {
-      .addPIParameter_impl(
-        self,
-        private,
+      private$.impl(
+        .addPIParameter_impl,
         task,
         path,
         scenarios,
@@ -543,7 +538,7 @@ Project <- R6::R6Class(
 
     #' @description Remove a parameter from a PI task. See [removePIParameter()].
     removePIParameter = function(task, id) {
-      .removePIParameter_impl(self, private, task, id)
+      private$.impl(.removePIParameter_impl, task, id)
     },
 
     #' @description Add an output mapping to a PI task. See
@@ -561,9 +556,8 @@ Project <- R6::R6Class(
       weight = NULL,
       id = NULL
     ) {
-      .addPIOutputMapping_impl(
-        self,
-        private,
+      private$.impl(
+        .addPIOutputMapping_impl,
         task,
         outputPath,
         observedData,
@@ -581,24 +575,24 @@ Project <- R6::R6Class(
     #' @description Remove an output mapping from a PI task. See
     #'   [removePIOutputMapping()].
     removePIOutputMapping = function(task, id) {
-      .removePIOutputMapping_impl(self, private, task, id)
+      private$.impl(.removePIOutputMapping_impl, task, id)
     },
 
     #' @description Save the project's in-memory edits to its on-disk tree. See
     #'   [saveProject()].
     save = function() {
-      .saveProject_impl(self, private)
+      private$.impl(.saveProject_impl)
     },
 
     #' @description Discard in-memory edits and re-read from disk. See
     #'   [reloadProject()].
     reload = function() {
-      .reloadProject_impl(self, private)
+      private$.impl(.reloadProject_impl)
     },
 
     #' @description Validate the project. See [validateProject()].
     validate = function() {
-      .validateProject_impl(self, private)
+      private$.impl(.validateProject_impl)
     },
 
     #' @description Package-internal pre-op validation gate. Runs targeted
@@ -1096,6 +1090,24 @@ Project <- R6::R6Class(
     # family) route every state change through them; the authoring logic lives
     # in `_impl()` free functions in the domain files, which receive `private`
     # from the calling method and reach the seam through it.
+
+    # Dispatch to a domain `_impl()`, resolving the error-attribution call once.
+    # Every public authoring method forwards here rather than calling its
+    # `_impl()` directly: `private$.impl(.addScenario_impl, id, modelFile, ...)`.
+    # This hands the impl its own `self` / `private`, plus the call env `.call`
+    # that any abort in the impl should be attributed to. `caller_env(2)` is
+    # read from this method's frame: one frame up is the public method that
+    # called `.impl()`, two frames up is the exported free function the user
+    # actually called (`addScenario()` etc.), so an abort reads
+    # `Error in \`addScenario()\`:`, never the internal `_impl`. The impl only
+    # installs the value it is handed (`rlang::local_error_call(.call)`); the
+    # depth arithmetic lives here, in one place, instead of being copied into
+    # every `_impl`. An impl that calls a sibling impl directly (the reentrant
+    # PKML and observed-data paths) does not route through `.impl()`; it threads
+    # its own `.call` on, so its attribution is unchanged.
+    .impl = function(fn, ...) {
+      fn(self, private, ..., .call = rlang::caller_env(2))
+    },
 
     # Read one definition section. Returns the plain backing list (NOT wrapped
     # in the read-only `DefinitionList` the public `project$<section>` getter

--- a/R/project.R
+++ b/R/project.R
@@ -1105,6 +1105,12 @@ Project <- R6::R6Class(
     # every `_impl`. An impl that calls a sibling impl directly (the reentrant
     # PKML and observed-data paths) does not route through `.impl()`; it threads
     # its own `.call` on, so its attribution is unchanged.
+    #
+    # `.call` is a reserved formal on every `_impl`: an authoring method that
+    # forwards a user-facing `...` must not let `.call` reach `...` (no public
+    # argument is named `.call`, so this only happens on misuse, e.g.
+    # `do.call(addIndividual, list(.call = x))`); it would match `.call` twice
+    # and R aborts with "matched by multiple actual arguments".
     .impl = function(fn, ...) {
       fn(self, private, ..., .call = rlang::caller_env(2))
     },

--- a/R/scenario-from-pkml.R
+++ b/R/scenario-from-pkml.R
@@ -228,11 +228,10 @@ createScenariosFromPKML <- function(
   steadyStateTimeUnit = NULL,
   overwriteFormulasInSS = FALSE,
   readPopulationFromCSV = FALSE,
-  paramSheets = lifecycle::deprecated()
+  paramSheets = lifecycle::deprecated(),
+  .call
 ) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+  rlang::local_error_call(.call)
   # Handle deprecated paramSheets argument
   if (lifecycle::is_present(paramSheets)) {
     lifecycle::deprecate_soft(
@@ -596,11 +595,19 @@ createScenariosFromPKML <- function(
   tryCatch(
     {
       if (length(pending) > 0) {
+        # Reentrant call: this reaches the sibling `_impl` directly, not through
+        # `self$addOutputPath()` / `private$.impl()`, so it threads the
+        # attribution call itself. `caller_env(2)` here is the same frame the
+        # callee's own dispatch would have resolved: one up is this `_impl`'s
+        # caller (`private$.impl`), two up is the `createScenariosFromPKML`
+        # method, so an abort still reads `Error in
+        # \`project$createScenariosFromPKML()\`:`, as before the shared helper.
         .addOutputPath_impl(
           self,
           private,
           id = names(pending),
-          path = unname(pending)
+          path = unname(pending),
+          .call = rlang::caller_env(2)
         )
       }
       for (spec in specs) {
@@ -620,7 +627,8 @@ createScenariosFromPKML <- function(
           steadyStateTime = spec$steadyStateTime,
           steadyStateTimeUnit = spec$steadyStateTimeUnit,
           overwriteFormulasInSS = spec$overwriteFormulasInSS,
-          readPopulationFromCSV = spec$readPopulationFromCSV
+          readPopulationFromCSV = spec$readPopulationFromCSV,
+          .call = rlang::caller_env(2)
         )
       }
     },

--- a/R/scenarios.R
+++ b/R/scenarios.R
@@ -794,11 +794,10 @@ addScenario <- function(
   steadyStateTime = 1000,
   steadyStateTimeUnit = "min",
   overwriteFormulasInSS = FALSE,
-  readPopulationFromCSV = FALSE
+  readPopulationFromCSV = FALSE,
+  .call
 ) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+  rlang::local_error_call(.call)
   .assertIdVector(id)
   id <- .canonicalizeId(id)
   n <- length(id)
@@ -830,7 +829,7 @@ addScenario <- function(
   if (length(clash) > 0L) {
     cli::cli_abort("scenario {.val {clash}} already exists")
   }
-  call <- rlang::caller_env(2)
+  call <- .call
   scenarios <- .collectCanonicalizedRefs(lapply(seq_len(n), function(i) {
     .buildScenarioEntry(self, id[[i]], perDefinition[[i]], call = call)
   }))
@@ -984,10 +983,8 @@ removeScenario <- function(project, id) {
 #
 # @keywords internal
 # @noRd
-.removeScenario_impl <- function(self, private, id) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.removeScenario_impl <- function(self, private, id, .call) {
+  rlang::local_error_call(.call)
   .assertIdVector(id)
   id <- .canonicalizeId(id)
 
@@ -1145,10 +1142,8 @@ setScenario <- function(
 #
 # @keywords internal
 # @noRd
-.setScenario_impl <- function(self, private, id, ...) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.setScenario_impl <- function(self, private, id, ..., .call) {
+  rlang::local_error_call(.call)
   .assertIdVector(id)
   id <- .canonicalizeId(id)
   n <- length(id)
@@ -1175,7 +1170,7 @@ setScenario <- function(
   )
   suppliedNames <- names(dots)
 
-  call <- rlang::caller_env(2)
+  call <- .call
   updated <- .collectCanonicalizedRefs(lapply(seq_len(n), function(i) {
     .setOneScenario(
       self,
@@ -1429,10 +1424,8 @@ renameScenario <- function(project, id, newId) {
 #
 # @keywords internal
 # @noRd
-.renameScenario_impl <- function(self, private, id, newId) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.renameScenario_impl <- function(self, private, id, newId, .call) {
+  rlang::local_error_call(.call)
   id <- .assertScenarioIdArg(id, "id")
   newId <- .assertScenarioIdArg(newId, "newId")
 
@@ -1495,10 +1488,8 @@ duplicateScenario <- function(project, id, newId) {
 #
 # @keywords internal
 # @noRd
-.duplicateScenario_impl <- function(self, private, id, newId) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.duplicateScenario_impl <- function(self, private, id, newId, .call) {
+  rlang::local_error_call(.call)
   id <- .assertScenarioIdArg(id, "id")
   newId <- .assertScenarioIdArg(newId, "newId")
 

--- a/R/validation.R
+++ b/R/validation.R
@@ -251,10 +251,8 @@ validateProject <- function(project) {
 #
 # @keywords internal
 # @noRd
-.validateProject_impl <- function(self, private) {
-  # Attribute any abort to the public authoring function the user called
-  # (the free-function forwarder), not this internal `_impl`.
-  rlang::local_error_call(rlang::caller_env(2))
+.validateProject_impl <- function(self, private, .call) {
+  rlang::local_error_call(.call)
   results <- .runProjectValidation(self, sections = NULL)
 
   if (!isAnyCriticalErrors(results)) {


### PR DESCRIPTION
Two scoped cleanups on the v6 `Project` internal API surface (sub-issues of the internal-API-surface umbrella), each left out of earlier PRs to keep those diffs focused. Both are pure internal refactors with no user-facing behaviour change: the full test suite stays green and every error-attribution snapshot is byte-identical.

## Shared `_impl` dispatch helper

Every exported authoring function forwards to a `Project` method, which forwarded to a `.<name>_impl(self, private, ...)` free function that opened with the same two-line comment plus `rlang::local_error_call(rlang::caller_env(2))`, so an abort would name the public function the user called rather than the internal `_impl`. That boilerplate was copy-pasted, byte-identical, into 45 `_impl` functions across 12 files, with the call-depth `2` hard-coded at each site.

This introduces one private dispatch method, `private$.impl(fn, ...)`, that resolves the attribution call once and hands it to the `_impl` as a `.call` argument. Each `_impl` now simply installs it with `rlang::local_error_call(.call)`, and the depth arithmetic lives in exactly one place. The eight sites that also threaded the call into a `.build*Entry()` helper reuse `.call` instead of recomputing it, and the few reentrant paths where one `_impl` calls another directly (the `createScenariosFromPKML` and observed-data chains) thread `.call` explicitly so their attribution is unchanged. `.call` is a required argument, so a forgotten thread fails loudly at the call site instead of silently misattributing an error.

## Redundant `.markModified()` calls in `R/plots.R`

Six mutator `_impl` functions in `R/plots.R` called `private$.markModified()` immediately after `private$.setSection()`. That is a no-op: `.setSection()` already sets the in-memory dirty bit and invalidates the validation cache, doing the same work `.markModified()` does. `R/plots.R` was the last file still carrying this; the other domain files omit it. The six calls are removed; `.markModified()` itself stays, as it remains a valid standalone method.

Closes #1136
Closes #1138
