### PR TITLE
Cut single-use deps and hand-rolled boilerplate from the audit

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,8 +43,6 @@ Imports:
     tlf (>= 1.6.0),
     ospsuite.utils (>= 1.10.0),
     tools,
-    usethis,
-    vctrs,
     writexl
 Suggests:
     clipr,

--- a/R/esqlabs-env.R
+++ b/R/esqlabs-env.R
@@ -33,7 +33,7 @@ esqlabsRSettingNames <- enum(names(esqlabsEnv))
 #' getEsqlabsRSetting("packageVersion")
 #' getEsqlabsRSetting("packageName")
 getEsqlabsRSetting <- function(settingName) {
-  if (!(any(names(esqlabsEnv) == settingName))) {
+  if (!(settingName %in% names(esqlabsEnv))) {
     cli::cli_abort(messages$errorPackageSettingNotFound(
       settingName,
       esqlabsEnv
@@ -64,8 +64,8 @@ getEsqlabsRSetting <- function(settingName) {
   unsortedColors <- setdiff(unsortedColors, firstColors)
   # nrOfColors - 3 because the first three colors are already sampled
   nrPerColor <- floor((nrOfColors - 3) / 3)
-  firstColor <- seq(1, by = 3, length.out = floor(nrPerColor))
-  thirdColor <- rev(seq(3, by = 3, length.out = floor(nrPerColor)))
+  firstColor <- seq(1, by = 3, length.out = nrPerColor)
+  thirdColor <- rev(seq(3, by = 3, length.out = nrPerColor))
   secondColor <- setdiff(1:(nrOfColors - 3), c(firstColor, thirdColor))
   idxs <- c(firstColor, secondColor, thirdColor)
   sortedColors <- vector("character", length = nrOfColors - 3)

--- a/R/file-utils.R
+++ b/R/file-utils.R
@@ -53,7 +53,7 @@ readExcel <- function(path, sheet = NULL, ...) {
   return(readxl::read_excel(
     path,
     sheet,
-    .name_repair = ~ vctrs::vec_as_names(..., repair = "unique", quiet = TRUE),
+    .name_repair = "unique_quiet",
     ...
   ))
 }

--- a/R/parallel.R
+++ b/R/parallel.R
@@ -46,9 +46,6 @@ executeInParallel <- function(
     {
       parLapply(cl = cl, X = firstArguments, fun = fun, ...)
     },
-    error = function(e) {
-      stop(e)
-    },
     finally = {
       stopCluster(cl)
     }

--- a/R/scenarios.R
+++ b/R/scenarios.R
@@ -98,26 +98,16 @@ Scenario <- function(
   modelParameterSets = NULL,
   initialConditions = NULL
 ) {
-  rec <- stats::setNames(
-    vector("list", length(.scenarioFieldNames)),
-    .scenarioFieldNames
-  )
-  env <- environment()
-  for (n in .scenarioFieldNames) {
-    # `rec[n] <- list(value)` keeps NULL-valued slots so the record always
-    # carries the full 15-name shape regardless of which arguments are set.
-    rec[n] <- list(env[[n]])
-  }
-  structure(rec, class = c("Scenario", "list"))
+  # `mget()` reads every formal by name (the formals are exactly
+  # `.scenarioFieldNames`, in order), keeping NULL-valued slots so the record
+  # always carries the full shape regardless of which arguments are set.
+  structure(mget(.scenarioFieldNames), class = c("Scenario", "list"))
 }
 
 #' @exportS3Method
 #' @noRd
 as.list.Scenario <- function(x, ...) {
-  stats::setNames(
-    lapply(.scenarioFieldNames, function(n) x[[n]]),
-    .scenarioFieldNames
-  )
+  unclass(x)
 }
 
 #' @exportS3Method
@@ -566,25 +556,9 @@ print.Scenario <- function(x, ...) {
   # fields) or an internal `.setSection()` call. Reject any field the
   # serializer does not know, so a typo'd or stale field cannot be silently
   # dropped on write and then be absent on the next load. `simulationType` is
-  # the derived discriminant validated above; the rest mirror `.scenarioToJson`.
-  knownScenarioFields <- c(
-    "scenarioName",
-    "simulationType",
-    "individualId",
-    "populationId",
-    "readPopulationFromCSV",
-    "modelParameterSets",
-    "initialConditions",
-    "applicationProtocol",
-    "simulationTime",
-    "simulationTimeUnit",
-    "simulateSteadyState",
-    "steadyStateTime",
-    "steadyStateTimeUnit",
-    "overwriteFormulasInSS",
-    "modelFile",
-    "outputPaths"
-  )
+  # the derived discriminant validated above. The allowed set is exactly the
+  # `Scenario` record shape, `.scenarioFieldNames`.
+  knownScenarioFields <- .scenarioFieldNames
   unknown <- setdiff(names(sc), knownScenarioFields)
   if (length(unknown) > 0L) {
     cli::cli_abort(c(

--- a/R/sensitivity-calculation-utils.R
+++ b/R/sensitivity-calculation-utils.R
@@ -575,7 +575,11 @@ saveSensitivityCalculation <- function(
 
     contents <- list.files(outputDir, all.files = TRUE, no.. = TRUE)
     if (interactive() && length(contents) > 0) {
-      if (!usethis::ui_yeah(messages$promptDeleteOutputDir(outputDir))) {
+      answer <- utils::menu(
+        title = messages$promptDeleteOutputDir(outputDir),
+        choices = c("Yes", "No")
+      )
+      if (answer != 1L) {
         cli::cli_abort(messages$abortedByUser())
       }
     }

--- a/R/utils.R
+++ b/R/utils.R
@@ -176,7 +176,7 @@ getMoleculeNameFromQuantity <- function(quantity) {
   quantityType <- quantity$quantityType
 
   # If the passed quantitiy is a molecule, return its name
-  if (any(c("Drug", "Molecule") == quantityType)) {
+  if (quantityType %in% c("Drug", "Molecule")) {
     return(quantity$name)
   }
 
@@ -185,7 +185,7 @@ getMoleculeNameFromQuantity <- function(quantity) {
   parentContainerType <- parentContainer$containerType
 
   # If parent container is not a molecule, stop with an error
-  if (!(any(c("Drug", "Molecule") == parentContainerType))) {
+  if (!(parentContainerType %in% c("Drug", "Molecule"))) {
     msg <- messages$cannotGetMoleculeFromQuantity(quantity$path)
     cli::cli_abort("{msg}")
   }


### PR DESCRIPTION
Trims a set of small, verified over-engineering findings from a repo-wide audit: two dependencies each reached for a single function the platform already covers, and a handful of hand-rolled snippets that base R expresses more directly. Every change is behaviour-preserving; the full test suite passes unchanged (2490 passing) and `R CMD check` reports no new warnings or notes. Findings that touch exported API, sit in the path of pending pull requests, or turned out to be load-bearing on a close read were deliberately left out of this pull request.

## Dependencies

Drops `usethis` and `vctrs` from `Imports`, each of which was used in exactly one place:

- `usethis::ui_yeah()` (the delete-output-dir prompt in `saveSensitivityCalculation()`) is replaced by `utils::menu()`, matching the package's existing `.confirmOverwrite()` prompt idiom.
- `vctrs::vec_as_names(repair = "unique", quiet = TRUE)` inside `readExcel()` is replaced by `readxl`'s built-in `.name_repair = "unique_quiet"`, which does the same thing.

## Code cleanups

- `executeInParallel()`: the `tryCatch` `error = function(e) stop(e)` handler only re-raised the error unchanged, which is what `tryCatch` does with no handler at all; removed, keeping the `finally` that stops the cluster.
- `Scenario()`: builds the record with `mget(.scenarioFieldNames)` instead of a preallocated list plus a per-field copy loop (the formals are exactly those field names, in order).
- `as.list.Scenario()`: returns `unclass(x)`, since a `Scenario` is already a named list of those fields in order.
- `.validateScenarioFields()`: reuses `.scenarioFieldNames` for the allowed-field set instead of a second hand-synced copy of the same 16 names.
- `getEsqlabsRSetting()` and `getMoleculeNameFromQuantity()`: `any(names(x) == y)` / `any(c(...) == x)` become `y %in% names(x)` / `x %in% c(...)`.
- `.getEsqlabsColors()`: drops a `floor()` re-wrap of an already-floored value.