### PR TITLE
Unify R6 method, helper, and message-catalog casing

### DIFF
--- a/R/create-plots.R
+++ b/R/create-plots.R
@@ -87,11 +87,11 @@ createPlots <- function(
   if (isTRUE(stopIfNotFound)) {
     unknownGrids <- setdiff(plotGrids, names(allPlotGrids))
     if (length(unknownGrids) > 0) {
-      cli::cli_abort(messages$stopPlotGridNamesNotFound(unknownGrids))
+      cli::cli_abort(messages$plotGridNamesNotFound(unknownGrids))
     }
     unknownPlots <- setdiff(plots, names(allPlotConfig))
     if (length(unknownPlots) > 0) {
-      cli::cli_abort(messages$stopPlotIdsNotFound(unknownPlots))
+      cli::cli_abort(messages$plotIdsNotFound(unknownPlots))
     }
   }
 
@@ -264,7 +264,7 @@ createPlotsFromExcel <- function(...) {
       for (limitsField in check$limits) {
         limitsValue <- plotConfiguration[[limitsField]]
         if (!is.null(limitsValue) && 0 %in% limitsValue) {
-          msg <- messages$warningLogScaleWithZeroLimit(
+          msg <- messages$logScaleWithZeroLimit(
             plotID = plotID,
             axisLimitsField = limitsField,
             axis = check$axis
@@ -414,7 +414,7 @@ createPlotsFromExcel <- function(...) {
   }
   duplicatedPlotIds <- ids[duplicated(ids)]
   if (length(duplicatedPlotIds) > 0) {
-    msg <- messages$PlotIDsMustBeUnique(duplicatedPlotIds)
+    msg <- messages$plotIDsMustBeUnique(duplicatedPlotIds)
     cli::cli_abort("{msg}")
   }
   if (any(vapply(plotTypes, is.null, logical(1)))) {
@@ -439,7 +439,7 @@ createPlotsFromExcel <- function(...) {
     dataCombinedNames
   )
   if (length(missingDataCombined) != 0) {
-    msg <- messages$stopInvalidDataCombinedName(missingDataCombined)
+    msg <- messages$invalidDataCombinedName(missingDataCombined)
     cli::cli_abort("{msg}")
   }
   invisible(plotConfigurations)
@@ -470,7 +470,7 @@ createPlotsFromExcel <- function(...) {
   )
   duplicatedGridIds <- gridIds[duplicated(gridIds)]
   if (length(duplicatedGridIds) > 0) {
-    msg <- messages$PlotGridsNamesMustBeUnique(duplicatedGridIds)
+    msg <- messages$plotGridsNamesMustBeUnique(duplicatedGridIds)
     cli::cli_abort("{msg}")
   }
   referencedPlotIds <- unique(unlist(lapply(
@@ -479,7 +479,7 @@ createPlotsFromExcel <- function(...) {
   )))
   missingPlots <- setdiff(referencedPlotIds, plotIDs)
   if (length(missingPlots) != 0) {
-    msg <- messages$errorInvalidPlotID(missingPlots)
+    msg <- messages$invalidPlotID(missingPlots)
     cli::cli_abort("{msg}")
   }
   invisible(plotGrids)

--- a/R/data-combined.R
+++ b/R/data-combined.R
@@ -44,7 +44,7 @@ createDataCombined <- function(
     allGridIds <- names(.unwrapDefinitionList(project$definitions$plotGrids) %||% list())
     missingGrids <- setdiff(plotGrids[!is.na(plotGrids)], allGridIds)
     if (length(missingGrids) > 0) {
-      cli::cli_abort(messages$stopPlotGridNamesNotFound(missingGrids))
+      cli::cli_abort(messages$plotGridNamesNotFound(missingGrids))
     }
     dataCombined <- union(
       dataCombined,
@@ -58,7 +58,7 @@ createDataCombined <- function(
     names(allSpecs)
   )
   if (length(missingNames) > 0) {
-    cli::cli_abort(messages$stopDataCombinedNamesNotFound(missingNames))
+    cli::cli_abort(messages$dataCombinedNamesNotFound(missingNames))
   }
 
   selectedSpecs <- allSpecs[intersect(names(allSpecs), dataCombined)]
@@ -214,13 +214,13 @@ createDataCombinedFromExcel <- function(...) {
           # A scenario that is present but whose run failed carries
           # `results = NULL`; distinguish it from a genuinely wrong path.
           msg <- if (!is.null(scenarioResult) && is.null(results)) {
-            messages$stopScenarioRunFailed(
+            messages$scenarioRunFailed(
               dataCombinedName = name,
               scenarioName = scenarioName,
               path = simulated[j, ]$path
             )
           } else {
-            messages$stopWrongOutputPath(
+            messages$wrongOutputPath(
               dataCombinedName = name,
               scenarioName = scenarioName,
               path = simulated[j, ]$path
@@ -373,7 +373,7 @@ createDataCombinedFromExcel <- function(...) {
     dfDataCombined[dfDataCombined$dataType == "simulated", ]$path
   )
   if (sum(missingLabel) > 0) {
-    cli::cli_abort(messages$stopNoPathProvided(dfDataCombined[
+    cli::cli_abort(messages$noPathProvided(dfDataCombined[
       dfDataCombined$dataType == "simulated",
     ]$dataCombinedName[missingLabel]))
   }
@@ -383,7 +383,7 @@ createDataCombinedFromExcel <- function(...) {
     dfDataCombined[dfDataCombined$dataType == "observed", ]$dataSet
   )
   if (sum(missingLabel) > 0) {
-    cli::cli_abort(messages$stopNoDataSetProvided(dfDataCombined[
+    cli::cli_abort(messages$noDataSetProvided(dfDataCombined[
       dfDataCombined$dataType == "observed",
     ]$dataCombinedName[missingLabel]))
   }
@@ -401,9 +401,9 @@ createDataCombinedFromExcel <- function(...) {
   )
   if (length(missingScenarios) != 0) {
     if (stopIfNotFound) {
-      cli::cli_abort(messages$warningInvalidScenarioName(missingScenarios))
+      cli::cli_abort(messages$invalidScenarioName(missingScenarios))
     }
-    cli::cli_warn(messages$warningInvalidScenarioName(missingScenarios))
+    cli::cli_warn(messages$invalidScenarioName(missingScenarios))
     dfDataCombined <- dplyr::filter(
       dfDataCombined,
       (dataType == "observed") | !(scenario %in% missingScenarios)
@@ -416,9 +416,9 @@ createDataCombinedFromExcel <- function(...) {
   )
   if (length(missingDataSets) != 0) {
     if (stopIfNotFound) {
-      cli::cli_abort(messages$stopInvalidDataSetName(missingDataSets))
+      cli::cli_abort(messages$invalidDataSetName(missingDataSets))
     }
-    cli::cli_warn(messages$warningInvalidDataSetName(missingDataSets))
+    cli::cli_warn(messages$combineInvalidDataSetName(missingDataSets))
     dfDataCombined <- dfDataCombined[
       !(dfDataCombined$dataSet %in% missingDataSets),
     ]

--- a/R/data-utils.R
+++ b/R/data-utils.R
@@ -148,7 +148,7 @@ calculateMeanDataSet <- function(
 ) {
   validateIsOfType(dataSets, "DataSet")
   if (!any(c("arithmetic", "geometric") == method)) {
-    msg <- messages$errorInvalidMeanMethod()
+    msg <- messages$invalidMeanMethod()
     cli::cli_abort("{msg}")
   }
   validateEnumValue(lloqMode, LLOQMode)
@@ -168,7 +168,7 @@ calculateMeanDataSet <- function(
   } else if (length(molWeights) > 1) {
     # molWeight is not specified by user and molWeights of data sets differ -
     # error
-    msg <- messages$errorOutputMolWeightNeeded()
+    msg <- messages$outputMolWeightNeeded()
     cli::cli_abort("{msg}")
   } else if (!is.na(molWeights)) {
     # molWeight is not specified by user and all molWeights are equal and not NULL -

--- a/R/definition-files.R
+++ b/R/definition-files.R
@@ -273,7 +273,7 @@
 # is a one-place edit (the spec) rather than three lists kept in lockstep. Used
 # by the whole-tree writers, where write order does not matter (each kind writes
 # into its own folder independently); the load order that must resolve
-# `outputPaths` before scenarios is fixed separately in `Project$.read_json()`.
+# `outputPaths` before scenarios is fixed separately in `Project$.readJson()`.
 #
 # @keywords internal
 # @noRd

--- a/R/file-utils.R
+++ b/R/file-utils.R
@@ -140,7 +140,7 @@ readExcel <- function(path, sheet = NULL, ...) {
 # Expand every `${VAR}` / `$VAR` reference in `path` against the environment,
 # leaving an unset variable's reference in place and never touching `$PATH`.
 # The one place the package's env-var-in-path contract lives; the `Project`
-# working-folder resolver (`.replace_env_var`) and the Excel-import folder
+# working-folder resolver (`.replaceEnvVar`) and the Excel-import folder
 # resolution both call it so they cannot drift.
 # @keywords internal
 # @noRd

--- a/R/individuals.R
+++ b/R/individuals.R
@@ -66,7 +66,7 @@
   result <- validationResult$new()
 
   if (is.null(individuals) || length(individuals) == 0) {
-    result$add_warning("Data", "No individuals defined")
+    result$addWarning("Data", "No individuals defined")
     return(result)
   }
 
@@ -74,7 +74,7 @@
   for (id in names(individuals)) {
     indiv <- individuals[[id]]
 
-    result <- .check_required_fields(
+    result <- .checkRequiredFields(
       indiv,
       requiredFields,
       paste0("individual '", id, "'"),
@@ -84,7 +84,7 @@
     for (numField in c("weight", "height", "age")) {
       val <- indiv[[numField]]
       if (!is.null(val) && !is.na(val) && !is.numeric(val)) {
-        result$add_warning(
+        result$addWarning(
           "Data Type",
           paste0(
             "Field '",

--- a/R/messages.R
+++ b/R/messages.R
@@ -18,7 +18,7 @@ messages <- ospsuite.utils::messages
 # not yet migrated, so not all validation wording lives here.
 
 # Parameters structure####
-messages$errorWrongXLSStructure <- function(
+messages$wrongXLSStructure <- function(
   filePath,
   expectedColNames,
   optionalMessage = ""
@@ -37,7 +37,7 @@ messages$wrongParametersStructure <- function(argumentName) {
   )
 }
 
-messages$errorMissingValuesInParameters <- function(
+messages$missingValuesInParameters <- function(
   filePath,
   parameterPaths
 ) {
@@ -46,7 +46,7 @@ messages$errorMissingValuesInParameters <- function(
   )
 }
 
-messages$warningDuplicateParameters <- function(
+messages$duplicateParameters <- function(
   filePath,
   parameterPaths
 ) {
@@ -55,7 +55,7 @@ messages$warningDuplicateParameters <- function(
   )
 }
 
-messages$errorMissingUnitsInInitialConditions <- function(
+messages$missingUnitsInInitialConditions <- function(
   filePath,
   moleculePaths
 ) {
@@ -64,7 +64,7 @@ messages$errorMissingUnitsInInitialConditions <- function(
   )
 }
 
-messages$errorMissingValuesInInitialConditions <- function(
+messages$missingValuesInInitialConditions <- function(
   filePath,
   moleculePaths
 ) {
@@ -73,7 +73,7 @@ messages$errorMissingValuesInInitialConditions <- function(
   )
 }
 
-messages$errorInvalidIsPresentInInitialConditions <- function(
+messages$invalidIsPresentInInitialConditions <- function(
   filePath,
   moleculePaths
 ) {
@@ -82,7 +82,7 @@ messages$errorInvalidIsPresentInInitialConditions <- function(
   )
 }
 
-messages$errorMissingPathInInitialConditions <- function(
+messages$missingPathInInitialConditions <- function(
   filePath,
   sheet,
   rows
@@ -92,7 +92,7 @@ messages$errorMissingPathInInitialConditions <- function(
   )
 }
 
-messages$warningDuplicateInitialConditions <- function(
+messages$duplicateInitialConditions <- function(
   filePath,
   moleculePaths
 ) {
@@ -102,18 +102,18 @@ messages$warningDuplicateInitialConditions <- function(
 }
 
 # Enum####
-messages$errorEnumPutListMultipleKeys <- function() {
+messages$enumPutListMultipleKeys <- function() {
   cliFormat("Trying to put multiple keys, but only one key is allowed!")
 }
 
 # populations ####
-messages$errorDistributionNotSupported <- function(string) {
+messages$distributionNotSupported <- function(string) {
   cliFormat(
     "The distribution {.val {string}} is not supported. Supported distributions are listed in {.var Distributions}."
   )
 }
 
-messages$errorWrongOntogenyStructure <- function(entry) {
+messages$wrongOntogenyStructure <- function(entry) {
   cliFormat(
     "Wrong structure provided for the protein ontogeny specification.
     Expected is a pair of {.cls ProteinName:Ontogeny}, but the entry is: {.val {entry}}"
@@ -355,7 +355,7 @@ messages$invalidArgumentLength <- function(noOfOutpaths, noOfScenarios) {
   ))
 }
 
-messages$warningValueWithinThresholdNotExisting <- function(
+messages$valueWithinThresholdNotExisting <- function(
   value,
   threshold,
   optionalMessage = ""
@@ -366,13 +366,13 @@ messages$warningValueWithinThresholdNotExisting <- function(
 }
 
 # data-utils ####
-messages$errorInvalidMeanMethod <- function() {
+messages$invalidMeanMethod <- function() {
   cliFormat(
     "Invalid value for argument {.arg method}, supported values are {.val arithmetic} or {.val geometric}"
   )
 }
 
-messages$errorOutputMolWeightNeeded <- function() {
+messages$outputMolWeightNeeded <- function() {
   cliFormat(
     "{.arg outputMolWeight} can not be {.val NULL} when data sets have different molWeights"
   )
@@ -391,14 +391,14 @@ messages$nrOfColorsShouldBePositive <- function(nrOfColors) {
   )
 }
 
-messages$PlotIDsMustBeUnique <- function(duplicated_plotIDs = "") {
+messages$plotIDsMustBeUnique <- function(duplicated_plotIDs = "") {
   duplicates <- paste(duplicated_plotIDs, collapse = ", ")
   cliFormat(
     "plotId must be unique in plotConfiguration, but the following plotIds are duplicated: {.val {duplicates}}"
   )
 }
 
-messages$PlotGridsNamesMustBeUnique <- function(
+messages$plotGridsNamesMustBeUnique <- function(
   duplicated_plotGridsNames = ""
 ) {
   cliFormat(
@@ -407,12 +407,12 @@ messages$PlotGridsNamesMustBeUnique <- function(
   )
 }
 
-messages$UnknownPlotConfiguration <- function(name) {
+messages$unknownPlotConfiguration <- function(name) {
   cliFormat("Unknown plot configuration option: {.arg {name}}")
 }
 
 # scenario####
-messages$errorApplicationProtocolNotFound <- function(
+messages$applicationProtocolNotFound <- function(
   scenarioName,
   applicationProtocol
 ) {
@@ -421,7 +421,7 @@ messages$errorApplicationProtocolNotFound <- function(
     in the excel file {.file ApplicationProtocols.xlsx}"
   )
 }
-messages$warningInvalidScenarioName <- function(scenarioNames) {
+messages$invalidScenarioName <- function(scenarioNames) {
   cliFormat(
     "The following scenarios are not present in {.arg scenarioResults}:
     {.val {paste(scenarioNames, collapse = \",\n\")}}. Data cannot be added to {.var DataCombined} object."
@@ -440,7 +440,7 @@ messages$invalidArgumentLengthScenarios <- function(
   ))
 }
 
-messages$warningNoIndividualCharacteristics <- function(
+messages$noIndividualCharacteristics <- function(
   scenarioName,
   individualId
 ) {
@@ -456,7 +456,7 @@ messages$noPopulationIdForPopulationScenario <- function(scenarioName) {
   )
 }
 
-messages$stopWrongTimeIntervalString <- function(timeIntervalString) {
+messages$wrongTimeIntervalString <- function(timeIntervalString) {
   cliFormat(
     "The time interval string {.val {timeIntervalString}} is not valid! Please 
     check the format of the string. Following criteria must be 
@@ -467,7 +467,7 @@ messages$stopWrongTimeIntervalString <- function(timeIntervalString) {
   )
 }
 
-messages$stopScenarioMissingTimeUnit <- function(scenarioName) {
+messages$scenarioMissingTimeUnit <- function(scenarioName) {
   cliFormat(
     "Scenario {.val {scenarioName}} has simulation time defined, but no unit is specified! 
     Please specify simulation time unit."
@@ -480,7 +480,7 @@ messages$missingResultsForScenario <- function(scenarioName) {
   )
 }
 
-messages$errorSavingScenarioResult <- function(scenarioName, conditionMessage) {
+messages$savingScenarioResult <- function(scenarioName, conditionMessage) {
   # Escape braces in the condition message so that cli does not try to
   # re-interpret arbitrary error text as glue expressions when cli_warn()
   # processes the returned vector.
@@ -530,7 +530,7 @@ messages$cannotGetMoleculeFromQuantity <- function(
 }
 
 # data sets
-messages$warningInvalidDataSetName <- function(dataSetNames) {
+messages$combineInvalidDataSetName <- function(dataSetNames) {
   cliFormat(
     "The following data sets are not present in {.var observedData}:
     {.val {paste(dataSetNames, collapse =',\n')}}. Data can not be added to {.var DataCombined} object."
@@ -538,7 +538,7 @@ messages$warningInvalidDataSetName <- function(dataSetNames) {
 }
 
 # Plots.xlsx####
-messages$warningLogScaleWithZeroLimit <- function(
+messages$logScaleWithZeroLimit <- function(
   plotID,
   axisLimitsField,
   axis
@@ -549,7 +549,7 @@ messages$warningLogScaleWithZeroLimit <- function(
   )
 }
 
-messages$errorInvalidPlotID <- function(plotIDs) {
+messages$invalidPlotID <- function(plotIDs) {
   cliFormat(
     "The plots with plotIds {.val {paste(plotIDs, collapse = ',\n')}} are used in the sheet
     {.field plotGrids} but are not defined in the sheet {.var plotConfiguration}."
@@ -600,28 +600,28 @@ messages$missingDataCombinedName <- function() {
   )
 }
 
-messages$stopInvalidDataCombinedName <- function(dataCombinedNames) {
+messages$invalidDataCombinedName <- function(dataCombinedNames) {
   cliFormat(
     "The following DataCombined are used in {.var plotConfiguration} sheet but are not present in {.var DataCombined} sheet:
     {.val {paste(dataCombinedNames, collapse = ', ')}}"
   )
 }
 
-messages$stopDataCombinedNamesNotFound <- function(dataCombinedNames) {
+messages$dataCombinedNamesNotFound <- function(dataCombinedNames) {
   cliFormat(
     "The following DataCombined names are not defined in the Excel file:
     {.val {paste(dataCombinedNames, collapse = ', ')}}"
   )
 }
 
-messages$stopNoPathProvided <- function(dataCombinedName) {
+messages$noPathProvided <- function(dataCombinedName) {
   cliFormat(
     "No output path is defined for the DataCombined {.val {paste(dataCombinedName, collapse = \", \")}}
     Each simulation output must have an output path specified."
   )
 }
 
-messages$stopWrongOutputPath <- function(dataCombinedName, scenarioName, path) {
+messages$wrongOutputPath <- function(dataCombinedName, scenarioName, path) {
   cliFormat(
     "Output path {.path {path}} is defined in the DataCombined {.val {paste(dataCombinedName, collapse = \", \")}}
     for scenario {.cls {scenarioName}} but has not been simulated.
@@ -629,7 +629,7 @@ messages$stopWrongOutputPath <- function(dataCombinedName, scenarioName, path) {
   )
 }
 
-messages$stopScenarioRunFailed <- function(
+messages$scenarioRunFailed <- function(
   dataCombinedName,
   scenarioName,
   path
@@ -641,28 +641,28 @@ messages$stopScenarioRunFailed <- function(
   )
 }
 
-messages$stopPlotGridNamesNotFound <- function(plotGridNames) {
+messages$plotGridNamesNotFound <- function(plotGridNames) {
   cliFormat(
     "The following plot grids are not defined in the project:
     {.val {paste(plotGridNames, collapse = ', ')}}"
   )
 }
 
-messages$stopPlotIdsNotFound <- function(plotIds) {
+messages$plotIdsNotFound <- function(plotIds) {
   cliFormat(
     "The following plots are not defined in the project:
     {.val {paste(plotIds, collapse = ', ')}}"
   )
 }
 
-messages$stopNoDataSetProvided <- function(dataCombinedName) {
+messages$noDataSetProvided <- function(dataCombinedName) {
   cliFormat(
     "No data set is defined for the DataCombined {.val {paste(dataCombinedName, collapse = \", \n\")}}.
     Each observed data must have a {.var dataSet} specified."
   )
 }
 
-messages$stopInvalidDataSetName <- function(dataSetNames) {
+messages$invalidDataSetName <- function(dataSetNames) {
   cliFormat(
     "The following data sets are not present in {.var observedData}: {.val {paste0(dataSetNames, collapse = ',\n')}}"
   )
@@ -717,7 +717,7 @@ messages$invalidCustomFunctionParameters <- function(providedParams) {
   )
 }
 
-messages$errorNotNamedList <- function(objectName, optionalMessage = "") {
+messages$notNamedList <- function(objectName, optionalMessage = "") {
   callingFunction <- ospsuite.utils:::.getCallingFunctionName()
   cliFormat(
     "{.fn {callingFunction}}: argument {.arg {objectName}} is not a named list! {optionalMessage}"
@@ -730,18 +730,18 @@ messages$invalidVariationRangeLength <- function() {
   )
 }
 
-messages$errorSensitivityCalculationNotFound <- function(path) {
+messages$sensitivityCalculationNotFound <- function(path) {
   cliFormat("Sensitivity calculation not found at path {.file {path}}.")
 }
 
-messages$errorOutputDirExists <- function(outputDir) {
+messages$outputDirExists <- function(outputDir) {
   cliFormat(
     "Directory {.file {outputDir}} already exists.",
     "Set {.code overwrite = TRUE} to replace it."
   )
 }
 
-messages$errorFailedToLoadSimulation <- function(path, message) {
+messages$failedToLoadSimulation <- function(path, message) {
   cliFormat(
     "Failed to load simulation from saved path {.file {path}}.",
     "Please provide the {.cls Simulation} object explicitly.",
@@ -749,7 +749,7 @@ messages$errorFailedToLoadSimulation <- function(path, message) {
   )
 }
 
-messages$errorCorruptSensitivityCalculation <- function(path) {
+messages$corruptSensitivityCalculation <- function(path) {
   cliFormat(
     "Failed to load sensitivity calculation from {.file {path}}.",
     "The saved files appear to be incomplete or corrupted."
@@ -810,7 +810,7 @@ messages$excelFieldTypeError <- function(
   )
 }
 
-messages$warningSensitivityPKParameterNotCalculated <- function(
+messages$sensitivityPKParameterNotCalculated <- function(
   parameterPath,
   pkParameter
 ) {
@@ -876,53 +876,53 @@ messages$failedToCopyTemplate <- function(paths) {
   )
 }
 
-messages$errorPIDatasetNotFound <- function(datasetName, availableDatasets) {
+messages$PIDatasetNotFound <- function(datasetName, availableDatasets) {
   cli::format_message(c(
     "x" = "Dataset {.val {datasetName}} not found",
     "i" = "Available datasets: {.val {paste(availableDatasets, collapse = ', ')}}"
   ))
 }
 
-messages$errorPIInvalidBounds <- function(paramPath, min, start, max) {
+messages$PIInvalidBounds <- function(paramPath, min, start, max) {
   cliFormat(
     "Parameter {.val {paramPath}} has invalid bounds: Min={.val {min}}, Start={.val {start}}, Max={.val {max}}.
     Expected: Min <= Start <= Max"
   )
 }
 
-messages$errorPIRequiredField <- function(field, recordType, recordId) {
+messages$PIRequiredField <- function(field, recordType, recordId) {
   cliFormat(
     "Required field {.val {field}} is missing or empty on {recordType} {.val {recordId}}."
   )
 }
 
-messages$errorPIEmptyList <- function(field, taskId) {
+messages$PIEmptyList <- function(field, taskId) {
   cliFormat(
     "Field {.val {field}} on PITask {.val {taskId}} must contain at least one entry."
   )
 }
 
-messages$errorPIScenariosEmpty <- function(recordType, recordId) {
+messages$PIScenariosEmpty <- function(recordType, recordId) {
   cliFormat(
     "Field {.code scenarios} on {recordType} {.val {recordId}} must be a non-empty character vector."
   )
 }
 
-messages$errorPIInvalidNumericField <- function(field, recordId, value) {
+messages$PIInvalidNumericField <- function(field, recordId, value) {
   cliFormat(
     "Field {.code {field}} on PIOutputMapping {.val {recordId}} is invalid: \\
     {.val {value}}. Expected a finite numeric value."
   )
 }
 
-messages$errorPIInvalidScaling <- function(recordId, value) {
+messages$PIInvalidScaling <- function(recordId, value) {
   cliFormat(
     "Field {.code scaling} on PIOutputMapping {.val {recordId}} is invalid: \\
     {.val {value}}. Expected a non-empty string."
   )
 }
 
-messages$errorPIWrongElementType <- function(
+messages$PIWrongElementType <- function(
   field,
   index,
   taskId,
@@ -933,32 +933,32 @@ messages$errorPIWrongElementType <- function(
   )
 }
 
-messages$errorPIOutputQuantityNotFound <- function(path, simulationName) {
+messages$PIOutputQuantityNotFound <- function(path, simulationName) {
   cliFormat(
     "Output quantity {.path {path}} not found in simulation {.val {simulationName}}.
     Check that the output path exists in the simulation."
   )
 }
 
-messages$errorPIParameterNotFound <- function(path, simulationName) {
+messages$PIParameterNotFound <- function(path, simulationName) {
   cliFormat(
     "Parameter {.path {path}} not found in simulation {.val {simulationName}}.
     Check that the parameter path is correct and exists in the simulation."
   )
 }
 
-messages$errorPIScenarioNotFound <- function(scenarioName, availableScenarios) {
+messages$PIScenarioNotFound <- function(scenarioName, availableScenarios) {
   cli::format_message(c(
     "x" = "Scenario {.val {scenarioName}} referenced in PI task configuration not found",
     "i" = "Available scenarios: {.val {paste(availableScenarios, collapse = ', ')}}"
   ))
 }
 
-messages$messageBuildingPITask <- function(piTaskName) {
+messages$buildingPITask <- function(piTaskName) {
   cliFormat("Building PI task: {.val {piTaskName}}")
 }
 
-messages$messageRunningPITask <- function(piTaskName) {
+messages$runningPITask <- function(piTaskName) {
   cliFormat("Running PI task: {.val {piTaskName}}")
 }
 
@@ -1082,11 +1082,11 @@ messages$observedDataNameCollision <- function(duplicates) {
 # of a `validationResult` entry (a plain string, not a `cli`-tagged vector), so
 # they interpolate the ids as plain text (single-quoted to match the rest of the
 # validator's wording) instead of styling them with `cli` `{.val}` markup.
-messages$validationObservedDataMissingType <- function(entryLabel) {
+messages$observedDataMissingType <- function(entryLabel) {
   cliFormat("{entryLabel} is missing required field 'type'")
 }
 
-messages$validationObservedDataInvalidType <- function(
+messages$observedDataInvalidType <- function(
   entryLabel,
   type,
   validTypes
@@ -1096,7 +1096,7 @@ messages$validationObservedDataInvalidType <- function(
   )
 }
 
-messages$validationObservedDataMissingField <- function(
+messages$validatorObservedDataMissingField <- function(
   entryLabel,
   type,
   field
@@ -1104,11 +1104,11 @@ messages$validationObservedDataMissingField <- function(
   cliFormat("{entryLabel} ({type}) is missing required field '{field}'")
 }
 
-messages$validationObservedDataFileNotFound <- function(entryLabel, file) {
+messages$validatorObservedDataFileNotFound <- function(entryLabel, file) {
   cliFormat("{entryLabel} references non-existent file: {file}")
 }
 
-messages$validationObservedDataImporterNotFound <- function(
+messages$observedDataImporterNotFound <- function(
   entryLabel,
   importerConfiguration
 ) {
@@ -1117,7 +1117,7 @@ messages$validationObservedDataImporterNotFound <- function(
   )
 }
 
-messages$validationObservedDataPathEscapes <- function(entryLabel, path) {
+messages$observedDataPathEscapes <- function(entryLabel, path) {
   cliFormat(
     "{entryLabel} references a file outside the project folder: {path}"
   )

--- a/R/observed-data.R
+++ b/R/observed-data.R
@@ -101,7 +101,7 @@ print.ObservedDataSource <- function(x, ...) {
   result <- validationResult$new()
 
   if (is.null(observedData) || length(observedData) == 0) {
-    result$add_warning("Data", "No observedData defined")
+    result$addWarning("Data", "No observedData defined")
     return(result)
   }
 
@@ -112,7 +112,7 @@ print.ObservedDataSource <- function(x, ...) {
     entryLabel <- paste0("observedData entry ", i)
 
     if (is.null(entry$type)) {
-      result$add_critical_error(
+      result$addCriticalError(
         "Missing Fields",
         messages$validationObservedDataMissingType(entryLabel)
       )
@@ -120,7 +120,7 @@ print.ObservedDataSource <- function(x, ...) {
     }
 
     if (!entry$type %in% validTypes) {
-      result$add_critical_error(
+      result$addCriticalError(
         "Invalid Value",
         messages$validationObservedDataInvalidType(
           entryLabel,
@@ -136,7 +136,7 @@ print.ObservedDataSource <- function(x, ...) {
     # never disagree about, e.g., whether an Excel source needs `sheets`.
     for (field in .observedDataRequiredFields(entry$type)) {
       if (.observedDataFieldMissing(entry, field)) {
-        result$add_critical_error(
+        result$addCriticalError(
           "Missing Fields",
           messages$validationObservedDataMissingField(
             entryLabel,
@@ -154,14 +154,14 @@ print.ObservedDataSource <- function(x, ...) {
     if (!is.null(dataFolder)) {
       if (!is.null(entry$file)) {
         if (.pathEscapesRoot(entry$file, dataFolder)) {
-          result$add_critical_error(
+          result$addCriticalError(
             "Path Containment",
             messages$validationObservedDataPathEscapes(entryLabel, entry$file)
           )
         } else {
           filePath <- file.path(dataFolder, entry$file)
           if (!file.exists(filePath)) {
-            result$add_warning(
+            result$addWarning(
               "File Not Found",
               messages$validationObservedDataFileNotFound(
                 entryLabel,
@@ -175,7 +175,7 @@ print.ObservedDataSource <- function(x, ...) {
         identical(entry$type, "excel") && !is.null(entry$importerConfiguration)
       ) {
         if (.pathEscapesRoot(entry$importerConfiguration, dataFolder)) {
-          result$add_critical_error(
+          result$addCriticalError(
             "Path Containment",
             messages$validationObservedDataPathEscapes(
               entryLabel,
@@ -185,7 +185,7 @@ print.ObservedDataSource <- function(x, ...) {
         } else {
           importerPath <- file.path(dataFolder, entry$importerConfiguration)
           if (!file.exists(importerPath)) {
-            result$add_warning(
+            result$addWarning(
               "File Not Found",
               messages$validationObservedDataImporterNotFound(
                 entryLabel,

--- a/R/observed-data.R
+++ b/R/observed-data.R
@@ -114,7 +114,7 @@ print.ObservedDataSource <- function(x, ...) {
     if (is.null(entry$type)) {
       result$addCriticalError(
         "Missing Fields",
-        messages$validationObservedDataMissingType(entryLabel)
+        messages$observedDataMissingType(entryLabel)
       )
       next
     }
@@ -122,7 +122,7 @@ print.ObservedDataSource <- function(x, ...) {
     if (!entry$type %in% validTypes) {
       result$addCriticalError(
         "Invalid Value",
-        messages$validationObservedDataInvalidType(
+        messages$observedDataInvalidType(
           entryLabel,
           entry$type,
           validTypes
@@ -138,7 +138,7 @@ print.ObservedDataSource <- function(x, ...) {
       if (.observedDataFieldMissing(entry, field)) {
         result$addCriticalError(
           "Missing Fields",
-          messages$validationObservedDataMissingField(
+          messages$validatorObservedDataMissingField(
             entryLabel,
             entry$type,
             field
@@ -156,14 +156,14 @@ print.ObservedDataSource <- function(x, ...) {
         if (.pathEscapesRoot(entry$file, dataFolder)) {
           result$addCriticalError(
             "Path Containment",
-            messages$validationObservedDataPathEscapes(entryLabel, entry$file)
+            messages$observedDataPathEscapes(entryLabel, entry$file)
           )
         } else {
           filePath <- file.path(dataFolder, entry$file)
           if (!file.exists(filePath)) {
             result$addWarning(
               "File Not Found",
-              messages$validationObservedDataFileNotFound(
+              messages$validatorObservedDataFileNotFound(
                 entryLabel,
                 entry$file
               )
@@ -177,7 +177,7 @@ print.ObservedDataSource <- function(x, ...) {
         if (.pathEscapesRoot(entry$importerConfiguration, dataFolder)) {
           result$addCriticalError(
             "Path Containment",
-            messages$validationObservedDataPathEscapes(
+            messages$observedDataPathEscapes(
               entryLabel,
               entry$importerConfiguration
             )
@@ -187,7 +187,7 @@ print.ObservedDataSource <- function(x, ...) {
           if (!file.exists(importerPath)) {
             result$addWarning(
               "File Not Found",
-              messages$validationObservedDataImporterNotFound(
+              messages$observedDataImporterNotFound(
                 entryLabel,
                 entry$importerConfiguration
               )

--- a/R/output-paths.R
+++ b/R/output-paths.R
@@ -23,7 +23,7 @@
 #'   same length as `id`.
 #' @returns The `project` object, invisibly.
 #' @export
-#' @family output path
+#' @family outputPath
 addOutputPath <- function(project, id, path) {
   validateIsOfType(project, "Project")
   project$addOutputPath(id, path)
@@ -85,7 +85,7 @@ addOutputPath <- function(project, id, path) {
 #'   canonicalized the same way [addOutputPath()] canonicalizes it.
 #' @returns The `project` object, invisibly.
 #' @export
-#' @family output path
+#' @family outputPath
 removeOutputPath <- function(project, id) {
   validateIsOfType(project, "Project")
   project$removeOutputPath(id)
@@ -139,7 +139,7 @@ removeOutputPath <- function(project, id) {
 #'
 #' @returns The `project` object, invisibly.
 #' @export
-#' @family output path
+#' @family outputPath
 setOutputPath <- function(project, id, path) {
   validateIsOfType(project, "Project")
   project$setOutputPath(id, path)

--- a/R/output-paths.R
+++ b/R/output-paths.R
@@ -205,16 +205,16 @@ setOutputPath <- function(project, id, path) {
   result <- validationResult$new()
 
   if (is.null(outputPaths) || length(outputPaths) == 0) {
-    result$add_warning("Data", "No output paths defined")
+    result$addWarning("Data", "No output paths defined")
     return(result)
   }
 
-  result <- .check_no_duplicates(names(outputPaths), "outputPathId", result)
+  result <- .checkNoDuplicates(names(outputPaths), "outputPathId", result)
 
   values <- unlist(outputPaths, use.names = FALSE)
   emptyIds <- names(outputPaths)[is.na(values) | values == ""]
   if (length(emptyIds) > 0) {
-    result$add_critical_error(
+    result$addCriticalError(
       "Missing Fields",
       paste0(
         "Empty output path values for IDs: ",
@@ -225,7 +225,7 @@ setOutputPath <- function(project, id, path) {
 
   dupeValues <- values[duplicated(values) & !is.na(values)]
   if (length(dupeValues) > 0) {
-    result$add_warning(
+    result$addWarning(
       "Uniqueness",
       paste0(
         "Multiple IDs point to the same output path: ",

--- a/R/parameter-identification.R
+++ b/R/parameter-identification.R
@@ -537,7 +537,7 @@ print.PITask <- function(x, ...) {
 .validatePI <- function(piTasks) {
   result <- validationResult$new()
   if (is.null(piTasks) || length(piTasks) == 0L) {
-    result$add_warning("Data", "No parameterIdentification tasks defined")
+    result$addWarning("Data", "No parameterIdentification tasks defined")
     return(result)
   }
 
@@ -545,14 +545,14 @@ print.PITask <- function(x, ...) {
     task <- piTasks[[taskId]]
 
     paramIds <- vapply(task$parameters, `[[`, character(1), "id")
-    .check_no_duplicates(
+    .checkNoDuplicates(
       paramIds,
       paste0("PIParameter id within task '", taskId, "'"),
       result
     )
 
     mappingIds <- vapply(task$outputMappings, `[[`, character(1), "id")
-    .check_no_duplicates(
+    .checkNoDuplicates(
       mappingIds,
       paste0("PIOutputMapping id within task '", taskId, "'"),
       result
@@ -560,7 +560,7 @@ print.PITask <- function(x, ...) {
 
     for (p in task$parameters) {
       if (!(p$minValue <= p$startValue && p$startValue <= p$maxValue)) {
-        result$add_critical_error(
+        result$addCriticalError(
           "Invalid Bounds",
           messages$errorPIInvalidBounds(
             p$path,
@@ -572,7 +572,7 @@ print.PITask <- function(x, ...) {
       }
       outsideTask <- setdiff(p$scenarios, task$scenarios)
       if (length(outsideTask) > 0L) {
-        result$add_critical_error(
+        result$addCriticalError(
           "Invalid Reference",
           paste0(
             "PI task '",
@@ -589,7 +589,7 @@ print.PITask <- function(x, ...) {
     for (m in task$outputMappings) {
       outsideTask <- setdiff(m$scenarios, task$scenarios)
       if (length(outsideTask) > 0L) {
-        result$add_critical_error(
+        result$addCriticalError(
           "Invalid Reference",
           paste0(
             "PI task '",

--- a/R/parameter-identification.R
+++ b/R/parameter-identification.R
@@ -51,7 +51,7 @@ PIParameter <- function(
   startValue
 ) {
   if (!is.character(id) || length(id) != 1L || is.na(id) || nchar(id) == 0) {
-    cli::cli_abort(messages$errorPIRequiredField(
+    cli::cli_abort(messages$PIRequiredField(
       "id",
       "PIParameter",
       "<unset>"
@@ -63,12 +63,12 @@ PIParameter <- function(
       any(is.na(scenarios)) ||
       any(nchar(scenarios) == 0)
   ) {
-    cli::cli_abort(messages$errorPIScenariosEmpty("PIParameter", id))
+    cli::cli_abort(messages$PIScenariosEmpty("PIParameter", id))
   }
   if (
     !is.character(path) || length(path) != 1L || is.na(path) || nchar(path) == 0
   ) {
-    cli::cli_abort(messages$errorPIRequiredField("path", "PIParameter", id))
+    cli::cli_abort(messages$PIRequiredField("path", "PIParameter", id))
   }
   # `units` is optional: NULL or an empty string both mean "no display unit".
   # A non-empty string is the declared unit. NA or a non-scalar must never
@@ -78,25 +78,25 @@ PIParameter <- function(
     !is.null(units) &&
       (!is.character(units) || length(units) != 1L || is.na(units))
   ) {
-    cli::cli_abort(messages$errorPIRequiredField("units", "PIParameter", id))
+    cli::cli_abort(messages$PIRequiredField("units", "PIParameter", id))
   }
   if (!is.numeric(minValue) || length(minValue) != 1L || is.na(minValue)) {
-    cli::cli_abort(messages$errorPIRequiredField("minValue", "PIParameter", id))
+    cli::cli_abort(messages$PIRequiredField("minValue", "PIParameter", id))
   }
   if (!is.numeric(maxValue) || length(maxValue) != 1L || is.na(maxValue)) {
-    cli::cli_abort(messages$errorPIRequiredField("maxValue", "PIParameter", id))
+    cli::cli_abort(messages$PIRequiredField("maxValue", "PIParameter", id))
   }
   if (
     !is.numeric(startValue) || length(startValue) != 1L || is.na(startValue)
   ) {
-    cli::cli_abort(messages$errorPIRequiredField(
+    cli::cli_abort(messages$PIRequiredField(
       "startValue",
       "PIParameter",
       id
     ))
   }
   if (minValue > maxValue || startValue < minValue || startValue > maxValue) {
-    cli::cli_abort(messages$errorPIInvalidBounds(
+    cli::cli_abort(messages$PIInvalidBounds(
       path,
       minValue,
       startValue,
@@ -169,7 +169,7 @@ PIOutputMapping <- function(
   weight = NULL
 ) {
   if (!is.character(id) || length(id) != 1L || is.na(id) || nchar(id) == 0) {
-    cli::cli_abort(messages$errorPIRequiredField(
+    cli::cli_abort(messages$PIRequiredField(
       "id",
       "PIOutputMapping",
       "<unset>"
@@ -181,7 +181,7 @@ PIOutputMapping <- function(
       any(is.na(scenarios)) ||
       any(nchar(scenarios) == 0)
   ) {
-    cli::cli_abort(messages$errorPIScenariosEmpty("PIOutputMapping", id))
+    cli::cli_abort(messages$PIScenariosEmpty("PIOutputMapping", id))
   }
   if (
     !is.character(outputPath) ||
@@ -189,7 +189,7 @@ PIOutputMapping <- function(
       is.na(outputPath) ||
       nchar(outputPath) == 0
   ) {
-    cli::cli_abort(messages$errorPIRequiredField(
+    cli::cli_abort(messages$PIRequiredField(
       "outputPath",
       "PIOutputMapping",
       id
@@ -201,7 +201,7 @@ PIOutputMapping <- function(
       is.na(observedData) ||
       nchar(observedData) == 0
   ) {
-    cli::cli_abort(messages$errorPIRequiredField(
+    cli::cli_abort(messages$PIRequiredField(
       "observedData",
       "PIOutputMapping",
       id
@@ -214,12 +214,12 @@ PIOutputMapping <- function(
         is.na(scaling) ||
         nchar(scaling) == 0)
   ) {
-    cli::cli_abort(messages$errorPIInvalidScaling(id, scaling))
+    cli::cli_abort(messages$PIInvalidScaling(id, scaling))
   }
   for (field in c("xOffset", "yOffset", "xFactor", "yFactor")) {
     value <- get(field)
     if (!is.numeric(value) || length(value) != 1L || is.na(value)) {
-      cli::cli_abort(messages$errorPIInvalidNumericField(field, id, value))
+      cli::cli_abort(messages$PIInvalidNumericField(field, id, value))
     }
   }
   # `weight` may arrive as a bare list of numbers from a JSON round trip, so
@@ -231,7 +231,7 @@ PIOutputMapping <- function(
         !is.numeric(flatWeight) ||
         any(is.na(flatWeight))
     ) {
-      cli::cli_abort(messages$errorPIInvalidNumericField("weight", id, weight))
+      cli::cli_abort(messages$PIInvalidNumericField("weight", id, weight))
     }
   }
 
@@ -314,7 +314,7 @@ PITask <- function(
   configuration = list()
 ) {
   if (!is.character(id) || length(id) != 1L || is.na(id) || nchar(id) == 0) {
-    cli::cli_abort(messages$errorPIRequiredField("id", "PITask", "<unset>"))
+    cli::cli_abort(messages$PIRequiredField("id", "PITask", "<unset>"))
   }
 
   if (
@@ -323,15 +323,15 @@ PITask <- function(
       any(is.na(scenarios)) ||
       any(nchar(scenarios) == 0)
   ) {
-    cli::cli_abort(messages$errorPIScenariosEmpty("PITask", id))
+    cli::cli_abort(messages$PIScenariosEmpty("PITask", id))
   }
 
   if (!is.list(parameters) || length(parameters) == 0L) {
-    cli::cli_abort(messages$errorPIEmptyList("parameters", id))
+    cli::cli_abort(messages$PIEmptyList("parameters", id))
   }
   for (i in seq_along(parameters)) {
     if (!inherits(parameters[[i]], "PIParameter")) {
-      cli::cli_abort(messages$errorPIWrongElementType(
+      cli::cli_abort(messages$PIWrongElementType(
         "parameters",
         i,
         id,
@@ -341,12 +341,12 @@ PITask <- function(
   }
 
   if (!is.list(outputMappings) || length(outputMappings) == 0L) {
-    cli::cli_abort(messages$errorPIEmptyList("outputMappings", id))
+    cli::cli_abort(messages$PIEmptyList("outputMappings", id))
   }
   for (i in seq_along(outputMappings)) {
     if (!inherits(outputMappings[[i]], "PIOutputMapping")) {
       cli::cli_abort(
-        messages$errorPIWrongElementType(
+        messages$PIWrongElementType(
           "outputMappings",
           i,
           id,
@@ -562,7 +562,7 @@ print.PITask <- function(x, ...) {
       if (!(p$minValue <= p$startValue && p$startValue <= p$maxValue)) {
         result$addCriticalError(
           "Invalid Bounds",
-          messages$errorPIInvalidBounds(
+          messages$PIInvalidBounds(
             p$path,
             p$minValue,
             p$startValue,
@@ -634,7 +634,7 @@ print.PITask <- function(x, ...) {
   for (sName in scenarioNames) {
     sc <- project$definitions$scenarios[[sName]]
     if (is.null(sc)) {
-      cli::cli_abort(messages$errorPIScenarioNotFound(
+      cli::cli_abort(messages$PIScenarioNotFound(
         sName,
         names(project$definitions$scenarios)
       ))
@@ -675,14 +675,14 @@ print.PITask <- function(x, ...) {
     paramObjs <- lapply(p$scenarios, function(sName) {
       sim <- simulations[[sName]]
       if (is.null(sim)) {
-        cli::cli_abort(messages$errorPIScenarioNotFound(
+        cli::cli_abort(messages$PIScenarioNotFound(
           sName,
           names(simulations)
         ))
       }
       param <- ospsuite::getParameter(p$path, container = sim)
       if (is.null(param)) {
-        cli::cli_abort(messages$errorPIParameterNotFound(p$path, sim$name))
+        cli::cli_abort(messages$PIParameterNotFound(p$path, sim$name))
       }
       param
     })
@@ -718,14 +718,14 @@ print.PITask <- function(x, ...) {
     for (sName in m$scenarios) {
       sim <- simulations[[sName]]
       if (is.null(sim)) {
-        cli::cli_abort(messages$errorPIScenarioNotFound(
+        cli::cli_abort(messages$PIScenarioNotFound(
           sName,
           names(simulations)
         ))
       }
       quantity <- ospsuite::getQuantity(fullPath, container = sim)
       if (is.null(quantity)) {
-        cli::cli_abort(messages$errorPIOutputQuantityNotFound(
+        cli::cli_abort(messages$PIOutputQuantityNotFound(
           fullPath,
           sim$name
         ))
@@ -735,7 +735,7 @@ print.PITask <- function(x, ...) {
       )
       ds <- observedData[[m$observedDataId]]
       if (is.null(ds)) {
-        cli::cli_abort(messages$errorPIDatasetNotFound(
+        cli::cli_abort(messages$PIDatasetNotFound(
           m$observedDataId,
           names(observedData)
         ))
@@ -965,7 +965,7 @@ runPI <- function(
   # hours-long) optimisations.
   runtimes <- list()
   for (taskName in tasks) {
-    msg <- messages$messageBuildingPITask(taskName)
+    msg <- messages$buildingPITask(taskName)
     cli::cli_inform("{msg}")
     runtimes[[taskName]] <- .createSinglePITask(
       project = project,
@@ -977,7 +977,7 @@ runPI <- function(
 
   results <- list()
   for (taskName in tasks) {
-    msg <- messages$messageRunningPITask(taskName)
+    msg <- messages$runningPITask(taskName)
     cli::cli_inform("{msg}")
     runtime <- runtimes[[taskName]]
     entry <- tryCatch(
@@ -1156,7 +1156,7 @@ addPITask <- function(
 
   # Only dereference the output-path reference on well-typed records (the kept
   # record field is `outputPathId`). Malformed entries are left for PITask() to
-  # reject with the typed errorPIWrongElementType, instead of dying here on a
+  # reject with the typed PIWrongElementType, instead of dying here on a
   # raw "$ operator is invalid for atomic vectors".
   if (is.list(outputMappings)) {
     for (m in outputMappings) {

--- a/R/parameters.R
+++ b/R/parameters.R
@@ -87,7 +87,7 @@ readParametersFromXLS <- function(paramsXLSpath, sheets = NULL) {
     data <- readExcel(path = paramsXLSpath, sheet = sheet)
 
     if (!all(columnNames %in% names(data))) {
-      cli::cli_abort(messages$errorWrongXLSStructure(
+      cli::cli_abort(messages$wrongXLSStructure(
         filePath = paramsXLSpath,
         expectedColNames = columnNames
       ))
@@ -108,7 +108,7 @@ readParametersFromXLS <- function(paramsXLSpath, sheets = NULL) {
     isBlankValue <- is.na(valuesRaw) | trimws(as.character(valuesRaw)) == ""
     invalidValues <- !isBlankValue & is.na(parsedValues)
     if (any(invalidValues)) {
-      cli::cli_abort(messages$errorMissingValuesInParameters(
+      cli::cli_abort(messages$missingValuesInParameters(
         filePath = paramsXLSpath,
         parameterPaths = fullPaths[invalidValues]
       ))
@@ -122,7 +122,7 @@ readParametersFromXLS <- function(paramsXLSpath, sheets = NULL) {
       intersect(fullPaths, seenPaths)
     ))
     if (length(duplicatePaths) > 0) {
-      cli::cli_warn(messages$warningDuplicateParameters(
+      cli::cli_warn(messages$duplicateParameters(
         filePath = paramsXLSpath,
         parameterPaths = duplicatePaths
       ))
@@ -301,7 +301,7 @@ extendParameterStructure <- function(parameters, newParameters) {
     data <- readExcel(path = filePath, sheet = sheet)
 
     if (!all(columnNames %in% names(data))) {
-      msg <- messages$errorWrongXLSStructure(
+      msg <- messages$wrongXLSStructure(
         filePath = filePath,
         expectedColNames = columnNames
       )
@@ -320,7 +320,7 @@ extendParameterStructure <- function(parameters, newParameters) {
     isPresent[numericFlag] <- isPresentChr[numericFlag] == "1"
     invalidIsPresent <- !isBlank & is.na(isPresent)
     if (any(invalidIsPresent)) {
-      msg <- messages$errorInvalidIsPresentInInitialConditions(
+      msg <- messages$invalidIsPresentInInitialConditions(
         filePath = filePath,
         moleculePaths = paste(
           data[["Container Path"]],
@@ -350,7 +350,7 @@ extendParameterStructure <- function(parameters, newParameters) {
       is.na(moleculeName) |
       trimws(moleculeName) == ""
     if (any(missingPathParts)) {
-      msg <- messages$errorMissingPathInInitialConditions(
+      msg <- messages$missingPathInInitialConditions(
         filePath = filePath,
         sheet = sheet,
         rows = keptRowNumbers[missingPathParts]
@@ -368,7 +368,7 @@ extendParameterStructure <- function(parameters, newParameters) {
       intersect(fullPaths, seenPaths)
     ))
     if (length(duplicatePaths) > 0) {
-      msg <- messages$warningDuplicateInitialConditions(
+      msg <- messages$duplicateInitialConditions(
         filePath = filePath,
         moleculePaths = duplicatePaths
       )
@@ -380,7 +380,7 @@ extendParameterStructure <- function(parameters, newParameters) {
     parsedValues <- suppressWarnings(as.numeric(data[["Value"]]))
     missingValues <- is.na(parsedValues)
     if (any(missingValues)) {
-      msg <- messages$errorMissingValuesInInitialConditions(
+      msg <- messages$missingValuesInInitialConditions(
         filePath = filePath,
         moleculePaths = fullPaths[missingValues]
       )
@@ -390,7 +390,7 @@ extendParameterStructure <- function(parameters, newParameters) {
     unitsRaw <- as.character(data[["Units"]])
     missingUnits <- is.na(data[["Units"]]) | trimws(unitsRaw) == ""
     if (any(missingUnits)) {
-      msg <- messages$errorMissingUnitsInInitialConditions(
+      msg <- messages$missingUnitsInInitialConditions(
         filePath = filePath,
         moleculePaths = fullPaths[missingUnits]
       )

--- a/R/plots-utils.R
+++ b/R/plots-utils.R
@@ -148,7 +148,7 @@ col2hsv <- function(color) {
 #' @examples
 #' createEsqlabsPlotConfiguration()
 #'
-#' @family create-plotting-configurations
+#' @family createPlottingConfigurations
 #'
 #' @export
 createEsqlabsPlotConfiguration <- function() {
@@ -208,7 +208,7 @@ createEsqlabsPlotConfiguration <- function() {
 #' @examples
 #' createEsqlabsPlotGridConfiguration()
 #'
-#' @family create-plotting-configurations
+#' @family createPlottingConfigurations
 #'
 #' @export
 createEsqlabsPlotGridConfiguration <- function() {

--- a/R/plots-utils.R
+++ b/R/plots-utils.R
@@ -235,7 +235,7 @@ createEsqlabsPlotGridConfiguration <- function() {
 
   for (name in names(plotOverrideConfig)) {
     if (!name %in% names(plotConfiguration)) {
-      cli::cli_warn(messages$UnknownPlotConfiguration(name))
+      cli::cli_warn(messages$unknownPlotConfiguration(name))
       next
     }
 

--- a/R/plots.R
+++ b/R/plots.R
@@ -12,7 +12,7 @@
 # independent of this file.
 #
 # Called by:
-#   - Project$.read_json() via the three plots definition-tree specs
+#   - Project$.readJson() via the three plots definition-tree specs
 #     (data-combined / plots / plot-grids).
 #   - .runProjectValidation() via .validatePlots()
 #   - .projectToJson() via .dataCombinedSectionToJson() / .plotsSectionToJson()
@@ -264,7 +264,7 @@ print.DataCombined <- function(x, ...) {
       length(plotConfig %||% list()) == 0 &&
       length(plotGrids %||% list()) == 0
   ) {
-    result$add_warning("Data", "No plots defined")
+    result$addWarning("Data", "No plots defined")
     return(result)
   }
 
@@ -272,13 +272,13 @@ print.DataCombined <- function(x, ...) {
   plotGrids <- plotGrids %||% list()
 
   if (is.null(dataCombined) || length(dataCombined) == 0) {
-    result$add_warning("Data", "dataCombined is empty")
+    result$addWarning("Data", "dataCombined is empty")
   } else {
     for (dcName in names(dataCombined)) {
       dc <- dataCombined[[dcName]]
       for (entry in dc$simulated %||% list()) {
         if (.isMissingField(entry$label)) {
-          result$add_critical_error(
+          result$addCriticalError(
             "Missing Fields",
             paste0(
               "Simulated entry in dataCombined '",
@@ -288,7 +288,7 @@ print.DataCombined <- function(x, ...) {
           )
         }
         if (.isMissingField(entry$scenario)) {
-          result$add_critical_error(
+          result$addCriticalError(
             "Missing Fields",
             paste0(
               "Simulated entry in dataCombined '",
@@ -298,7 +298,7 @@ print.DataCombined <- function(x, ...) {
           )
         }
         if (.isMissingField(entry$path)) {
-          result$add_critical_error(
+          result$addCriticalError(
             "Missing Fields",
             paste0(
               "Simulated entry in dataCombined '",
@@ -310,7 +310,7 @@ print.DataCombined <- function(x, ...) {
       }
       for (entry in dc$observed %||% list()) {
         if (.isMissingField(entry$label)) {
-          result$add_critical_error(
+          result$addCriticalError(
             "Missing Fields",
             paste0(
               "Observed entry in dataCombined '",
@@ -320,7 +320,7 @@ print.DataCombined <- function(x, ...) {
           )
         }
         if (.isMissingField(entry$dataSet)) {
-          result$add_critical_error(
+          result$addCriticalError(
             "Missing Fields",
             paste0(
               "Observed entry in dataCombined '",
@@ -334,7 +334,7 @@ print.DataCombined <- function(x, ...) {
   }
 
   if (length(plotConfig) == 0) {
-    result$add_warning("Data", "plotConfiguration is empty")
+    result$addWarning("Data", "plotConfiguration is empty")
   } else {
     for (field in c("plotId", "dataCombinedId", "plotType")) {
       missingField <- Filter(
@@ -342,7 +342,7 @@ print.DataCombined <- function(x, ...) {
         plotConfig
       )
       if (length(missingField) > 0) {
-        result$add_critical_error(
+        result$addCriticalError(
           "Missing Fields",
           paste0("plotConfiguration is missing required field '", field, "'")
         )
@@ -354,12 +354,12 @@ print.DataCombined <- function(x, ...) {
       function(p) p$plotId %||% NA_character_,
       character(1)
     )
-    result <- .check_no_duplicates(plotIds, "plotId", result)
+    result <- .checkNoDuplicates(plotIds, "plotId", result)
 
     plotTypes <- unlist(lapply(plotConfig, function(p) p$plotType))
     invalidTypes <- setdiff(plotTypes, .validPlotTypes)
     if (length(invalidTypes) > 0) {
-      result$add_critical_error(
+      result$addCriticalError(
         "Invalid Reference",
         paste0(
           "plotConfiguration has unknown plotType(s): ",
@@ -379,7 +379,7 @@ print.DataCombined <- function(x, ...) {
       names(dataCombined %||% list())
     )
     if (length(invalidDataCombinedRefs) > 0) {
-      result$add_critical_error(
+      result$addCriticalError(
         "Invalid Reference",
         paste0(
           "plotConfiguration references unknown dataCombinedId: ",
@@ -412,7 +412,7 @@ print.DataCombined <- function(x, ...) {
     )))
     invalidGridRefs <- setdiff(allGridIds, knownPlotIds)
     if (length(invalidGridRefs) > 0) {
-      result$add_critical_error(
+      result$addCriticalError(
         "Invalid Reference",
         paste0(
           "plotGrids references unknown plotIds: ",
@@ -459,7 +459,7 @@ print.DataCombined <- function(x, ...) {
         presentFields
       )
       for (field in presentFields) {
-        result$add_warning(
+        result$addWarning(
           "Data",
           paste0(
             "Plot '",

--- a/R/populations.R
+++ b/R/populations.R
@@ -257,7 +257,7 @@ extendPopulationFromXLS <- function(population, XLSpath, sheet = NULL) {
     },
     error = function(e) {
       cli::cli_abort(
-        messages$errorWrongXLSStructure(
+        messages$wrongXLSStructure(
           filePath = XLSpath,
           expectedColNames = columnNames
         )
@@ -267,7 +267,7 @@ extendPopulationFromXLS <- function(population, XLSpath, sheet = NULL) {
 
   if (!all(columnNames %in% names(data))) {
     cli::cli_abort(
-      messages$errorWrongXLSStructure(
+      messages$wrongXLSStructure(
         filePath = XLSpath,
         expectedColNames = columnNames
       )
@@ -321,7 +321,7 @@ Distributions <- enum(list(
 #' @export
 sampleRandomValue <- function(distribution, mean, sd, n) {
   if (!enumHasKey(distribution, Distributions)) {
-    cli::cli_abort(messages$errorDistributionNotSupported(distribution))
+    cli::cli_abort(messages$distributionNotSupported(distribution))
   }
 
   if (distribution == Distributions$Normal) {

--- a/R/populations.R
+++ b/R/populations.R
@@ -71,14 +71,14 @@
   result <- validationResult$new()
 
   if (is.null(populations) || length(populations) == 0) {
-    result$add_warning("Data", "No populations defined")
+    result$addWarning("Data", "No populations defined")
     return(result)
   }
 
   for (id in names(populations)) {
     pop <- populations[[id]]
 
-    result <- .check_required_fields(
+    result <- .checkRequiredFields(
       pop,
       c("species"),
       paste0("population '", id, "'"),
@@ -88,7 +88,7 @@
     if (!is.null(pop$proportionOfFemales)) {
       pof <- as.numeric(pop$proportionOfFemales)
       if (!is.na(pof) && (pof < 0 || pof > 100)) {
-        result$add_warning(
+        result$addWarning(
           "Data Range",
           paste0(
             "proportionOfFemales in population '",
@@ -115,7 +115,7 @@
           !is.na(hi) &&
           lo > hi
       ) {
-        result$add_warning(
+        result$addWarning(
           "Data Range",
           paste0(pair[1], " > ", pair[2], " in population '", id, "'")
         )

--- a/R/project-excel.R
+++ b/R/project-excel.R
@@ -112,7 +112,7 @@ importProjectFromExcel <- function(
     # Containment is judged on the raw (pre-expansion) value: a `${VAR}` opts
     # into an out-of-project location and is exempt, everything else must stay
     # under `pcDir`. Resolution then expands the variable and joins a relative
-    # value onto `pcDir`, matching `.clean_path()`'s expand-then-resolve order.
+    # value onto `pcDir`, matching `.cleanPath()`'s expand-then-resolve order.
     declaresEnvVar <- grepl("\\$\\{?[A-Za-z_]", configsFolderRaw)
     if (!declaresEnvVar) {
       configsFolder <- .resolveProjectPath(

--- a/R/project-excel.R
+++ b/R/project-excel.R
@@ -32,7 +32,7 @@
 #' @return Invisibly returns the path to the created project file (the
 #'   `Project.json`).
 #' @export
-#' @family project persistence
+#' @family projectPersistence
 importProjectFromExcel <- function(
   projectConfigPath = "Project.xlsx",
   outputDir = NULL,
@@ -412,7 +412,7 @@ importProjectFromExcel <- function(
 #' @return Invisibly returns the path to the created
 #'   `Project.xlsx`.
 #' @export
-#' @family project persistence
+#' @family projectPersistence
 exportProjectToExcel <- function(
   project,
   outputDir = NULL,
@@ -802,7 +802,7 @@ exportProjectToExcel <- function(
 #' @returns Invisibly, a `list(tree_in_sync, excel_in_sync, details)` (see
 #'   the `status` field of [Project]).
 #' @export
-#' @family project persistence
+#' @family projectPersistence
 #' @seealso [saveProject()], [reloadProject()], [exportProjectToExcel()],
 #'   [importProjectFromExcel()].
 #' @examples

--- a/R/project-lifecycle.R
+++ b/R/project-lifecycle.R
@@ -16,7 +16,7 @@
 #'
 #' @returns Object of type `Project`
 #' @export
-#' @family project persistence
+#' @family projectPersistence
 #' @seealso [saveProject()], [reloadProject()], [snapshotProject()],
 #'   [restoreProject()], [projectStatus()].
 #'
@@ -83,7 +83,7 @@ loadProject <- function(path = "Project.json") {
 #'
 #' @returns Invisibly, the `project`.
 #' @export
-#' @family project persistence
+#' @family projectPersistence
 #' @seealso [loadProject()], [reloadProject()], [snapshotProject()],
 #'   [restoreProject()], [projectStatus()].
 #' @examples
@@ -165,7 +165,7 @@ saveProject <- function(project) {
 #'
 #' @returns Invisibly, the `project`, with unsaved changes discarded.
 #' @export
-#' @family project persistence
+#' @family projectPersistence
 #' @seealso [loadProject()], [saveProject()], [snapshotProject()],
 #'   [restoreProject()], [projectStatus()].
 #' @examples
@@ -298,7 +298,7 @@ isProjectInitialized <- function(destination = ".") {
 #' @returns Invisibly returns `destination`, the path the project was
 #'   initialized in.
 #' @export
-#' @family project persistence
+#' @family projectPersistence
 initProject <- function(
   destination = ".",
   type = c("minimal", "example"),
@@ -506,7 +506,7 @@ initProject <- function(
 #' @returns A string representing the path to the example
 #'   `Project.json` file shipped with the package.
 #' @export
-#' @family project persistence
+#' @family projectPersistence
 #' @examples
 #' exampleProjectPath()
 exampleProjectPath <- function() {

--- a/R/project-lifecycle.R
+++ b/R/project-lifecycle.R
@@ -215,7 +215,7 @@ reloadProject <- function(project) {
     sections = c("scenarios", "crossReferences")
   )
   r <- results$crossReferences
-  if (is.null(r) || !r$has_critical_errors()) {
+  if (is.null(r) || !r$hasCriticalErrors()) {
     return(invisible(NULL))
   }
   bullets <- vapply(r$critical_errors, function(e) e$message, character(1))

--- a/R/project-snapshot.R
+++ b/R/project-snapshot.R
@@ -42,7 +42,7 @@
 #' @returns Invisibly, the path of the written snapshot file (always with the
 #'   `.esqlabsR` extension).
 #' @export
-#' @family project persistence
+#' @family projectPersistence
 #' @seealso [restoreProject()], [loadProject()], [saveProject()].
 #' @examples
 #' # Create a temporary example project and snapshot it to a single file.
@@ -129,7 +129,7 @@ snapshotProject <- function(
 #' @returns A freshly loaded `Project` working from `dir`, with no unsaved
 #'   changes.
 #' @export
-#' @family project persistence
+#' @family projectPersistence
 #' @seealso [snapshotProject()], [loadProject()], [reloadProject()].
 #' @examples
 #' # Write a snapshot, then recreate a project folder from it.

--- a/R/project-to-json.R
+++ b/R/project-to-json.R
@@ -1,6 +1,6 @@
 # v2.0 Project → JSON serialization (internal) ----
 #
-# Inverse of `Project$.read_json()` (called by `Project$new()`). Walks a
+# Inverse of `Project$.readJson()` (called by `Project$new()`). Walks a
 # `Project` and emits a v2.0 `Project.json` file. The contract is:
 #
 #   loadProject(path) |> saveSnapshot(out)  produces a JSON file that, when
@@ -18,7 +18,7 @@
 
 #' Internal: render a `Project` to a JSON-shaped R list in the v2.0 schema.
 #'
-#' Not exported. Companion to `Project$.read_json()`. The list returned here
+#' Not exported. Companion to `Project$.readJson()`. The list returned here
 #' is the canonical input to `jsonlite::write_json` (see `.saveProjectJson()`);
 #' writing and re-parsing it yields a structurally identical `Project`.
 #'
@@ -190,7 +190,7 @@
 # Per-section helpers ---------------------------------------------------------
 #
 # Each helper is paired with a `.parse<Section>()` (called from
-# `Project$.read_json()`) and is the canonical place for that section's
+# `Project$.readJson()`) and is the canonical place for that section's
 # JSON-shape concerns. Today most helpers are trivial because the parser is
 # JSON-faithful; the bodies will grow as section-specific transformations
 # move here from caller code (e.g. relative-path normalization, ID

--- a/R/project.R
+++ b/R/project.R
@@ -233,7 +233,7 @@ Project <- R6::R6Class(
       ) {
         cli::cli_abort(messages$invalidPathArgument())
       }
-      private$.read_json(projectFilePath)
+      private$.readJson(projectFilePath)
       invisible(self)
     },
 
@@ -833,7 +833,7 @@ Project <- R6::R6Class(
     # Build one writable get/set spec for a `{value, description}` record field
     # stored under `private[[store]][[name]]`. The getter resolves the raw value
     # against `parentFn()` (a resolver returning the base path) via
-    # `.clean_path()`, so a folder/file field reads resolved and writes verbatim;
+    # `.cleanPath()`, so a folder/file field reads resolved and writes verbatim;
     # the setter stores the raw value and invalidates the container. Shared by
     # the `paths` and `excel` groups, which differ only in `store` and `parentFn`.
     .recordFieldSpec = function(store, name, parentFn) {
@@ -842,7 +842,7 @@ Project <- R6::R6Class(
       force(parentFn)
       list(
         get = function() {
-          private$.clean_path(private[[store]][[name]]$value, parentFn())
+          private$.cleanPath(private[[store]][[name]]$value, parentFn())
         },
         set = function(value) {
           private[[store]][[name]]$value <- value
@@ -898,7 +898,7 @@ Project <- R6::R6Class(
     # writable (raw on write, resolved on read); every write sets the dirty bit.
     .excelGroup = function() {
       configResolved <- function() {
-        private$.clean_path(
+        private$.cleanPath(
           private$.excelData$configurationsFolder$value,
           private$.projectDirPath
         )
@@ -1208,18 +1208,18 @@ Project <- R6::R6Class(
     # identity is preserved (the same R6 instance is mutated), so existing
     # handles stay valid.
     .reload = function() {
-      private$.read_json(private$.projectFilePath)
+      private$.readJson(private$.projectFilePath)
       invisible(self)
     },
 
-    .replace_env_var = function(path) {
+    .replaceEnvVar = function(path) {
       .replaceEnvVarPath(path)
     },
 
-    .clean_path = function(
+    .cleanPath = function(
       path,
       parent = NULL,
-      replace_env_vars = TRUE
+      replaceEnvVars = TRUE
     ) {
       if (
         is.null(path) ||
@@ -1228,8 +1228,8 @@ Project <- R6::R6Class(
       ) {
         return(NULL)
       }
-      if (replace_env_vars) {
-        path <- private$.replace_env_var(path)
+      if (replaceEnvVars) {
+        path <- private$.replaceEnvVar(path)
       }
       if (
         is.null(parent) ||
@@ -1258,7 +1258,7 @@ Project <- R6::R6Class(
     .resolveWorkingFolder = function(name) {
       raw <- private$.filePathsData[[name]]$value
       projectDir <- private$.projectDirPath
-      resolved <- private$.clean_path(raw, projectDir)
+      resolved <- private$.cleanPath(raw, projectDir)
       if (is.null(resolved)) {
         return(NULL)
       }
@@ -1292,7 +1292,7 @@ Project <- R6::R6Class(
       resolved
     },
 
-    .read_json = function(jsonPath) {
+    .readJson = function(jsonPath) {
       jsonPath <- fs::path_abs(jsonPath)
       if (!fs::file_exists(jsonPath)) {
         cli::cli_abort(messages$fileNotFound(jsonPath))

--- a/R/scenario-execution.R
+++ b/R/scenario-execution.R
@@ -156,7 +156,7 @@
   ) {
     appData <- project$definitions$applications[[scenario$applicationProtocol]]
     if (is.null(appData)) {
-      cli::cli_abort(messages$errorApplicationProtocolNotFound(
+      cli::cli_abort(messages$applicationProtocolNotFound(
         scenarioName = scenario$scenarioName,
         applicationProtocol = scenario$applicationProtocol
       ))
@@ -261,7 +261,7 @@
   if (!is.null(scenario$individualId) && !is.na(scenario$individualId)) {
     indivData <- project$definitions$individuals[[scenario$individualId]]
     if (is.null(indivData)) {
-      cli::cli_warn(messages$warningNoIndividualCharacteristics(
+      cli::cli_warn(messages$noIndividualCharacteristics(
         scenarioName = scenario$scenarioName,
         individualId = scenario$individualId
       ))
@@ -298,7 +298,7 @@
   # 4. Set simulation time intervals
   if (!is.null(scenario$simulationTime)) {
     if (is.null(scenario$simulationTimeUnit)) {
-      cli::cli_abort(messages$stopScenarioMissingTimeUnit(
+      cli::cli_abort(messages$scenarioMissingTimeUnit(
         scenario$scenarioName
       ))
     }
@@ -483,7 +483,7 @@
   for (i in seq_along(parts)) {
     pair <- unlist(strsplit(parts[[i]], ":", fixed = TRUE))
     if (length(pair) != 2L) {
-      cli::cli_abort(messages$errorWrongOntogenyStructure(parts[[i]]))
+      cli::cli_abort(messages$wrongOntogenyStructure(parts[[i]]))
     }
     validateEnumValue(value = pair[[2]], enum = ospsuite::StandardOntogeny)
     out[[i]] <- ospsuite::MoleculeOntogeny$new(

--- a/R/scenario-results.R
+++ b/R/scenario-results.R
@@ -97,7 +97,7 @@ saveScenarioResults <- function(
         ospsuite::exportResultsToCSV(results = results, filePath = outputPath)
       },
       error = function(cond) {
-        cli::cli_warn(messages$errorSavingScenarioResult(
+        cli::cli_warn(messages$savingScenarioResult(
           scenarioName = scenarioName,
           conditionMessage = conditionMessage(cond)
         ))

--- a/R/scenarios.R
+++ b/R/scenarios.R
@@ -335,7 +335,7 @@ print.Scenario <- function(x, ...) {
   result <- validationResult$new()
 
   if (is.null(scenarios) || length(scenarios) == 0) {
-    result$add_warning("Data", "No scenarios defined")
+    result$addWarning("Data", "No scenarios defined")
     return(result)
   }
 
@@ -343,7 +343,7 @@ print.Scenario <- function(x, ...) {
     sc <- scenarios[[name]]
 
     if (is.null(sc$modelFile) || sc$modelFile == "") {
-      result$add_critical_error(
+      result$addCriticalError(
         "Missing Fields",
         paste0("Scenario '", name, "' has no modelFile")
       )
@@ -357,7 +357,7 @@ print.Scenario <- function(x, ...) {
         !fs::is_absolute_path(sc$modelFile) &&
           .pathEscapesRoot(sc$modelFile, simulationsFolder)
       ) {
-        result$add_critical_error(
+        result$addCriticalError(
           "Path Containment",
           paste0(
             "Scenario '",
@@ -369,7 +369,7 @@ print.Scenario <- function(x, ...) {
       } else {
         modelFilePath <- file.path(simulationsFolder, sc$modelFile)
         if (!file.exists(modelFilePath)) {
-          result$add_warning(
+          result$addWarning(
             "File Not Found",
             paste0(
               "Scenario '",
@@ -384,7 +384,7 @@ print.Scenario <- function(x, ...) {
 
     simType <- sc$simulationType %||% ""
     if (!simType %in% c("Individual", "Population")) {
-      result$add_critical_error(
+      result$addCriticalError(
         "Validation",
         paste0(
           "Scenario '",
@@ -406,14 +406,14 @@ print.Scenario <- function(x, ...) {
       nzchar(sc$populationId)
 
     if (simType == "Population" && !hasPopulationId) {
-      result$add_critical_error(
+      result$addCriticalError(
         "Missing Fields",
         paste0("Population scenario '", name, "' has no populationId")
       )
     }
 
     if (simType != "Population" && hasPopulationId) {
-      result$add_warning(
+      result$addWarning(
         "Validation",
         paste0(
           "Scenario '",
@@ -584,7 +584,7 @@ print.Scenario <- function(x, ...) {
 .validateApplications <- function(applications) {
   result <- validationResult$new()
   if (is.null(applications) || length(applications) == 0) {
-    result$add_warning("Data", "No applications defined")
+    result$addWarning("Data", "No applications defined")
   }
   result
 }

--- a/R/sensitivity-calculation-utils.R
+++ b/R/sensitivity-calculation-utils.R
@@ -219,7 +219,7 @@
     pkParameter <- unique(data$PKParameter)[1]
 
     cli::cli_warn(
-      messages$warningSensitivityPKParameterNotCalculated(
+      messages$sensitivityPKParameterNotCalculated(
         parameterPath,
         pkParameter
       )
@@ -488,7 +488,7 @@
     listNames <- names(object)
     argName <- deparse(substitute(object))
     if (hasEmptyStrings(listNames)) {
-      cli::cli_abort(messages$errorNotNamedList(argName))
+      cli::cli_abort(messages$notNamedList(argName))
     }
   }
 }
@@ -570,7 +570,7 @@ saveSensitivityCalculation <- function(
 
   if (dir.exists(outputDir)) {
     if (!overwrite) {
-      cli::cli_abort(messages$errorOutputDirExists(outputDir))
+      cli::cli_abort(messages$outputDirExists(outputDir))
     }
 
     contents <- list.files(outputDir, all.files = TRUE, no.. = TRUE)
@@ -646,7 +646,7 @@ loadSensitivityCalculation <- function(outputDir, simulation = NULL) {
 
   metaPath <- file.path(outputDir, "sensitivityCalculation.meta")
   if (!file.exists(metaPath)) {
-    cli::cli_abort(messages$errorSensitivityCalculationNotFound(metaPath))
+    cli::cli_abort(messages$sensitivityCalculationNotFound(metaPath))
   }
 
   # Load sensitivityCalculation structure
@@ -661,7 +661,7 @@ loadSensitivityCalculation <- function(outputDir, simulation = NULL) {
       },
       error = function(e) {
         cli::cli_abort(
-          messages$errorFailedToLoadSimulation(simFilePath, e$message)
+          messages$failedToLoadSimulation(simFilePath, e$message)
         )
       }
     )
@@ -679,7 +679,7 @@ loadSensitivityCalculation <- function(outputDir, simulation = NULL) {
 
   expectedCount <- length(parameterPaths) * length(variationRange)
   if (length(simResultFiles) != expectedCount) {
-    cli::cli_abort(messages$errorCorruptSensitivityCalculation(outputDir))
+    cli::cli_abort(messages$corruptSensitivityCalculation(outputDir))
   }
 
   simulationResults <- sensitivityCalculation$simulationResults
@@ -702,7 +702,7 @@ loadSensitivityCalculation <- function(outputDir, simulation = NULL) {
           simulationResult$allQuantityPaths
       )
     ) {
-      cli::cli_abort(messages$errorCorruptSensitivityCalculation(outputDir))
+      cli::cli_abort(messages$corruptSensitivityCalculation(outputDir))
     }
   }
 

--- a/R/sensitivity-calculation.R
+++ b/R/sensitivity-calculation.R
@@ -38,7 +38,7 @@
 #' @param simulationRunOptions Optional instance of a `SimulationRunOptions`
 #'   used during the simulation run
 #'
-#' @family sensitivity-calculation
+#' @family sensitivityCalculation
 #'
 #' @returns
 #'

--- a/R/sensitivity-spider-plot.R
+++ b/R/sensitivity-spider-plot.R
@@ -66,7 +66,7 @@
 #'
 #' @import ggplot2
 #'
-#' @family sensitivity-calculation
+#' @family sensitivityCalculation
 #'
 #' @returns A `patchwork` object containing the combined ggplot objects if a
 #'   single output path is specified, or a list of `patchwork` objects for

--- a/R/sensitivity-time-profiles.R
+++ b/R/sensitivity-time-profiles.R
@@ -53,7 +53,7 @@
 #'
 #' @import ggplot2
 #'
-#' @family sensitivity-calculation
+#' @family sensitivityCalculation
 #'
 #' @returns A `patchwork` object containing the combined ggplot objects if a
 #'   single output path is specified, or a list of `patchwork` objects for

--- a/R/sensitivity-tornado-plot.R
+++ b/R/sensitivity-tornado-plot.R
@@ -43,7 +43,7 @@
 #'
 #' @import ggplot2
 #'
-#' @family sensitivity-calculation
+#' @family sensitivityCalculation
 #'
 #' @returns A `patchwork` object containing the combined ggplot objects if a
 #'   single output path is specified, or a list of `patchwork` objects for

--- a/R/utils.R
+++ b/R/utils.R
@@ -55,7 +55,7 @@ getIndexClosestToValue <- function(
   idx <- which(distances == minDist & distances <= thresholdAbs)
 
   if (length(idx) == 0) {
-    msg <- messages$warningValueWithinThresholdNotExisting(value, thresholdAbs)
+    msg <- messages$valueWithinThresholdNotExisting(value, thresholdAbs)
     cli::cli_warn("{msg}")
     return(NULL)
   }
@@ -127,19 +127,19 @@ compareWithNA <- function(v1, v2) {
   simulationTimeIntervals <- lapply(simulationTimeIntervals, as.numeric)
   validateIsNumeric(simulationTimeIntervals)
   if (any(unlist(simulationTimeIntervals) < 0)) {
-    msg <- messages$stopWrongTimeIntervalString(simulationTimeIntervalsString)
+    msg <- messages$wrongTimeIntervalString(simulationTimeIntervalsString)
     cli::cli_abort("{msg}")
   }
   if (any(vapply(simulationTimeIntervals, length, integer(1)) != 3)) {
-    msg <- messages$stopWrongTimeIntervalString(simulationTimeIntervalsString)
+    msg <- messages$wrongTimeIntervalString(simulationTimeIntervalsString)
     cli::cli_abort("{msg}")
   }
   if (any(vapply(simulationTimeIntervals, \(x) x[3] <= 0, logical(1)))) {
-    msg <- messages$stopWrongTimeIntervalString(simulationTimeIntervalsString)
+    msg <- messages$wrongTimeIntervalString(simulationTimeIntervalsString)
     cli::cli_abort("{msg}")
   }
   if (any(vapply(simulationTimeIntervals, \(x) x[1] >= x[2], logical(1)))) {
-    msg <- messages$stopWrongTimeIntervalString(simulationTimeIntervalsString)
+    msg <- messages$wrongTimeIntervalString(simulationTimeIntervalsString)
     cli::cli_abort("{msg}")
   }
   return(simulationTimeIntervals)
@@ -213,7 +213,7 @@ getMoleculeNameFromQuantity <- function(quantity) {
 #' myEnum <- enumPutList("g", list(12, 2, "a"), myEnum, overwrite = TRUE)
 enumPutList <- function(key, values, enum, overwrite = FALSE) {
   if (length(key) > 1) {
-    msg <- messages$errorEnumPutListMultipleKeys()
+    msg <- messages$enumPutListMultipleKeys()
     cli::cli_abort("{msg}")
   }
   if (enumHasKey(key, enum) && !overwrite) {

--- a/R/validation.R
+++ b/R/validation.R
@@ -38,7 +38,7 @@ validationResult <- R6::R6Class(
     #' @param category Error category (e.g., "Structure", "Missing Fields", "Uniqueness")
     #' @param message Error message
     #' @param details Optional list with additional details (sheet, row, column)
-    add_critical_error = function(category, message, details = NULL) {
+    addCriticalError = function(category, message, details = NULL) {
       error_entry <- list(
         category = category,
         message = message,
@@ -52,7 +52,7 @@ validationResult <- R6::R6Class(
     #' @param category Warning category (e.g., "Data", "Structure")
     #' @param message Warning message
     #' @param details Optional list with additional details (sheet, row, column)
-    add_warning = function(category, message, details = NULL) {
+    addWarning = function(category, message, details = NULL) {
       warning_entry <- list(
         category = category,
         message = message,
@@ -63,17 +63,17 @@ validationResult <- R6::R6Class(
     },
 
     #' @description Check if validation passed (no critical errors)
-    is_valid = function() {
+    isValid = function() {
       length(self$critical_errors) == 0
     },
 
     #' @description Check if there are critical errors
-    has_critical_errors = function() {
+    hasCriticalErrors = function() {
       length(self$critical_errors) > 0
     },
 
     #' @description Get formatted messages for display
-    get_formatted_messages = function() {
+    getFormattedMessages = function() {
       list(
         critical = lapply(self$critical_errors, function(e) {
           paste0("[", e$category, "] ", e$message)
@@ -85,9 +85,9 @@ validationResult <- R6::R6Class(
     },
 
     #' @description Get validation summary
-    get_summary = function() {
+    getSummary = function() {
       list(
-        has_critical_errors = self$has_critical_errors(),
+        has_critical_errors = self$hasCriticalErrors(),
         critical_error_count = length(self$critical_errors),
         warning_count = length(self$warnings)
       )
@@ -287,7 +287,7 @@ isAnyCriticalErrors <- function(validationResults) {
     validationResults,
     function(r) {
       if (inherits(r, "validationResult")) {
-        r$has_critical_errors()
+        r$hasCriticalErrors()
       } else {
         FALSE
       }
@@ -326,7 +326,7 @@ validationSummary <- function(validationResults) {
   for (name in names(validationResults)) {
     result <- validationResults[[name]]
     if (inherits(result, "validationResult")) {
-      if (result$has_critical_errors()) {
+      if (result$hasCriticalErrors()) {
         summary$total_critical_errors <- summary$total_critical_errors +
           length(result$critical_errors)
         summary$sections_with_errors <- c(summary$sections_with_errors, name)
@@ -416,7 +416,7 @@ validationSummary <- function(validationResults) {
   lines <- character()
   for (section in names(results)) {
     r <- results[[section]]
-    if (!inherits(r, "validationResult") || !r$has_critical_errors()) {
+    if (!inherits(r, "validationResult") || !r$hasCriticalErrors()) {
       next
     }
     for (e in r$critical_errors) {
@@ -616,10 +616,10 @@ validationSummary <- function(validationResults) {
 #' @return The (mutated) `result`, returned for fluent chaining.
 #' @keywords internal
 #' @noRd
-.check_no_duplicates <- function(ids, fieldName, result) {
+.checkNoDuplicates <- function(ids, fieldName, result) {
   dupes <- ids[duplicated(ids) & !is.na(ids)]
   if (length(dupes) > 0) {
-    result$add_critical_error(
+    result$addCriticalError(
       "Uniqueness",
       paste0(
         "Duplicate ",
@@ -641,7 +641,7 @@ validationSummary <- function(validationResults) {
 #' @return The (mutated) `result`.
 #' @keywords internal
 #' @noRd
-.check_required_fields <- function(
+.checkRequiredFields <- function(
   entry,
   requiredFields,
   entryName,
@@ -650,7 +650,7 @@ validationSummary <- function(validationResults) {
   for (field in requiredFields) {
     val <- entry[[field]]
     if (is.null(val) || (length(val) == 1 && (is.na(val) || val == ""))) {
-      result$add_critical_error(
+      result$addCriticalError(
         "Missing Fields",
         paste0(
           "Required field '",
@@ -678,7 +678,7 @@ validationSummary <- function(validationResults) {
   result <- validationResult$new()
 
   if (is.null(parameterSets) || length(parameterSets) == 0) {
-    result$add_warning("Data", paste0("No ", sectionName, " defined"))
+    result$addWarning("Data", paste0("No ", sectionName, " defined"))
     return(result)
   }
 
@@ -708,7 +708,7 @@ validationSummary <- function(validationResults) {
           parameterNames == ""
       )
     ) {
-      result$add_critical_error(
+      result$addCriticalError(
         "Missing Fields",
         paste0(
           "Set '",
@@ -726,7 +726,7 @@ validationSummary <- function(validationResults) {
       logical(1)
     )
     if (any(nonNumeric)) {
-      result$add_warning(
+      result$addWarning(
         "Data Type",
         paste0(
           "Set '",
@@ -741,7 +741,7 @@ validationSummary <- function(validationResults) {
     fullPaths <- paste(containerPaths, parameterNames, sep = "|")
     dupes <- fullPaths[duplicated(fullPaths)]
     if (length(dupes) > 0) {
-      result$add_warning(
+      result$addWarning(
         "Uniqueness",
         paste0(
           "Duplicate parameter paths in set '",
@@ -863,7 +863,7 @@ validationSummary <- function(validationResults) {
     if (!inherits(sectionResult, "validationResult")) {
       sectionResult <- .validationAdapters[[section]](project)
     }
-    if (sectionResult$has_critical_errors()) {
+    if (sectionResult$hasCriticalErrors()) {
       return(TRUE)
     }
   }
@@ -917,7 +917,7 @@ validationSummary <- function(validationResults) {
       "plot dataCombined scenario references",
       "PI scenarios / outputPath references"
     )
-    result$add_warning(
+    result$addWarning(
       "Skipped",
       paste0(
         "Cross-reference validation skipped due to critical errors. ",
@@ -953,7 +953,7 @@ validationSummary <- function(validationResults) {
         !is.na(sc$individualId) &&
         !.refResolves(sc$individualId, individualIds)
     ) {
-      result$add_critical_error(
+      result$addCriticalError(
         "Invalid Reference",
         paste0(
           "Scenario '",
@@ -971,7 +971,7 @@ validationSummary <- function(validationResults) {
         !is.na(sc$populationId) &&
         !.refResolves(sc$populationId, populationIds)
     ) {
-      result$add_critical_error(
+      result$addCriticalError(
         "Invalid Reference",
         paste0(
           "Scenario '",
@@ -987,7 +987,7 @@ validationSummary <- function(validationResults) {
     if (!is.null(sc$modelParameterSets) && length(sc$modelParameterSets) > 0) {
       invalidSets <- .danglingRefs(sc$modelParameterSets, parameterSetKeys)
       if (length(invalidSets) > 0) {
-        result$add_critical_error(
+        result$addCriticalError(
           "Invalid Reference",
           paste0(
             "Scenario '",
@@ -1003,7 +1003,7 @@ validationSummary <- function(validationResults) {
     if (!is.null(sc$initialConditions) && length(sc$initialConditions) > 0) {
       invalidICs <- .danglingRefs(sc$initialConditions, initialConditionKeys)
       if (length(invalidICs) > 0) {
-        result$add_critical_error(
+        result$addCriticalError(
           "Invalid Reference",
           paste0(
             "Scenario '",
@@ -1021,7 +1021,7 @@ validationSummary <- function(validationResults) {
         !is.na(sc$applicationProtocol) &&
         !.refResolves(sc$applicationProtocol, applicationKeys)
     ) {
-      result$add_critical_error(
+      result$addCriticalError(
         "Invalid Reference",
         paste0(
           "Scenario '",
@@ -1041,7 +1041,7 @@ validationSummary <- function(validationResults) {
     if (!is.null(scOutputPathIds)) {
       invalidOutputPaths <- .danglingRefs(scOutputPathIds, outputPathKeys)
       if (length(invalidOutputPaths) > 0) {
-        result$add_critical_error(
+        result$addCriticalError(
           "Invalid Reference",
           paste0(
             "Scenario '",
@@ -1064,7 +1064,7 @@ validationSummary <- function(validationResults) {
     refs <- as.character(unlist(refs))
     invalid <- .danglingRefs(refs, parameterSetKeys)
     if (length(invalid) > 0) {
-      result$add_critical_error(
+      result$addCriticalError(
         "Invalid Reference",
         paste0(
           "Individual '",
@@ -1084,7 +1084,7 @@ validationSummary <- function(validationResults) {
     refs <- as.character(unlist(refs))
     invalid <- .danglingRefs(refs, parameterSetKeys)
     if (length(invalid) > 0) {
-      result$add_critical_error(
+      result$addCriticalError(
         "Invalid Reference",
         paste0(
           "Application '",
@@ -1113,7 +1113,7 @@ validationSummary <- function(validationResults) {
     }))
     invalidScenarios <- .danglingRefs(referencedScenarios, scenarioNames)
     if (length(invalidScenarios) > 0) {
-      result$add_critical_error(
+      result$addCriticalError(
         "Invalid Reference",
         paste0(
           "dataCombined references undefined scenarios: ",
@@ -1136,7 +1136,7 @@ validationSummary <- function(validationResults) {
 
     badTaskScenarios <- .danglingRefs(task$scenarios, scenarioNames)
     if (length(badTaskScenarios) > 0L) {
-      result$add_critical_error(
+      result$addCriticalError(
         "Invalid Reference",
         paste0(
           "PI task '",
@@ -1151,7 +1151,7 @@ validationSummary <- function(validationResults) {
     for (p in task$parameters) {
       bad <- .danglingRefs(p$scenarios, scenarioNames)
       if (length(bad) > 0L) {
-        result$add_critical_error(
+        result$addCriticalError(
           "Invalid Reference",
           paste0(
             "PI task '",
@@ -1169,7 +1169,7 @@ validationSummary <- function(validationResults) {
     for (m in task$outputMappings) {
       badScenarios <- .danglingRefs(m$scenarios, scenarioNames)
       if (length(badScenarios) > 0L) {
-        result$add_critical_error(
+        result$addCriticalError(
           "Invalid Reference",
           paste0(
             "PI task '",
@@ -1183,7 +1183,7 @@ validationSummary <- function(validationResults) {
         )
       }
       if (is.null(m$outputPathId) || is.na(m$outputPathId)) {
-        result$add_critical_error(
+        result$addCriticalError(
           "Invalid Reference",
           paste0(
             "PI task '",
@@ -1194,7 +1194,7 @@ validationSummary <- function(validationResults) {
           )
         )
       } else if (!.refResolves(m$outputPathId, outputPathKeys)) {
-        result$add_critical_error(
+        result$addCriticalError(
           "Invalid Reference",
           paste0(
             "PI task '",

--- a/REFACTORING-LOG.md
+++ b/REFACTORING-LOG.md
@@ -12,3 +12,4 @@ One bullet per commit, newest at the bottom: `- YYYY-MM-DD HH:MM: plain-language
 - 2026-07-22 13:10: Addressed PR review on the observed-data work: keep a session DataSet recoverable if a save aborts, guard name-less and unsafe-named sentinels, warn per project, and align the log format with the rule.
 - 2026-07-22 15:00: Unified R6 method and helper casing to camelCase: validationResult methods, Project's parsing-era private methods, and the shared validation check helpers.
 - 2026-07-22 15:30: Dropped the severity/kind prefixes from messages catalog entry names (error/stop/warning/validation/message), naming each by what it describes; kept a short context qualifier where two entries would otherwise collide.
+- 2026-07-22 16:00: Normalized @family roxygen values to camelCase (spaced and kebab-case ones), leaving singular/plural as-is; updated the matching has_concept() entry in _pkgdown.yml.

--- a/REFACTORING-LOG.md
+++ b/REFACTORING-LOG.md
@@ -10,3 +10,4 @@ One bullet per commit, newest at the bottom: `- YYYY-MM-DD HH:MM: plain-language
 - 2026-07-22 12:22: Updated the observed-data vignette and NEWS for the round-trip and the script-vs-programmatic safety trade-off.
 - 2026-07-22 12:35: Fixed a data-loss bug when saving a programmatic DataSet; the whole batch is validated before any PKML is written.
 - 2026-07-22 13:10: Addressed PR review on the observed-data work: keep a session DataSet recoverable if a save aborts, guard name-less and unsafe-named sentinels, warn per project, and align the log format with the rule.
+- 2026-07-22 15:00: Unified R6 method and helper casing to camelCase: validationResult methods, Project's parsing-era private methods, and the shared validation check helpers.

--- a/REFACTORING-LOG.md
+++ b/REFACTORING-LOG.md
@@ -11,3 +11,4 @@ One bullet per commit, newest at the bottom: `- YYYY-MM-DD HH:MM: plain-language
 - 2026-07-22 12:35: Fixed a data-loss bug when saving a programmatic DataSet; the whole batch is validated before any PKML is written.
 - 2026-07-22 13:10: Addressed PR review on the observed-data work: keep a session DataSet recoverable if a save aborts, guard name-less and unsafe-named sentinels, warn per project, and align the log format with the rule.
 - 2026-07-22 15:00: Unified R6 method and helper casing to camelCase: validationResult methods, Project's parsing-era private methods, and the shared validation check helpers.
+- 2026-07-22 15:30: Dropped the severity/kind prefixes from messages catalog entry names (error/stop/warning/validation/message), naming each by what it describes; kept a short context qualifier where two entries would otherwise collide.

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -109,7 +109,7 @@ reference:
       - matches("^plot")
       - matches("^col")
       - matches("[Cc]olor")
-      - has_concept("create-plotting-configurations")
+      - has_concept("createPlottingConfigurations")
       - createDataCombined
       - createPlots
   - title: Input validation

--- a/man/addOutputPath.Rd
+++ b/man/addOutputPath.Rd
@@ -54,8 +54,8 @@ parameter-identification sub-definition helpers act on a single definition per
 call.
 }
 \seealso{
-Other output path:
+Other outputPath:
 \code{\link[=removeOutputPath]{removeOutputPath()}},
 \code{\link[=setOutputPath]{setOutputPath()}}
 }
-\concept{output path}
+\concept{outputPath}

--- a/man/createEsqlabsPlotConfiguration.Rd
+++ b/man/createEsqlabsPlotConfiguration.Rd
@@ -21,7 +21,7 @@ createEsqlabsPlotConfiguration()
 
 }
 \seealso{
-Other create-plotting-configurations:
+Other createPlottingConfigurations:
 \code{\link[=createEsqlabsPlotGridConfiguration]{createEsqlabsPlotGridConfiguration()}}
 }
-\concept{create-plotting-configurations}
+\concept{createPlottingConfigurations}

--- a/man/createEsqlabsPlotGridConfiguration.Rd
+++ b/man/createEsqlabsPlotGridConfiguration.Rd
@@ -22,7 +22,7 @@ createEsqlabsPlotGridConfiguration()
 
 }
 \seealso{
-Other create-plotting-configurations:
+Other createPlottingConfigurations:
 \code{\link[=createEsqlabsPlotConfiguration]{createEsqlabsPlotConfiguration()}}
 }
-\concept{create-plotting-configurations}
+\concept{createPlottingConfigurations}

--- a/man/exampleProjectPath.Rd
+++ b/man/exampleProjectPath.Rd
@@ -17,7 +17,7 @@ Get the path to the example Project.json
 exampleProjectPath()
 }
 \seealso{
-Other project persistence:
+Other projectPersistence:
 \code{\link[=exportProjectToExcel]{exportProjectToExcel()}},
 \code{\link[=importProjectFromExcel]{importProjectFromExcel()}},
 \code{\link[=initProject]{initProject()}},
@@ -28,4 +28,4 @@ Other project persistence:
 \code{\link[=saveProject]{saveProject()}},
 \code{\link[=snapshotProject]{snapshotProject()}}
 }
-\concept{project persistence}
+\concept{projectPersistence}

--- a/man/exportProjectToExcel.Rd
+++ b/man/exportProjectToExcel.Rd
@@ -37,7 +37,7 @@ object (typically loaded from JSON). This is the reverse of
 \code{importProjectFromExcel()}.
 }
 \seealso{
-Other project persistence:
+Other projectPersistence:
 \code{\link[=exampleProjectPath]{exampleProjectPath()}},
 \code{\link[=importProjectFromExcel]{importProjectFromExcel()}},
 \code{\link[=initProject]{initProject()}},
@@ -48,4 +48,4 @@ Other project persistence:
 \code{\link[=saveProject]{saveProject()}},
 \code{\link[=snapshotProject]{snapshotProject()}}
 }
-\concept{project persistence}
+\concept{projectPersistence}

--- a/man/importProjectFromExcel.Rd
+++ b/man/importProjectFromExcel.Rd
@@ -48,7 +48,7 @@ folder deliberately placed outside the project with the \verb{$\{VAR\}}
 environment-variable form is still allowed.
 }
 \seealso{
-Other project persistence:
+Other projectPersistence:
 \code{\link[=exampleProjectPath]{exampleProjectPath()}},
 \code{\link[=exportProjectToExcel]{exportProjectToExcel()}},
 \code{\link[=initProject]{initProject()}},
@@ -59,4 +59,4 @@ Other project persistence:
 \code{\link[=saveProject]{saveProject()}},
 \code{\link[=snapshotProject]{snapshotProject()}}
 }
-\concept{project persistence}
+\concept{projectPersistence}

--- a/man/initProject.Rd
+++ b/man/initProject.Rd
@@ -39,7 +39,7 @@ configuration files from the JSON; set \code{createExcel = FALSE} for a
 JSON-only project.
 }
 \seealso{
-Other project persistence:
+Other projectPersistence:
 \code{\link[=exampleProjectPath]{exampleProjectPath()}},
 \code{\link[=exportProjectToExcel]{exportProjectToExcel()}},
 \code{\link[=importProjectFromExcel]{importProjectFromExcel()}},
@@ -50,4 +50,4 @@ Other project persistence:
 \code{\link[=saveProject]{saveProject()}},
 \code{\link[=snapshotProject]{snapshotProject()}}
 }
-\concept{project persistence}
+\concept{projectPersistence}

--- a/man/loadProject.Rd
+++ b/man/loadProject.Rd
@@ -55,7 +55,7 @@ saveProject(project)
 \code{\link[=saveProject]{saveProject()}}, \code{\link[=reloadProject]{reloadProject()}}, \code{\link[=snapshotProject]{snapshotProject()}},
 \code{\link[=restoreProject]{restoreProject()}}, \code{\link[=projectStatus]{projectStatus()}}.
 
-Other project persistence:
+Other projectPersistence:
 \code{\link[=exampleProjectPath]{exampleProjectPath()}},
 \code{\link[=exportProjectToExcel]{exportProjectToExcel()}},
 \code{\link[=importProjectFromExcel]{importProjectFromExcel()}},
@@ -66,4 +66,4 @@ Other project persistence:
 \code{\link[=saveProject]{saveProject()}},
 \code{\link[=snapshotProject]{snapshotProject()}}
 }
-\concept{project persistence}
+\concept{projectPersistence}

--- a/man/projectStatus.Rd
+++ b/man/projectStatus.Rd
@@ -45,7 +45,7 @@ project$status # the same information as a structured list
 \code{\link[=saveProject]{saveProject()}}, \code{\link[=reloadProject]{reloadProject()}}, \code{\link[=exportProjectToExcel]{exportProjectToExcel()}},
 \code{\link[=importProjectFromExcel]{importProjectFromExcel()}}.
 
-Other project persistence:
+Other projectPersistence:
 \code{\link[=exampleProjectPath]{exampleProjectPath()}},
 \code{\link[=exportProjectToExcel]{exportProjectToExcel()}},
 \code{\link[=importProjectFromExcel]{importProjectFromExcel()}},
@@ -56,4 +56,4 @@ Other project persistence:
 \code{\link[=saveProject]{saveProject()}},
 \code{\link[=snapshotProject]{snapshotProject()}}
 }
-\concept{project persistence}
+\concept{projectPersistence}

--- a/man/reloadProject.Rd
+++ b/man/reloadProject.Rd
@@ -35,7 +35,7 @@ reloadProject(project) # discard the edit, back to disk
 \code{\link[=loadProject]{loadProject()}}, \code{\link[=saveProject]{saveProject()}}, \code{\link[=snapshotProject]{snapshotProject()}},
 \code{\link[=restoreProject]{restoreProject()}}, \code{\link[=projectStatus]{projectStatus()}}.
 
-Other project persistence:
+Other projectPersistence:
 \code{\link[=exampleProjectPath]{exampleProjectPath()}},
 \code{\link[=exportProjectToExcel]{exportProjectToExcel()}},
 \code{\link[=importProjectFromExcel]{importProjectFromExcel()}},
@@ -46,4 +46,4 @@ Other project persistence:
 \code{\link[=saveProject]{saveProject()}},
 \code{\link[=snapshotProject]{snapshotProject()}}
 }
-\concept{project persistence}
+\concept{projectPersistence}

--- a/man/removeOutputPath.Rd
+++ b/man/removeOutputPath.Rd
@@ -21,8 +21,8 @@ skips) any id not present, and warns when a removed output path is still
 referenced.
 }
 \seealso{
-Other output path:
+Other outputPath:
 \code{\link[=addOutputPath]{addOutputPath()}},
 \code{\link[=setOutputPath]{setOutputPath()}}
 }
-\concept{output path}
+\concept{outputPath}

--- a/man/restoreProject.Rd
+++ b/man/restoreProject.Rd
@@ -60,7 +60,7 @@ project <- restoreProject(snapshot, file.path(tempdir(), "restored"))
 \seealso{
 \code{\link[=snapshotProject]{snapshotProject()}}, \code{\link[=loadProject]{loadProject()}}, \code{\link[=reloadProject]{reloadProject()}}.
 
-Other project persistence:
+Other projectPersistence:
 \code{\link[=exampleProjectPath]{exampleProjectPath()}},
 \code{\link[=exportProjectToExcel]{exportProjectToExcel()}},
 \code{\link[=importProjectFromExcel]{importProjectFromExcel()}},
@@ -71,4 +71,4 @@ Other project persistence:
 \code{\link[=saveProject]{saveProject()}},
 \code{\link[=snapshotProject]{snapshotProject()}}
 }
-\concept{project persistence}
+\concept{projectPersistence}

--- a/man/saveProject.Rd
+++ b/man/saveProject.Rd
@@ -52,7 +52,7 @@ saveProject(project) # clean save: "Project is already up to date; ..."
 \code{\link[=loadProject]{loadProject()}}, \code{\link[=reloadProject]{reloadProject()}}, \code{\link[=snapshotProject]{snapshotProject()}},
 \code{\link[=restoreProject]{restoreProject()}}, \code{\link[=projectStatus]{projectStatus()}}.
 
-Other project persistence:
+Other projectPersistence:
 \code{\link[=exampleProjectPath]{exampleProjectPath()}},
 \code{\link[=exportProjectToExcel]{exportProjectToExcel()}},
 \code{\link[=importProjectFromExcel]{importProjectFromExcel()}},
@@ -63,4 +63,4 @@ Other project persistence:
 \code{\link[=restoreProject]{restoreProject()}},
 \code{\link[=snapshotProject]{snapshotProject()}}
 }
-\concept{project persistence}
+\concept{projectPersistence}

--- a/man/sensitivityCalculation.Rd
+++ b/man/sensitivityCalculation.Rd
@@ -107,9 +107,9 @@ sensitivityCalculation(
 
 }
 \seealso{
-Other sensitivity-calculation:
+Other sensitivityCalculation:
 \code{\link[=sensitivitySpiderPlot]{sensitivitySpiderPlot()}},
 \code{\link[=sensitivityTimeProfiles]{sensitivityTimeProfiles()}},
 \code{\link[=sensitivityTornadoPlot]{sensitivityTornadoPlot()}}
 }
-\concept{sensitivity-calculation}
+\concept{sensitivityCalculation}

--- a/man/sensitivitySpiderPlot.Rd
+++ b/man/sensitivitySpiderPlot.Rd
@@ -142,9 +142,9 @@ sensitivitySpiderPlot(resultsNamed)
 
 }
 \seealso{
-Other sensitivity-calculation:
+Other sensitivityCalculation:
 \code{\link[=sensitivityCalculation]{sensitivityCalculation()}},
 \code{\link[=sensitivityTimeProfiles]{sensitivityTimeProfiles()}},
 \code{\link[=sensitivityTornadoPlot]{sensitivityTornadoPlot()}}
 }
-\concept{sensitivity-calculation}
+\concept{sensitivityCalculation}

--- a/man/sensitivityTimeProfiles.Rd
+++ b/man/sensitivityTimeProfiles.Rd
@@ -127,9 +127,9 @@ sensitivitySpiderPlot(resultsNamed)
 }
 }
 \seealso{
-Other sensitivity-calculation:
+Other sensitivityCalculation:
 \code{\link[=sensitivityCalculation]{sensitivityCalculation()}},
 \code{\link[=sensitivitySpiderPlot]{sensitivitySpiderPlot()}},
 \code{\link[=sensitivityTornadoPlot]{sensitivityTornadoPlot()}}
 }
-\concept{sensitivity-calculation}
+\concept{sensitivityCalculation}

--- a/man/sensitivityTornadoPlot.Rd
+++ b/man/sensitivityTornadoPlot.Rd
@@ -115,9 +115,9 @@ sensitivityTornadoPlot(resultsNamed)
 
 }
 \seealso{
-Other sensitivity-calculation:
+Other sensitivityCalculation:
 \code{\link[=sensitivityCalculation]{sensitivityCalculation()}},
 \code{\link[=sensitivitySpiderPlot]{sensitivitySpiderPlot()}},
 \code{\link[=sensitivityTimeProfiles]{sensitivityTimeProfiles()}}
 }
-\concept{sensitivity-calculation}
+\concept{sensitivityCalculation}

--- a/man/setOutputPath.Rd
+++ b/man/setOutputPath.Rd
@@ -59,8 +59,8 @@ parameter-identification sub-definition helpers act on a single definition per
 call.
 }
 \seealso{
-Other output path:
+Other outputPath:
 \code{\link[=addOutputPath]{addOutputPath()}},
 \code{\link[=removeOutputPath]{removeOutputPath()}}
 }
-\concept{output path}
+\concept{outputPath}

--- a/man/snapshotProject.Rd
+++ b/man/snapshotProject.Rd
@@ -52,7 +52,7 @@ snapshot # the path of the snapshot file
 \seealso{
 \code{\link[=restoreProject]{restoreProject()}}, \code{\link[=loadProject]{loadProject()}}, \code{\link[=saveProject]{saveProject()}}.
 
-Other project persistence:
+Other projectPersistence:
 \code{\link[=exampleProjectPath]{exampleProjectPath()}},
 \code{\link[=exportProjectToExcel]{exportProjectToExcel()}},
 \code{\link[=importProjectFromExcel]{importProjectFromExcel()}},
@@ -63,4 +63,4 @@ Other project persistence:
 \code{\link[=restoreProject]{restoreProject()}},
 \code{\link[=saveProject]{saveProject()}}
 }
-\concept{project persistence}
+\concept{projectPersistence}

--- a/man/validationResult.Rd
+++ b/man/validationResult.Rd
@@ -19,12 +19,12 @@ R6 class for storing validation results
 \subsection{Public methods}{
   \itemize{
     \item \href{#method-validationResult-initialize}{\code{validationResult$new()}}
-    \item \href{#method-validationResult-add_critical_error}{\code{validationResult$add_critical_error()}}
-    \item \href{#method-validationResult-add_warning}{\code{validationResult$add_warning()}}
-    \item \href{#method-validationResult-is_valid}{\code{validationResult$is_valid()}}
-    \item \href{#method-validationResult-has_critical_errors}{\code{validationResult$has_critical_errors()}}
-    \item \href{#method-validationResult-get_formatted_messages}{\code{validationResult$get_formatted_messages()}}
-    \item \href{#method-validationResult-get_summary}{\code{validationResult$get_summary()}}
+    \item \href{#method-validationResult-addCriticalError}{\code{validationResult$addCriticalError()}}
+    \item \href{#method-validationResult-addWarning}{\code{validationResult$addWarning()}}
+    \item \href{#method-validationResult-isValid}{\code{validationResult$isValid()}}
+    \item \href{#method-validationResult-hasCriticalErrors}{\code{validationResult$hasCriticalErrors()}}
+    \item \href{#method-validationResult-getFormattedMessages}{\code{validationResult$getFormattedMessages()}}
+    \item \href{#method-validationResult-getSummary}{\code{validationResult$getSummary()}}
     \item \href{#method-validationResult-clone}{\code{validationResult$clone()}}
   }
 }
@@ -41,13 +41,13 @@ R6 class for storing validation results
 }
 
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-validationResult-add_critical_error"></a>}}
-\if{latex}{\out{\hypertarget{method-validationResult-add_critical_error}{}}}
-\subsection{\code{validationResult$add_critical_error()}}{
+\if{html}{\out{<a id="method-validationResult-addCriticalError"></a>}}
+\if{latex}{\out{\hypertarget{method-validationResult-addCriticalError}{}}}
+\subsection{\code{validationResult$addCriticalError()}}{
   Add a critical error
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{validationResult$add_critical_error(category, message, details = NULL)}
+    \preformatted{validationResult$addCriticalError(category, message, details = NULL)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
@@ -62,13 +62,13 @@ R6 class for storing validation results
 }
 
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-validationResult-add_warning"></a>}}
-\if{latex}{\out{\hypertarget{method-validationResult-add_warning}{}}}
-\subsection{\code{validationResult$add_warning()}}{
+\if{html}{\out{<a id="method-validationResult-addWarning"></a>}}
+\if{latex}{\out{\hypertarget{method-validationResult-addWarning}{}}}
+\subsection{\code{validationResult$addWarning()}}{
   Add a warning
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{validationResult$add_warning(category, message, details = NULL)}
+    \preformatted{validationResult$addWarning(category, message, details = NULL)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
@@ -83,49 +83,49 @@ R6 class for storing validation results
 }
 
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-validationResult-is_valid"></a>}}
-\if{latex}{\out{\hypertarget{method-validationResult-is_valid}{}}}
-\subsection{\code{validationResult$is_valid()}}{
+\if{html}{\out{<a id="method-validationResult-isValid"></a>}}
+\if{latex}{\out{\hypertarget{method-validationResult-isValid}{}}}
+\subsection{\code{validationResult$isValid()}}{
   Check if validation passed (no critical errors)
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{validationResult$is_valid()}
+    \preformatted{validationResult$isValid()}
     \if{html}{\out{</div>}}
   }
 }
 
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-validationResult-has_critical_errors"></a>}}
-\if{latex}{\out{\hypertarget{method-validationResult-has_critical_errors}{}}}
-\subsection{\code{validationResult$has_critical_errors()}}{
+\if{html}{\out{<a id="method-validationResult-hasCriticalErrors"></a>}}
+\if{latex}{\out{\hypertarget{method-validationResult-hasCriticalErrors}{}}}
+\subsection{\code{validationResult$hasCriticalErrors()}}{
   Check if there are critical errors
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{validationResult$has_critical_errors()}
+    \preformatted{validationResult$hasCriticalErrors()}
     \if{html}{\out{</div>}}
   }
 }
 
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-validationResult-get_formatted_messages"></a>}}
-\if{latex}{\out{\hypertarget{method-validationResult-get_formatted_messages}{}}}
-\subsection{\code{validationResult$get_formatted_messages()}}{
+\if{html}{\out{<a id="method-validationResult-getFormattedMessages"></a>}}
+\if{latex}{\out{\hypertarget{method-validationResult-getFormattedMessages}{}}}
+\subsection{\code{validationResult$getFormattedMessages()}}{
   Get formatted messages for display
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{validationResult$get_formatted_messages()}
+    \preformatted{validationResult$getFormattedMessages()}
     \if{html}{\out{</div>}}
   }
 }
 
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-validationResult-get_summary"></a>}}
-\if{latex}{\out{\hypertarget{method-validationResult-get_summary}{}}}
-\subsection{\code{validationResult$get_summary()}}{
+\if{html}{\out{<a id="method-validationResult-getSummary"></a>}}
+\if{latex}{\out{\hypertarget{method-validationResult-getSummary}{}}}
+\subsection{\code{validationResult$getSummary()}}{
   Get validation summary
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{validationResult$get_summary()}
+    \preformatted{validationResult$getSummary()}
     \if{html}{\out{</div>}}
   }
 }

--- a/tests/testthat/test-data-utils.R
+++ b/tests/testthat/test-data-utils.R
@@ -231,7 +231,7 @@ test_that("It throws an error when molWeights of data sets are different and no 
   dataSet2$molWeight <- 2
   expect_error(
     calculateMeanDataSet(list(dataSet1, dataSet2)),
-    regexp = messages$errorOutputMolWeightNeeded(),
+    regexp = messages$outputMolWeightNeeded(),
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-parameter-identification.R
+++ b/tests/testthat/test-parameter-identification.R
@@ -576,7 +576,7 @@ test_that(".validatePI returns no errors on a well-formed task", {
     )
   )
   result <- esqlabsR:::.validatePI(list(T1 = task))
-  expect_false(result$has_critical_errors())
+  expect_false(result$hasCriticalErrors())
 })
 
 test_that(".validatePI surfaces duplicate parameter ids within a task", {
@@ -611,12 +611,12 @@ test_that(".validatePI surfaces duplicate parameter ids within a task", {
     )
   )
   result <- esqlabsR:::.validatePI(list(t = task))
-  expect_true(result$has_critical_errors())
+  expect_true(result$hasCriticalErrors())
 })
 
 test_that(".validatePI is empty-section-friendly", {
   result <- esqlabsR:::.validatePI(list())
-  expect_false(result$has_critical_errors())
+  expect_false(result$hasCriticalErrors())
 })
 
 test_that("validateProject() flags PI parameters that reference unknown scenarios", {
@@ -2274,7 +2274,7 @@ test_that(".validatePI surfaces duplicate output mapping ids within a task", {
     )
   )
   result <- esqlabsR:::.validatePI(list(T1 = task))
-  expect_false(result$is_valid())
+  expect_false(result$isValid())
   expect_match(
     paste(result$critical_errors, collapse = " "),
     "Duplicate PIOutputMapping id within task 'T1'"

--- a/tests/testthat/test-populations.R
+++ b/tests/testthat/test-populations.R
@@ -1,7 +1,7 @@
 test_that("`sampleRandomValue()` rejects an unsupported distribution", {
   expect_error(
     sampleRandomValue("xyz", 5, 2, 10),
-    messages$errorDistributionNotSupported("xyz")
+    messages$distributionNotSupported("xyz")
   )
 })
 

--- a/tests/testthat/test-project.R
+++ b/tests/testthat/test-project.R
@@ -122,7 +122,7 @@ test_that("project path fields are writable after the merger", {
   expect_match(project$paths$simulationsFolder, "AnotherModels$")
 })
 
-test_that(".clean_path expands env vars (other than PATH) and resolves to absolute", {
+test_that(".cleanPath expands env vars (other than PATH) and resolves to absolute", {
   project <- loadProject(
     system.file(
       "extdata",
@@ -134,7 +134,7 @@ test_that(".clean_path expands env vars (other than PATH) and resolves to absolu
     )
   )
   withr::local_envvar(MY_TEST_ROOT = tempdir())
-  resolved <- project$.__enclos_env__$private$.clean_path(
+  resolved <- project$.__enclos_env__$private$.cleanPath(
     "$MY_TEST_ROOT/sub",
     parent = NULL
   )
@@ -144,7 +144,7 @@ test_that(".clean_path expands env vars (other than PATH) and resolves to absolu
   )
 })
 
-test_that(".clean_path returns NULL on NULL/NA/zero-length input", {
+test_that(".cleanPath returns NULL on NULL/NA/zero-length input", {
   project <- loadProject(
     system.file(
       "extdata",
@@ -155,7 +155,7 @@ test_that(".clean_path returns NULL on NULL/NA/zero-length input", {
       mustWork = TRUE
     )
   )
-  cp <- project$.__enclos_env__$private$.clean_path
+  cp <- project$.__enclos_env__$private$.cleanPath
   expect_null(cp(NULL, parent = NULL))
   expect_null(cp(NA_character_, parent = NULL))
   expect_null(cp(character(0), parent = NULL))

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -1,17 +1,17 @@
 test_that("validationResult class works correctly", {
   result <- validationResult$new()
 
-  expect_true(result$is_valid())
-  expect_false(result$has_critical_errors())
+  expect_true(result$isValid())
+  expect_false(result$hasCriticalErrors())
 
-  result$add_critical_error("Test", "Test error")
-  expect_false(result$is_valid())
-  expect_true(result$has_critical_errors())
+  result$addCriticalError("Test", "Test error")
+  expect_false(result$isValid())
+  expect_true(result$hasCriticalErrors())
 
-  result$add_warning("Test", "Test warning")
+  result$addWarning("Test", "Test warning")
   expect_equal(length(result$warnings), 1)
 
-  summary <- result$get_summary()
+  summary <- result$getSummary()
   expect_named(
     summary,
     c("has_critical_errors", "critical_error_count", "warning_count")
@@ -28,12 +28,12 @@ test_that("validationResult exposes no dead `data` surface", {
   # separate one.
   expect_null(result$data)
   expect_null(result$set_data)
-  expect_false("has_data" %in% names(result$get_summary()))
+  expect_false("has_data" %in% names(result$getSummary()))
 })
 
 test_that("isAnyCriticalErrors detects errors in validation results", {
   result_with_error <- validationResult$new()
-  result_with_error$add_critical_error("Test", "Error message")
+  result_with_error$addCriticalError("Test", "Error message")
 
   result_no_error <- validationResult$new()
 
@@ -59,7 +59,7 @@ test_that("isAnyCriticalErrors returns FALSE when no errors", {
 
 test_that("isAnyCriticalErrors handles non-validationResult objects", {
   result_with_error <- validationResult$new()
-  result_with_error$add_critical_error("Test", "Error message")
+  result_with_error$addCriticalError("Test", "Error message")
 
   validationResults <- list(
     file1 = result_with_error,
@@ -72,12 +72,12 @@ test_that("isAnyCriticalErrors handles non-validationResult objects", {
 
 test_that("validationSummary correctly counts errors and warnings", {
   result1 <- validationResult$new()
-  result1$add_critical_error("Test", "Error 1")
-  result1$add_critical_error("Test", "Error 2")
-  result1$add_warning("Test", "Warning 1")
+  result1$addCriticalError("Test", "Error 1")
+  result1$addCriticalError("Test", "Error 2")
+  result1$addWarning("Test", "Warning 1")
 
   result2 <- validationResult$new()
-  result2$add_warning("Test", "Warning 2")
+  result2$addWarning("Test", "Warning 2")
 
   validationResults <- list(
     scenarios = result1,
@@ -114,12 +114,12 @@ test_that("validationSummary handles empty validation results", {
   expect_equal(summary$sections_with_warnings, character())
 })
 
-test_that("validationResult get_formatted_messages works correctly", {
+test_that("validationResult getFormattedMessages works correctly", {
   result <- validationResult$new()
-  result$add_critical_error("Structure", "Missing required field")
-  result$add_warning("Data", "Value out of range")
+  result$addCriticalError("Structure", "Missing required field")
+  result$addWarning("Data", "Value out of range")
 
-  formatted <- result$get_formatted_messages()
+  formatted <- result$getFormattedMessages()
 
   expect_true(is.list(formatted))
   expect_true("critical" %in% names(formatted))
@@ -130,9 +130,9 @@ test_that("validationResult get_formatted_messages works correctly", {
   expect_true(grepl("Data", formatted$warnings[[1]]))
 })
 
-test_that("validationResult add_critical_error with details works", {
+test_that("validationResult addCriticalError with details works", {
   result <- validationResult$new()
-  result$add_critical_error(
+  result$addCriticalError(
     "Structure",
     "Missing field",
     details = list(sheet = "Sheet1", row = 5)
@@ -143,9 +143,9 @@ test_that("validationResult add_critical_error with details works", {
   expect_equal(result$critical_errors[[1]]$details$row, 5)
 })
 
-test_that("validationResult add_warning with details works", {
+test_that("validationResult addWarning with details works", {
   result <- validationResult$new()
-  result$add_warning(
+  result$addWarning(
     "Data",
     "Value warning",
     details = list(column = "Age", value = -5)
@@ -547,7 +547,7 @@ test_that(".validatePlots flags a missing label in a dataCombined entry", {
     )
   )
   result <- esqlabsR:::.validatePlots(dataCombined, list(), list())
-  expect_false(result$is_valid())
+  expect_false(result$isValid())
   msgs <- vapply(result$critical_errors, \(e) e$message, character(1))
   expect_match(msgs, "Simulated entry.*missing 'label'", all = FALSE)
   expect_match(msgs, "Observed entry.*missing 'label'", all = FALSE)
@@ -782,7 +782,7 @@ test_that(".validateCrossReferences resolves individuals/populations as named li
 
 test_that(".validateCrossReferences skips and warns when prior section had critical errors", {
   prior <- list(scenarios = validationResult$new())
-  prior$scenarios$add_critical_error("X", "broken")
+  prior$scenarios$addCriticalError("X", "broken")
   project <- .fakeProject()
   result <- esqlabsR:::.validateCrossReferences(project, prior)
   expect_length(result$critical_errors, 0)
@@ -912,8 +912,8 @@ test_that("createPlots(validate = TRUE) aborts on a clearly broken project", {
 
 test_that(".abortValidationErrors escapes glue metacharacters in messages", {
   result <- validationResult$new()
-  result$add_critical_error("Structure", "Scenario \"Dose {mg}\" is broken")
-  result$add_critical_error("Structure", "Scenario S{1} also broken")
+  result$addCriticalError("Structure", "Scenario \"Dose {mg}\" is broken")
+  result$addCriticalError("Structure", "Scenario S{1} also broken")
   results <- list(scenarios = result)
   expect_snapshot(
     error = TRUE,
@@ -1204,17 +1204,17 @@ test_that("validateProject() flags a PI outputMapping with no outputPath", {
 # stable (no fixture paths, no timestamps in the rendered output).
 .fakeValidationResults <- function() {
   scenarios <- validationResult$new()
-  scenarios$add_critical_error(
+  scenarios$addCriticalError(
     "Invalid Reference",
     "Scenario 'S1' references undefined individual 'ghost'"
   )
-  scenarios$add_warning("Data", "Scenario 'S1' modelFile not found on disk")
+  scenarios$addWarning("Data", "Scenario 'S1' modelFile not found on disk")
 
   parameterSets <- validationResult$new()
-  parameterSets$add_warning("Data", "No parameter sets defined")
+  parameterSets$addWarning("Data", "No parameter sets defined")
 
   crossReferences <- validationResult$new()
-  crossReferences$add_critical_error(
+  crossReferences$addCriticalError(
     "Invalid Reference",
     "dataCombined references undefined scenarios: ghost"
   )

--- a/vignettes/validate-project.Rmd
+++ b/vignettes/validate-project.Rmd
@@ -42,8 +42,8 @@ project <- loadProject(file.path(project_dir, "Project.json"))
 
 Validation has exactly **two** levels, not three:
 
-- A **Critical Error** is a blocking problem: a duplicate id, a required field left empty, or a reference to a definition that does not exist. A section carrying one has no valid result (its `is_valid()` method returns `FALSE`), and the project will not run scenarios or build plots until it is resolved.
-- A **Warning** is a non-blocking note: surfaced so you see it, but it does not stop execution. A section with warnings and no critical errors is still valid (its `is_valid()` method returns `TRUE`).
+- A **Critical Error** is a blocking problem: a duplicate id, a required field left empty, or a reference to a definition that does not exist. A section carrying one has no valid result (its `isValid()` method returns `FALSE`), and the project will not run scenarios or build plots until it is resolved.
+- A **Warning** is a non-blocking note: surfaced so you see it, but it does not stop execution. A section with warnings and no critical errors is still valid (its `isValid()` method returns `TRUE`).
 
 There is no separate "valid data" tier. A section that simply passed is just a result with no critical errors. The quickest single question, "is anything blocking?", is answered by `isAnyCriticalErrors()`.
 


### PR DESCRIPTION
Unify the mixed camelCase / snake_case naming that the 6.0.0 project-model rework left across internal surfaces, so future work follows one rule instead of matching the neighbouring file. This is a mechanical rename sweep with no change to observable behaviour; each surface is a separate commit to keep the diff reviewable.

## R6 method and helper casing

Move the snake_case outliers to the package-default camelCase:
- `validationResult` methods: `add_critical_error`/`add_warning`/`is_valid`/`has_critical_errors`/`get_formatted_messages`/`get_summary` become camelCase. The class is internal, so all call sites move in the same change. The snake_case `@field`s and the `getSummary()` return-list keys are data shape, not methods, and are left unchanged.
- `Project` parsing-era private methods `.read_json`/`.replace_env_var`/`.clean_path` become camelCase (and the `.cleanPath` argument `replace_env_vars` follows).
- Shared validation helpers `.check_no_duplicates`/`.check_required_fields` become camelCase.

## Message-catalog entry names

Drop the inconsistent severity/kind prefixes (`error`/`stop`/`warning`/`validation`/`message`) from the `messages` catalog, naming each entry by what it describes. Acronyms stay uppercase (`PIParameterNotFound`), PascalCase entries are lowercased. Where dropping the prefix would collide two distinct messages, a short context qualifier keeps them apart (`combineInvalidDataSetName`, `validatorObservedDataFileNotFound`, `validatorObservedDataMissingField`).

## @family roxygen values

Normalize the spaced and kebab-case `@family` values to camelCase (`project persistence` to `projectPersistence`, `output path` to `outputPath`, `sensitivity-calculation` to `sensitivityCalculation`, `create-plotting-configurations` to `createPlottingConfigurations`), leaving singular/plural as-is. The matching `has_concept()` entry in `_pkgdown.yml` is updated so the reference index stays in sync.

Closes #1144