### PR TITLE
Validate the initialConditions section

### DIFF
--- a/R/parameters.R
+++ b/R/parameters.R
@@ -1,13 +1,23 @@
-# Section validation adapter ----
+# Section validation adapters ----
 #
 # Registered in `.validationAdapters` (R/validation.R) and called by
-# `.runProjectValidation()`. The actual shape check lives in
-# `.validateParameterSets()` (in `R/validation.R`).
+# `.runProjectValidation()`. The actual shape checks live in
+# `.validateParameterSets()` / `.validateInitialConditions()` (in
+# `R/validation.R`).
 
 #' @keywords internal
 #' @noRd
 .parameterSetsValidatorAdapter <- function(project) {
   .validateParameterSets(project$definitions$parameterSets, "parameterSets")
+}
+
+#' @keywords internal
+#' @noRd
+.initialConditionsValidatorAdapter <- function(project) {
+  .validateInitialConditions(
+    project$definitions$initialConditions,
+    "initialConditions"
+  )
 }
 
 # Merge the parameter-set sections of a parsed `Project.json` into the single

--- a/R/project.R
+++ b/R/project.R
@@ -1380,18 +1380,14 @@ Project <- R6::R6Class(
       private$.defaultSimulationRunOptions <- sections$defaultSimulationRunOptions
       private$.filePathsData <- sections$filePathsData
       private$.excelData <- sections$excelData
-      private$.outputPaths <- sections$outputPaths
-      private$.parameterSets <- sections$parameterSets
-      private$.initialConditions <- sections$initialConditions
-      private$.individuals <- sections$individuals
-      private$.populations <- sections$populations
-      private$.applications <- sections$applications
-      private$.scenarios <- sections$scenarios
-      private$.observedData <- sections$observedData
-      private$.dataCombined <- sections$dataCombined
-      private$.plots <- sections$plots
-      private$.plotGrids <- sections$plotGrids
-      private$.parameterIdentification <- sections$parameterIdentification
+
+      # The tree-owned sections are assigned by iterating the kind registry
+      # rather than named one by one, so a kind added to
+      # `.definitionTreeSpecs()` is committed here without a second edit. The
+      # container fields above are not sections and stay explicit.
+      for (kind in .definitionKindNames()) {
+        private[[private$.sectionField(kind)]] <- sections[[kind]]
+      }
 
       # Session-only observed-data state (runtime programmatic DataSets added via
       # `addObservedData(project, <DataSet>)`, and the observed-data names cache)

--- a/R/scenario-execution.R
+++ b/R/scenario-execution.R
@@ -535,6 +535,7 @@
         "populations",
         "applications",
         "parameterSets",
+        "initialConditions",
         "crossReferences"
       ),
       opName = opName

--- a/R/validation.R
+++ b/R/validation.R
@@ -784,23 +784,35 @@ validationSummary <- function(validationResults) {
     return(result)
   }
 
+  # Read one field as a scalar string, or `NA` when the entry does not hold
+  # exactly one value for it. A hand-edited set can write `"unit": []` or
+  # `"unit": ["mg", "g"]`, either of which would otherwise abort `vapply()`
+  # with an internal length error instead of being reported.
+  scalarField <- function(entries, field) {
+    vapply(
+      entries,
+      function(e) {
+        value <- e[[field]]
+        if (length(value) != 1L) NA_character_ else as.character(value)
+      },
+      character(1)
+    )
+  }
+
   for (setName in names(initialConditions)) {
     set <- initialConditions[[setName]]
     if (length(set) == 0) {
       next
     }
 
-    paths <- vapply(
-      set,
-      function(e) as.character(e$path %||% NA_character_),
-      character(1)
-    )
-    units <- vapply(
-      set,
-      function(e) as.character(e$unit %||% NA_character_),
-      character(1)
-    )
-    values <- lapply(set, function(e) e$value)
+    # An entry that is a bare string rather than a record (`["Organism|Liver|
+    # Aciclovir"]`) has no fields to read; treating it as an empty record folds
+    # it into the missing-field errors below instead of aborting on `$`.
+    entries <- lapply(set, function(e) if (is.list(e)) e else list())
+
+    paths <- scalarField(entries, "path")
+    units <- scalarField(entries, "unit")
+    values <- lapply(entries, function(e) e$value)
 
     if (any(is.na(paths) | paths == "")) {
       result$addCriticalError(
@@ -846,7 +858,11 @@ validationSummary <- function(validationResults) {
       )
     }
 
-    dupes <- paths[duplicated(paths)]
+    # Only real paths can duplicate: the blanks and `NA`s are already reported
+    # by the missing-path error above, and `duplicated()` would otherwise count
+    # two path-less entries as a duplicate of each other.
+    realPaths <- paths[!is.na(paths) & paths != ""]
+    dupes <- realPaths[duplicated(realPaths)]
     if (length(dupes) > 0) {
       result$addWarning(
         "Uniqueness",

--- a/R/validation.R
+++ b/R/validation.R
@@ -367,6 +367,7 @@ validationSummary <- function(validationResults) {
   scenarios = .scenariosValidatorAdapter,
   outputPaths = .outputPathsValidatorAdapter,
   parameterSets = .parameterSetsValidatorAdapter,
+  initialConditions = .initialConditionsValidatorAdapter,
   applications = .applicationsValidatorAdapter,
   plots = .plotsValidatorAdapter,
   dataCombined = .dataCombinedValidatorAdapter,
@@ -747,6 +748,110 @@ validationSummary <- function(validationResults) {
         "Uniqueness",
         paste0(
           "Duplicate parameter paths in set '",
+          setName,
+          "': ",
+          paste(unique(dupes), collapse = ", ")
+        )
+      )
+    }
+  }
+
+  result
+}
+
+#' Validate the initial-condition sets
+#'
+#' Each set is the array-of-records shape the parser and
+#' `addInitialConditionEntry()` produce: a list of
+#' `list(path, value, unit)` entries, one molecule start value each.
+#'
+#' The rules are the ones `.validateInitialConditionEntryArgs()`
+#' (R/parameters.R) already applies on the authoring path, restated here for
+#' the entries that never went through it: a set hand-written into the
+#' definitions tree, or one built by the Excel importer. `path` and `unit` are
+#' critical because a blank either way makes the set unusable
+#' (`ospsuite::setQuantityValuesByPath()` rejects a blank unit at run time);
+#' a non-numeric `value` and a duplicated `path` are warnings, matching how
+#' `.validateParameterSets()` grades the same two problems.
+#'
+#' @keywords internal
+#' @noRd
+.validateInitialConditions <- function(initialConditions, sectionName) {
+  result <- validationResult$new()
+
+  if (is.null(initialConditions) || length(initialConditions) == 0) {
+    result$addWarning("Data", paste0("No ", sectionName, " defined"))
+    return(result)
+  }
+
+  for (setName in names(initialConditions)) {
+    set <- initialConditions[[setName]]
+    if (length(set) == 0) {
+      next
+    }
+
+    paths <- vapply(
+      set,
+      function(e) as.character(e$path %||% NA_character_),
+      character(1)
+    )
+    units <- vapply(
+      set,
+      function(e) as.character(e$unit %||% NA_character_),
+      character(1)
+    )
+    values <- lapply(set, function(e) e$value)
+
+    if (any(is.na(paths) | paths == "")) {
+      result$addCriticalError(
+        "Missing Fields",
+        paste0(
+          "Set '",
+          setName,
+          "' in ",
+          sectionName,
+          " contains empty molecule paths"
+        )
+      )
+    }
+
+    if (any(is.na(units) | units == "")) {
+      result$addCriticalError(
+        "Missing Fields",
+        paste0(
+          "Set '",
+          setName,
+          "' in ",
+          sectionName,
+          " contains entries without a unit"
+        )
+      )
+    }
+
+    nonNumeric <- vapply(
+      values,
+      function(v) is.null(v) || length(v) != 1L || !is.numeric(v) || is.na(v),
+      logical(1)
+    )
+    if (any(nonNumeric)) {
+      result$addWarning(
+        "Data Type",
+        paste0(
+          "Set '",
+          setName,
+          "' in ",
+          sectionName,
+          " contains non-numeric values"
+        )
+      )
+    }
+
+    dupes <- paths[duplicated(paths)]
+    if (length(dupes) > 0) {
+      result$addWarning(
+        "Uniqueness",
+        paste0(
+          "Duplicate molecule paths in set '",
           setName,
           "': ",
           paste(unique(dupes), collapse = ", ")

--- a/REFACTORING-LOG.md
+++ b/REFACTORING-LOG.md
@@ -199,3 +199,4 @@ One bullet per commit, newest at the bottom: `- YYYY-MM-DD HH:MM: plain-language
 - 2026-08-05 15:45: Addressed review on the load-extraction PR: replaced two tests that could never fail with a real test of the atomicity guarantee, fixed a miscount and a "used to" aside in two comments, pointed two other comments at the function that actually raises them, and moved a validation check back to where its error message names the right place. (#1226)
 - 2026-08-06 08:44: Initial-condition sets are now checked when you validate a project. A set with a blank molecule path or a missing unit used to pass unnoticed. (#1226)
 - 2026-08-06 08:52: Loading a project now walks the list of section kinds instead of naming all twelve by hand, so a new kind needs no edit here. (#1226)
+- 2026-08-06 08:56: Added two tests that fail if a new project section is ever added without a validator or without an empty shape to write. (#1226)

--- a/REFACTORING-LOG.md
+++ b/REFACTORING-LOG.md
@@ -198,3 +198,4 @@ One bullet per commit, newest at the bottom: `- YYYY-MM-DD HH:MM: plain-language
 - 2026-08-05 15:20: Moved the glossary into CLAUDE.md itself instead of a separate file. (#1226)
 - 2026-08-05 15:45: Addressed review on the load-extraction PR: replaced two tests that could never fail with a real test of the atomicity guarantee, fixed a miscount and a "used to" aside in two comments, pointed two other comments at the function that actually raises them, and moved a validation check back to where its error message names the right place. (#1226)
 - 2026-08-06 08:44: Initial-condition sets are now checked when you validate a project. A set with a blank molecule path or a missing unit used to pass unnoticed. (#1226)
+- 2026-08-06 08:52: Loading a project now walks the list of section kinds instead of naming all twelve by hand, so a new kind needs no edit here. (#1226)

--- a/REFACTORING-LOG.md
+++ b/REFACTORING-LOG.md
@@ -197,3 +197,4 @@ One bullet per commit, newest at the bottom: `- YYYY-MM-DD HH:MM: plain-language
 - 2026-08-05 15:05: Added a glossary naming the three different things called "Scenario" and the four different things called "Parameters" apart. (#1226)
 - 2026-08-05 15:20: Moved the glossary into CLAUDE.md itself instead of a separate file. (#1226)
 - 2026-08-05 15:45: Addressed review on the load-extraction PR: replaced two tests that could never fail with a real test of the atomicity guarantee, fixed a miscount and a "used to" aside in two comments, pointed two other comments at the function that actually raises them, and moved a validation check back to where its error message names the right place. (#1226)
+- 2026-08-06 08:44: Initial-condition sets are now checked when you validate a project. A set with a blank molecule path or a missing unit used to pass unnoticed. (#1226)

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -1100,6 +1100,34 @@ test_that("ensureValid() aborts with a formatted summary on critical errors", {
   )
 })
 
+test_that("the run gate validates the initial conditions a scenario build applies", {
+  # A scenario build folds its referenced sets into the simulation
+  # (`.mergeScenarioInitialConditions()`), so a set the validator grades
+  # critical has to stop the build rather than fail inside `ospsuite`. Goes
+  # through `.scenarioBuildPreflight()` so it tests the gate's real section
+  # list, not a copy of it.
+  sc <- Scenario()
+  sc$modelFile <- "m.pkml"
+  project <- .fakeProject(
+    scenarios = list(s1 = sc),
+    initialConditions = list(
+      presysset = .asInitialConditionSet(
+        list(list(path = "Organism|A|Drug", value = 1, unit = ""))
+      )
+    )
+  )
+  expect_error(
+    .scenarioBuildPreflight(
+      project = project,
+      customParams = NULL,
+      simulationRunOptions = NULL,
+      validate = TRUE,
+      opName = "runScenarios"
+    ),
+    "without a unit"
+  )
+})
+
 test_that("a broken plots section leaves the run gate's cross-reference check in place", {
   # The run gate's own section list, as `.scenarioBuildPreflight()` passes it.
   runSections <- c(
@@ -1109,6 +1137,7 @@ test_that("a broken plots section leaves the run gate's cross-reference check in
     "populations",
     "applications",
     "parameterSets",
+    "initialConditions",
     "crossReferences"
   )
   sc <- Scenario()
@@ -1144,6 +1173,7 @@ test_that("a plotting-only dangling reference does not block the run gate", {
     "populations",
     "applications",
     "parameterSets",
+    "initialConditions",
     "crossReferences"
   )
   sc <- Scenario()

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -1009,6 +1009,26 @@ test_that(".validateCrossReferences resolves only the references the requested s
 
 # Dispatcher behaviour ----
 
+test_that("every definition kind has a validator", {
+  # `.definitionTreeSpecs()` is the source of truth for what a section is, and
+  # `.validationAdapters` is a hand-written list beside it, so the two drift
+  # apart silently: `initialConditions` sat unvalidated that way. `plotGrids`
+  # is the one deliberate absence -- `.plotsValidatorAdapter()` passes the
+  # grids into `.validatePlots()` along with the plots they hold.
+  validatedElsewhere <- "plotGrids"
+  expect_setequal(
+    setdiff(.definitionKindNames(), validatedElsewhere),
+    names(.validationAdapters)
+  )
+})
+
+test_that("every definition kind has a canonical empty JSON shape", {
+  # The container-only write emits one empty value per tree-owned section; a
+  # kind missing from that list would write a container the loader then reads
+  # as a section that was never there.
+  expect_setequal(names(.emptyTreeSectionsJson()), .definitionKindNames())
+})
+
 test_that(".runProjectValidation honors a targeted sections vector", {
   project <- .fakeProject()
   results <- .runProjectValidation(

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -514,6 +514,85 @@ test_that("validateProject() flags an invalid parameter set in the real shape", 
   expect_true(isAnyCriticalErrors(results))
 })
 
+# Section adapter: initial conditions ----
+
+test_that(".validateInitialConditions warns on an empty section", {
+  result <- .validateInitialConditions(list(), "initialConditions")
+  expect_s3_class(result, "validationResult")
+  expect_length(result$critical_errors, 0)
+  expect_length(result$warnings, 1)
+})
+
+test_that(".validateInitialConditions flags an empty molecule path", {
+  initialConditions <- list(
+    presysset = list(list(path = "", value = 1, unit = "µmol"))
+  )
+  result <- .validateInitialConditions(initialConditions, "initialConditions")
+  msgs <- vapply(result$critical_errors, \(e) e$message, character(1))
+  expect_match(msgs, "empty molecule paths", all = FALSE)
+})
+
+test_that(".validateInitialConditions flags a missing unit", {
+  # A blank unit is critical, not cosmetic: `setQuantityValuesByPath()` rejects
+  # it, so the set is unusable at run time.
+  initialConditions <- list(
+    presysset = list(list(path = "Organism|A|Drug", value = 1, unit = NULL))
+  )
+  result <- .validateInitialConditions(initialConditions, "initialConditions")
+  msgs <- vapply(result$critical_errors, \(e) e$message, character(1))
+  expect_match(msgs, "without a unit", all = FALSE)
+})
+
+test_that(".validateInitialConditions warns on a non-numeric value", {
+  initialConditions <- list(
+    presysset = list(list(
+      path = "Organism|A|Drug",
+      value = "abc",
+      unit = "µmol"
+    ))
+  )
+  result <- .validateInitialConditions(initialConditions, "initialConditions")
+  msgs <- vapply(result$warnings, \(w) w$message, character(1))
+  expect_match(msgs, "non-numeric value", all = FALSE)
+})
+
+test_that(".validateInitialConditions warns on a duplicated molecule path", {
+  initialConditions <- list(
+    presysset = list(
+      list(path = "Organism|A|Drug", value = 1, unit = "µmol"),
+      list(path = "Organism|A|Drug", value = 2, unit = "µmol")
+    )
+  )
+  result <- .validateInitialConditions(initialConditions, "initialConditions")
+  msgs <- vapply(result$warnings, \(w) w$message, character(1))
+  expect_match(msgs, "Duplicate molecule paths", all = FALSE)
+})
+
+test_that(".validateInitialConditions passes a well-formed set", {
+  initialConditions <- list(
+    presysset = list(list(path = "Organism|A|Drug", value = 1, unit = "µmol"))
+  )
+  result <- .validateInitialConditions(initialConditions, "initialConditions")
+  expect_length(result$critical_errors, 0)
+  expect_length(result$warnings, 0)
+})
+
+test_that("validateProject() flags an invalid initial-condition set", {
+  # The section reached `validateProject()` unchecked until it had an adapter;
+  # this is the whole-project path the hand-edited and Excel-imported cases
+  # arrive through.
+  project <- .fakeProject(
+    initialConditions = list(
+      presysset = .asInitialConditionSet(
+        list(list(path = "", value = 1, unit = ""))
+      )
+    )
+  )
+  results <- suppressWarnings(validateProject(project))
+  expect_true(isAnyCriticalErrors(results))
+  expect_true("initialConditions" %in% names(results))
+})
+
 # Section adapter: applications ----
 
 test_that(".validateApplications warns on empty section but emits no critical errors", {

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -577,6 +577,44 @@ test_that(".validateInitialConditions passes a well-formed set", {
   expect_length(result$warnings, 0)
 })
 
+test_that(".validateInitialConditions reports a non-scalar unit rather than aborting", {
+  # A hand-edited `"unit": []` or `"unit": ["mg", "g"]` is exactly the input
+  # this section polices, so it has to be reported, not abort the run.
+  initialConditions <- list(
+    presysset = list(
+      list(path = "Organism|A|Drug", value = 1, unit = list()),
+      list(path = "Organism|B|Drug", value = 2, unit = c("mg", "g"))
+    )
+  )
+  result <- .validateInitialConditions(initialConditions, "initialConditions")
+  msgs <- vapply(result$critical_errors, \(e) e$message, character(1))
+  expect_match(msgs, "without a unit", all = FALSE)
+})
+
+test_that(".validateInitialConditions reports a bare-string entry rather than aborting", {
+  # `"initialConditions": ["Organism|Liver|Aciclovir"]` parses to entries that
+  # are strings, not records, so they carry no field to read.
+  initialConditions <- list(presysset = list("Organism|Liver|Aciclovir"))
+  result <- .validateInitialConditions(initialConditions, "initialConditions")
+  msgs <- vapply(result$critical_errors, \(e) e$message, character(1))
+  expect_match(msgs, "empty molecule paths", all = FALSE)
+})
+
+test_that(".validateInitialConditions does not read path-less entries as duplicates", {
+  initialConditions <- list(
+    presysset = list(
+      list(value = 1, unit = "µmol"),
+      list(value = 2, unit = "µmol")
+    )
+  )
+  result <- .validateInitialConditions(initialConditions, "initialConditions")
+  msgs <- vapply(result$critical_errors, \(e) e$message, character(1))
+  expect_match(msgs, "empty molecule paths", all = FALSE)
+  # The missing paths are already reported above; calling them duplicates of
+  # each other adds a second finding pointing at a path that does not exist.
+  expect_length(result$warnings, 0)
+})
+
 test_that("validateProject() flags an invalid initial-condition set", {
   # The section reached `validateProject()` unchecked until it had an adapter;
   # this is the whole-project path the hand-edited and Excel-imported cases


### PR DESCRIPTION
`initialConditions` was the one project section with no entry in `.validationAdapters`, so `validateProject()` never looked at it. The authoring path is guarded and cross-reference validation catches a dangling reference, but the per-definition shape check every other section gets was missing: a set arriving by hand-editing the definitions tree, or from the Excel importer, passed a full validation clean however malformed it was. This is action 5 of the #1226 audit, minus the `R/parameters.R` split, which stays its own step.

## Validation

- `.validateInitialConditions()` in `R/validation.R`, modelled on `.validateParameterSets()` beside it. A blank molecule path or a missing unit is a critical error (`ospsuite::setQuantityValuesByPath()` rejects a blank unit at run time, so the set is unusable); a non-numeric value and a duplicated path are warnings, which is how the parameter-set validator grades the same two problems.
- `.initialConditionsValidatorAdapter()` in `R/parameters.R`, registered in `.validationAdapters`.
- The rules are the ones `.validateInitialConditionEntryArgs()` already applies on the authoring path, restated for the entries that never went through it.

## Drift

Two hand-written lists were derived from the kind registry instead, since that is how the gap opened in the first place:

- `.applyLoadedSections()` assigns the twelve tree-owned sections in a loop over `.definitionKindNames()`, reusing the existing `private$.sectionField()` mapping. The container fields stay explicit.
- Two tests assert that every registered kind has a validator (bar `plotGrids`, which `.plotsValidatorAdapter()` covers, named in the test with the reason) and an entry in `.emptyTreeSectionsJson()`.

## Example

<details><summary>Reprex</summary>

``` r
devtools::load_all("/Users/felix/Code/esqlabsR/.claude/worktrees/architecture-audit-implementation-238366", quiet = TRUE)

# A project whose initial-condition set was hand-written without a unit.
dir <- file.path(tempdir(), "Example")
dir.create(dir)
invisible(file.copy(
  list.files(dirname(exampleProjectPath()), full.names = TRUE),
  dir,
  recursive = TRUE
))
writeLines(
  jsonlite::toJSON(
    list(id = "presystemic", initialConditions = list(
      list(path = "Organism|VenousBlood|Plasma|Aciclovir", value = 0.5, unit = "")
    )),
    auto_unbox = TRUE,
    pretty = TRUE
  ),
  file.path(dir, "definitions", "initial-conditions", "presystemic.json")
)

project <- loadProject(dir)
validateProject(project)
#> Validation report: 1 critical error, 0 warnings.
#> initialConditions
#>   ✖ [Missing Fields] Set 'presystemic' in initialConditions contains entries without a unit
#> 11 sections OK.
```

</details>

Part of #1226.
