### PR TITLE
Give setScenario() the same ... signature as its siblings

### DIFF
--- a/R/authoring-vectorize.R
+++ b/R/authoring-vectorize.R
@@ -311,6 +311,28 @@ NULL
   })
 }
 
+# Abort when a `set*()` field arrived without a name. Every field a `set*_impl`
+# handles is looked up by name (the whole/scalar split, the alignment, the
+# per-definition apply), so an unnamed one is invisible to all of them and would
+# be dropped without a word. A field passed positionally arrives that way, since
+# the `...` those functions forward carries no formals to match it against. With
+# no named field at all R drops the names attribute entirely, so both that and a
+# partially-named list are covered by testing for a blank name.
+#
+# @keywords internal
+# @noRd
+.assertAuthoringFieldsNamed <- function(fields, call = rlang::caller_env()) {
+  if (length(fields) == 0L) {
+    return(invisible(fields))
+  }
+  names <- names(fields) %||% rep("", length(fields))
+  unnamed <- which(is.na(names) | names == "")
+  if (length(unnamed) > 0L) {
+    cli::cli_abort(messages$unnamedAuthoringFields(unnamed), call = call)
+  }
+  invisible(fields)
+}
+
 # Extract element `i` of a vector or list, preserving the scalar shape. Used by
 # `.recycleField` so a character vector yields a length-1 string and a list
 # yields its i-th element.

--- a/R/individuals.R
+++ b/R/individuals.R
@@ -461,6 +461,7 @@ setIndividual <- function(project, id, ...) {
   }
 
   dots <- list(...)
+  .assertAuthoringFieldsNamed(dots)
   wholeNames <- intersect(
     c("parameterSets", "proteinOntogenies"),
     names(dots)

--- a/R/messages.R
+++ b/R/messages.R
@@ -1133,10 +1133,25 @@ messages$setScenarioNoOverwrite <- function() {
   )
 }
 
+# Raised when an authoring field reaches `.alignAuthoringArgs()` without a name.
+# Every field there is looked up by name, so an unnamed one would be dropped in
+# silence; the usual way to produce one is passing a `set*()` field positionally.
+messages$unnamedAuthoringFields <- function(positions) {
+  # `cli::qty()` pluralizes on how many positions there are, not on the position
+  # numbers themselves: a lone field at position 2 is still one field. It has to
+  # sit before every plural marker, since interpolating `positions` resets the
+  # quantity cli pluralizes on, which is why the sentence keeps them together.
+  cli::format_message(c(
+    "Every field must be named.",
+    "x" = "{cli::qty(length(positions))}No name on field{?s} {positions}.",
+    "i" = "Name the field, for example \\
+    {.code setIndividual(project, id, species = \"Rat\")}."
+  ))
+}
+
 # Raised when a name reaching `setScenario()`'s field set is not a scenario
-# field. Only the R6 method can be called with one (the exported function's
-# formals reject it), and without the guard the value would be aligned as a
-# per-definition field and then dropped in silence.
+# field. Without the guard the value would be aligned as a per-definition field
+# and then dropped in silence.
 messages$setScenarioUnknownFields <- function(fields, settable) {
   cli::format_message(c(
     "{.fn setScenario} cannot set {.field {fields}}.",

--- a/R/messages.R
+++ b/R/messages.R
@@ -1137,6 +1137,9 @@ messages$setScenarioNoOverwrite <- function() {
 # Raised when an authoring field reaches `.alignAuthoringArgs()` without a name.
 # Every field there is looked up by name, so an unnamed one would be dropped in
 # silence; the usual way to produce one is passing a `set*()` field positionally.
+# The hint names no function and no field: `setScenario()`, `setIndividual()` and
+# `setPopulation()` all raise this, they share no field, and the abort header
+# already names the one the caller used.
 messages$unnamedAuthoringFields <- function(positions) {
   # `cli::qty()` pluralizes on how many positions there are, not on the position
   # numbers themselves: a lone field at position 2 is still one field. It has to
@@ -1145,8 +1148,7 @@ messages$unnamedAuthoringFields <- function(positions) {
   cli::format_message(c(
     "Every field must be named.",
     "x" = "{cli::qty(length(positions))}No name on field{?s} {positions}.",
-    "i" = "Name the field, for example \\
-    {.code setIndividual(project, id, species = \"Rat\")}."
+    "i" = "Pass each field as {.code name = value}."
   ))
 }
 

--- a/R/messages.R
+++ b/R/messages.R
@@ -1120,9 +1120,10 @@ messages$scenarioRecordWithFields <- function(fields) {
   ))
 }
 
-# `setScenario()` declares `overwrite` only to intercept it: without the formal,
-# R's partial matching would resolve the name to `overwriteFormulasInSS` and
-# quietly set a steady-state model option instead.
+# `setScenario()` intercepts `overwrite` rather than letting it reach the impl's
+# generic unknown-field message, because the name is a habit picked up from
+# `addScenario()` and the scenario carries a second argument that starts the
+# same way.
 messages$setScenarioNoOverwrite <- function() {
   c(
     "{.fn setScenario} has no {.arg overwrite} argument.",

--- a/R/populations.R
+++ b/R/populations.R
@@ -861,6 +861,7 @@ setPopulation <- function(project, id, ...) {
   }
 
   dots <- list(...)
+  .assertAuthoringFieldsNamed(dots)
   wholeNames <- intersect("proteinOntogenies", names(dots))
   perDefinition <- .alignAuthoringArgs(
     id,

--- a/R/scenarios.R
+++ b/R/scenarios.R
@@ -1362,6 +1362,7 @@ setScenario <- function(
   }
 
   dots <- list(...)
+  .assertAuthoringFieldsNamed(dots)
   # A name that is not a scenario field would otherwise be aligned as a
   # per-definition field and then quietly dropped when nothing applies it.
   unknownFields <- setdiff(names(dots), .settableScenarioFields)

--- a/R/scenarios.R
+++ b/R/scenarios.R
@@ -912,7 +912,9 @@ addScenario <- function(
 ) {
   validateIsOfType(project, "Project")
   if (inherits(id, "Scenario")) {
-    .assertScenarioRecordAlone(match.call(), missing(modelFile))
+    .assertScenarioRecordAlone(
+      .addScenarioExtraFields(match.call(), missing(modelFile))
+    )
     return(do.call(
       project$addScenario,
       c(.scenarioRecordArgs(id), list(overwrite = overwrite))
@@ -1200,124 +1202,47 @@ removeScenario <- function(project, id) {
 #'   `initialConditions` / `outputPaths` are applied whole to every scenario. A
 #'   field left unsupplied is untouched on every scenario.
 #'
+#'   There is no `overwrite` argument: `setScenario()` always updates the
+#'   scenario named by `id`, and passing the name is an error. Use
+#'   [addScenario()] for the `overwrite` that replaces a definition, and spell
+#'   `overwriteFormulasInSS` out in full for the steady-state model option.
+#'
 #' @inherit vectorizedAuthoring details
 #' @inheritSection addScenario Passing a scenario back
-#' @inheritParams addScenario
+#' @param project A `Project` object.
 #' @param id Character vector. Ids of the scenarios to modify. Each is
 #'   canonicalized the same way [addScenario()] canonicalizes it, and must
 #'   already exist in `scenarios` definitions. A `Scenario` record is also
 #'   accepted, and then supplies every field; see the section below.
-#' @param simulationTimeUnit Character time-unit string. Omitting the argument
-#'   leaves the current value untouched (there is no default; this is a
-#'   partial update).
-#' @param steadyState Logical, whether to simulate steady state. Omitting the
-#'   argument leaves the current value untouched (there is no default; this is
-#'   a partial update).
-#' @param steadyStateTime Numeric steady-state time in `steadyStateTimeUnit`.
-#'   Omitting the argument leaves the current value untouched (there is no
-#'   default; this is a partial update).
-#' @param steadyStateTimeUnit Character unit for `steadyStateTime`. Omitting
-#'   the argument leaves the current value untouched (there is no default; this
-#'   is a partial update).
-#' @param overwriteFormulasInSS Logical, whether to overwrite formulas during
-#'   steady state. Omitting the argument leaves the current value untouched
-#'   (there is no default; this is a partial update).
-#' @param readPopulationFromCSV Logical, whether to load the population from
-#'   CSV. Omitting the argument leaves the current value untouched (there is no
-#'   default; this is a partial update).
-#' @param overwrite Not an argument of `setScenario()`, which always updates the
-#'   scenario named by `id`. It is declared only to reject the name, which R's
-#'   partial matching would otherwise resolve to `overwriteFormulasInSS`. Pass
-#'   that name in full for the steady-state model option, or use [addScenario()]
-#'   for the `overwrite` that replaces a definition.
+#' @param ... Named fields to change. Accepted: `modelFile`, `individual`,
+#'   `population`, `application`, `parameterSets`, `initialConditions`,
+#'   `outputPaths`, `simulationTime`, `simulationTimeUnit`, `steadyState`,
+#'   `steadyStateTime`, `steadyStateTimeUnit`, `overwriteFormulasInSS`,
+#'   `readPopulationFromCSV`. Each takes the value [addScenario()] documents for
+#'   it, but has no default here: an omitted field is left untouched, a field
+#'   passed as `NULL` is cleared. Scalar-per-definition fields recycle/align
+#'   across `id`; `parameterSets`, `initialConditions` and `outputPaths` are
+#'   applied whole. An unknown or unnamed field triggers an error.
 #'
 #' @returns The `project` object, invisibly.
 #' @export
 #' @family scenario
-setScenario <- function(
-  project,
-  id,
-  modelFile,
-  individual,
-  population,
-  application,
-  parameterSets,
-  initialConditions,
-  outputPaths,
-  simulationTime,
-  simulationTimeUnit,
-  steadyState,
-  steadyStateTime,
-  steadyStateTimeUnit,
-  overwriteFormulasInSS,
-  readPopulationFromCSV,
-  overwrite
-) {
+setScenario <- function(project, id, ...) {
   validateIsOfType(project, "Project")
-  # `overwrite` is a formal only so it cannot be partial-matched:
-  # `setScenario(project, id, overwrite = TRUE)`, written out of habit from
-  # `addScenario()`, would otherwise match `overwriteFormulasInSS` and silently
-  # turn on a steady-state model option.
-  if (!missing(overwrite)) {
+  dots <- list(...)
+  # `overwrite` reaches the impl as an unknown field, which would name it in the
+  # generic "cannot set" message. Say what it is instead: `addScenario()` is the
+  # one with an `overwrite`, and this scenario also has an argument whose name
+  # starts the same way.
+  if ("overwrite" %in% names(dots)) {
     cli::cli_abort(messages$setScenarioNoOverwrite())
   }
   if (inherits(id, "Scenario")) {
-    .assertScenarioRecordAlone(match.call(), missing(modelFile))
+    .assertScenarioRecordAlone(names(dots))
     return(do.call(project$setScenario, .scenarioRecordArgs(id)))
   }
 
-  # Capture only the fields the caller actually supplied (partial update). A
-  # supplied `NULL` (e.g. `individual = NULL`) clears the field, distinct
-  # from an unsupplied argument; the `x[name] <- list(value)` form preserves a
-  # NULL-valued supplied field as a present-but-NULL list element (a plain
-  # `x$name <- NULL` would instead drop the name). Forward only the supplied
-  # fields to the method so its `...` carries exactly what the user gave, which
-  # is how the method distinguishes "clear this" from "leave untouched".
-  supplied <- list()
-  if (!missing(modelFile)) {
-    supplied["modelFile"] <- list(modelFile)
-  }
-  if (!missing(individual)) {
-    supplied["individual"] <- list(individual)
-  }
-  if (!missing(population)) {
-    supplied["population"] <- list(population)
-  }
-  if (!missing(application)) {
-    supplied["application"] <- list(application)
-  }
-  if (!missing(parameterSets)) {
-    supplied["parameterSets"] <- list(parameterSets)
-  }
-  if (!missing(initialConditions)) {
-    supplied["initialConditions"] <- list(initialConditions)
-  }
-  if (!missing(outputPaths)) {
-    supplied["outputPaths"] <- list(outputPaths)
-  }
-  if (!missing(simulationTime)) {
-    supplied["simulationTime"] <- list(simulationTime)
-  }
-  if (!missing(simulationTimeUnit)) {
-    supplied["simulationTimeUnit"] <- list(simulationTimeUnit)
-  }
-  if (!missing(steadyState)) {
-    supplied["steadyState"] <- list(steadyState)
-  }
-  if (!missing(steadyStateTime)) {
-    supplied["steadyStateTime"] <- list(steadyStateTime)
-  }
-  if (!missing(steadyStateTimeUnit)) {
-    supplied["steadyStateTimeUnit"] <- list(steadyStateTimeUnit)
-  }
-  if (!missing(overwriteFormulasInSS)) {
-    supplied["overwriteFormulasInSS"] <- list(overwriteFormulasInSS)
-  }
-  if (!missing(readPopulationFromCSV)) {
-    supplied["readPopulationFromCSV"] <- list(readPopulationFromCSV)
-  }
-
-  do.call(project$setScenario, c(list(id), supplied))
+  project$setScenario(id, ...)
 }
 
 # The scenario fields `setScenario()` can change, in the spelling its arguments
@@ -1822,28 +1747,36 @@ duplicateScenario <- function(project, id, newId) {
   Filter(Negate(is.null), entry)
 }
 
-# Abort when a `Scenario` record is passed as `id` alongside field arguments. The
-# record is the whole field set, so an accompanying field would be silently
+# Abort when a `Scenario` record is passed as `id` alongside field arguments.
+# The record is the whole field set, so an accompanying field would be silently
 # ignored; edit the record's own field and pass it back, or name the id instead
-# of the record. `call` is the caller's `match.call()`, whose names cover every
-# named argument; `modelFileMissing` covers the one field that can be passed
-# positionally (and a further positional argument implies it was).
+# of the record. `extra` is the field names the caller was given, which each
+# entrypoint reads off its own arguments: `setScenario()` from its `...`,
+# `addScenario()` from `match.call()` plus the one field its formals let through
+# positionally.
 #
 # @keywords internal
 # @noRd
-.assertScenarioRecordAlone <- function(
-  call,
-  modelFileMissing,
-  errorCall = rlang::caller_env()
-) {
-  extra <- setdiff(names(call), c("", "project", "id", "overwrite"))
-  if (!modelFileMissing) {
-    extra <- union("modelFile", extra)
-  }
+.assertScenarioRecordAlone <- function(extra, errorCall = rlang::caller_env()) {
   if (length(extra) > 0L) {
     cli::cli_abort(messages$scenarioRecordWithFields(extra), call = errorCall)
   }
   invisible(NULL)
+}
+
+# The field names an `addScenario()` call carried alongside a `Scenario` record.
+# `call` is the caller's `match.call()`, whose names cover every named argument;
+# `modelFileMissing` covers the one field that can be passed positionally (and a
+# further positional argument implies it was).
+#
+# @keywords internal
+# @noRd
+.addScenarioExtraFields <- function(call, modelFileMissing) {
+  extra <- setdiff(names(call), c("", "project", "id", "overwrite"))
+  if (!modelFileMissing) {
+    extra <- union("modelFile", extra)
+  }
+  extra
 }
 
 # Bring a `simulationTime` authoring argument to the one string form the rest of

--- a/R/scenarios.R
+++ b/R/scenarios.R
@@ -1238,6 +1238,10 @@ setScenario <- function(project, id, ...) {
     cli::cli_abort(messages$setScenarioNoOverwrite())
   }
   if (inherits(id, "Scenario")) {
+    # This branch returns before `.setScenario_impl()` runs, so the naming rule
+    # is enforced here too. An all-unnamed `...` has no names attribute at all,
+    # which would leave `.assertScenarioRecordAlone()` with nothing to report.
+    .assertAuthoringFieldsNamed(dots)
     .assertScenarioRecordAlone(names(dots))
     return(do.call(project$setScenario, .scenarioRecordArgs(id)))
   }

--- a/REFACTORING-LOG.md
+++ b/REFACTORING-LOG.md
@@ -201,3 +201,4 @@ One bullet per commit, newest at the bottom: `- YYYY-MM-DD HH:MM: plain-language
 - 2026-08-06 08:52: Loading a project now walks the list of section kinds instead of naming all twelve by hand, so a new kind needs no edit here. (#1226)
 - 2026-08-06 08:56: Added two tests that fail if a new project section is ever added without a validator or without an empty shape to write. (#1226)
 - 2026-08-06 09:05: Exporting to Excel no longer throws away a steady-state time a scenario declares but is not currently using; it used to come back as 1000 minutes.
+- 2026-08-06 09:20: A field passed without a name to setScenario, setIndividual or setPopulation is now an error; it used to be dropped in silence, leaving the definition unchanged.

--- a/REFACTORING-LOG.md
+++ b/REFACTORING-LOG.md
@@ -202,3 +202,4 @@ One bullet per commit, newest at the bottom: `- YYYY-MM-DD HH:MM: plain-language
 - 2026-08-06 08:56: Added two tests that fail if a new project section is ever added without a validator or without an empty shape to write. (#1226)
 - 2026-08-06 09:05: Exporting to Excel no longer throws away a steady-state time a scenario declares but is not currently using; it used to come back as 1000 minutes.
 - 2026-08-06 09:20: A field passed without a name to setScenario, setIndividual or setPopulation is now an error; it used to be dropped in silence, leaving the definition unchanged.
+- 2026-08-06 09:35: setScenario now takes its fields the same way setIndividual and setPopulation do, dropping 16 arguments and 70 lines of plumbing; fields must be named.

--- a/man/setScenario.Rd
+++ b/man/setScenario.Rd
@@ -4,25 +4,7 @@
 \alias{setScenario}
 \title{Modify fields of an existing scenario}
 \usage{
-setScenario(
-  project,
-  id,
-  modelFile,
-  individual,
-  population,
-  application,
-  parameterSets,
-  initialConditions,
-  outputPaths,
-  simulationTime,
-  simulationTimeUnit,
-  steadyState,
-  steadyStateTime,
-  steadyStateTimeUnit,
-  overwriteFormulasInSS,
-  readPopulationFromCSV,
-  overwrite
-)
+setScenario(project, id, ...)
 }
 \arguments{
 \item{project}{A \code{Project} object.}
@@ -32,66 +14,15 @@ canonicalized the same way \code{\link[=addScenario]{addScenario()}} canonicaliz
 already exist in \code{scenarios} definitions. A \code{Scenario} record is also
 accepted, and then supplies every field; see the section below.}
 
-\item{modelFile}{Character. Name of the \code{.pkml} model file (relative
-to model folder).}
-
-\item{individual}{Character or \code{NULL}. Id referencing
-\code{individuals} definitions.}
-
-\item{population}{Character or \code{NULL}. Id referencing
-\code{populations} definitions.}
-
-\item{application}{Character or \code{NULL}. Id of the application protocol
-referencing \code{applications} definitions.}
-
-\item{parameterSets}{Character vector or \code{NULL}. Parameter-set ids
-referencing \code{parameterSets} definitions. Applied whole to every scenario.}
-
-\item{initialConditions}{Character vector or \code{NULL}. Initial-condition set
-ids referencing \code{initialConditions} definitions. Applied whole to every
-scenario.}
-
-\item{outputPaths}{Character vector or \code{NULL}. Output-path ids referencing
-\code{outputPaths} definitions. Applied whole to every scenario.}
-
-\item{simulationTime}{The simulation time grid, or \code{NULL} (default) to keep
-the one the model file carries. One interval is a length-3 numeric vector
-\code{c(start, end, resolution)} or the same grid written as a string,
-\code{"start, end, resolution"}. Several intervals go in one string,
-\code{"start, end, resolution; start, end, resolution"}, or in a list of
-length-3 numeric vectors, which is the shape a scenario's parsed
-\code{simulationTime} carries. To give a different grid per scenario, pass a list
-with one element (in any of those forms) per id.}
-
-\item{simulationTimeUnit}{Character time-unit string. Omitting the argument
-leaves the current value untouched (there is no default; this is a
-partial update).}
-
-\item{steadyState}{Logical, whether to simulate steady state. Omitting the
-argument leaves the current value untouched (there is no default; this is
-a partial update).}
-
-\item{steadyStateTime}{Numeric steady-state time in \code{steadyStateTimeUnit}.
-Omitting the argument leaves the current value untouched (there is no
-default; this is a partial update).}
-
-\item{steadyStateTimeUnit}{Character unit for \code{steadyStateTime}. Omitting
-the argument leaves the current value untouched (there is no default; this
-is a partial update).}
-
-\item{overwriteFormulasInSS}{Logical, whether to overwrite formulas during
-steady state. Omitting the argument leaves the current value untouched
-(there is no default; this is a partial update).}
-
-\item{readPopulationFromCSV}{Logical, whether to load the population from
-CSV. Omitting the argument leaves the current value untouched (there is no
-default; this is a partial update).}
-
-\item{overwrite}{Not an argument of \code{setScenario()}, which always updates the
-scenario named by \code{id}. It is declared only to reject the name, which R's
-partial matching would otherwise resolve to \code{overwriteFormulasInSS}. Pass
-that name in full for the steady-state model option, or use \code{\link[=addScenario]{addScenario()}}
-for the \code{overwrite} that replaces a definition.}
+\item{...}{Named fields to change. Accepted: \code{modelFile}, \code{individual},
+\code{population}, \code{application}, \code{parameterSets}, \code{initialConditions},
+\code{outputPaths}, \code{simulationTime}, \code{simulationTimeUnit}, \code{steadyState},
+\code{steadyStateTime}, \code{steadyStateTimeUnit}, \code{overwriteFormulasInSS},
+\code{readPopulationFromCSV}. Each takes the value \code{\link[=addScenario]{addScenario()}} documents for
+it, but has no default here: an omitted field is left untouched, a field
+passed as \code{NULL} is cleared. Scalar-per-definition fields recycle/align
+across \code{id}; \code{parameterSets}, \code{initialConditions} and \code{outputPaths} are
+applied whole. An unknown or unnamed field triggers an error.}
 }
 \value{
 The \code{project} object, invisibly.
@@ -124,6 +55,11 @@ Details): a supplied scalar-per-definition field is recycled or aligned
 across \code{id}, and the whole-vector fields \code{parameterSets} /
 \code{initialConditions} / \code{outputPaths} are applied whole to every scenario. A
 field left unsupplied is untouched on every scenario.
+
+There is no \code{overwrite} argument: \code{setScenario()} always updates the
+scenario named by \code{id}, and passing the name is an error. Use
+\code{\link[=addScenario]{addScenario()}} for the \code{overwrite} that replaces a definition, and spell
+\code{overwriteFormulasInSS} out in full for the steady-state model option.
 }
 \details{
 The id argument sets \code{N}, the number of definitions to act on, and cannot

--- a/tests/testthat/_snaps/authoring-vectorize.md
+++ b/tests/testthat/_snaps/authoring-vectorize.md
@@ -49,3 +49,19 @@
       ! `weight` must be length 1 or length 3 (the number of ids).
       x It is length 2.
 
+# .assertAuthoringFieldsNamed names the unnamed positions
+
+    Code
+      .assertAuthoringFieldsNamed(list("Rat"))
+    Condition
+      Error:
+      ! Every field must be named. x No name on field 1. i Name the field, for example `setIndividual(project, id, species = "Rat")`.
+
+---
+
+    Code
+      .assertAuthoringFieldsNamed(list(species = "Rat", "UNKNOWN"))
+    Condition
+      Error:
+      ! Every field must be named. x No name on field 2. i Name the field, for example `setIndividual(project, id, species = "Rat")`.
+

--- a/tests/testthat/_snaps/authoring-vectorize.md
+++ b/tests/testthat/_snaps/authoring-vectorize.md
@@ -55,7 +55,7 @@
       .assertAuthoringFieldsNamed(list("Rat"))
     Condition
       Error:
-      ! Every field must be named. x No name on field 1. i Name the field, for example `setIndividual(project, id, species = "Rat")`.
+      ! Every field must be named. x No name on field 1. i Pass each field as `name = value`.
 
 ---
 
@@ -63,5 +63,5 @@
       .assertAuthoringFieldsNamed(list(species = "Rat", "UNKNOWN"))
     Condition
       Error:
-      ! Every field must be named. x No name on field 2. i Name the field, for example `setIndividual(project, id, species = "Rat")`.
+      ! Every field must be named. x No name on field 2. i Pass each field as `name = value`.
 

--- a/tests/testthat/_snaps/scenarios.md
+++ b/tests/testthat/_snaps/scenarios.md
@@ -144,6 +144,22 @@
       Error in `setScenario()`:
       ! A <Scenario> passed as `id` carries every field, so `individual` cannot be given alongside it. i Edit the record's own field and pass it back (`sc$modelFile <- "other.pkml"`), or name the scenario's id instead of the record.
 
+# a scenario record passed with an unnamed field alongside it aborts
+
+    Code
+      setScenario(project, sc, "Other.pkml")
+    Condition
+      Error in `setScenario()`:
+      ! Every field must be named. x No name on field 1. i Pass each field as `name = value`.
+
+---
+
+    Code
+      setScenario(project, sc, individual = NULL, "Other.pkml")
+    Condition
+      Error in `setScenario()`:
+      ! Every field must be named. x No name on field 2. i Pass each field as `name = value`.
+
 # setScenario aborts on a non-existent scenario, no file written
 
     Code

--- a/tests/testthat/test-authoring-vectorize.R
+++ b/tests/testthat/test-authoring-vectorize.R
@@ -118,6 +118,20 @@ test_that("setPopulation() rejects a positionally passed field", {
   expect_error(setPopulation(project, "pop1", "Rat"), "must be named")
 })
 
+test_that("the unnamed-field hint points at no one set*() function", {
+  # `setScenario()`, `setIndividual()` and `setPopulation()` all raise it, and
+  # they share no field, so an example written for one misdirects the other two.
+  # The abort header already names the function the caller used.
+  project <- .fakeProject(
+    populations = list(pop1 = list(species = "Human"))
+  )
+  err <- expect_error(setPopulation(project, "pop1", "Rat"))
+  expect_no_match(
+    conditionMessage(err),
+    "setScenario|setIndividual|setPopulation"
+  )
+})
+
 test_that(".coerceNumericField returns NULL for NULL and as.double otherwise", {
   # A NULL passes through as NULL so the set-path loops delete the key (clearing
   # the optional field); any other value coerces with as.double().

--- a/tests/testthat/test-authoring-vectorize.R
+++ b/tests/testthat/test-authoring-vectorize.R
@@ -85,6 +85,39 @@ test_that(".alignAuthoringArgs propagates a length error naming the field", {
   )
 })
 
+test_that(".assertAuthoringFieldsNamed passes a fully named field list", {
+  fields <- list(species = "Rat", weight = 0.25)
+  expect_identical(.assertAuthoringFieldsNamed(fields), fields)
+  expect_identical(.assertAuthoringFieldsNamed(list()), list())
+})
+
+test_that(".assertAuthoringFieldsNamed names the unnamed positions", {
+  # Every field is looked up by name downstream, so an unnamed one used to
+  # vanish without a word. It arrives that way when a `set*()` field is passed
+  # positionally.
+  expect_snapshot(error = TRUE, .assertAuthoringFieldsNamed(list("Rat")))
+  expect_snapshot(
+    error = TRUE,
+    .assertAuthoringFieldsNamed(list(species = "Rat", "UNKNOWN"))
+  )
+})
+
+test_that("setIndividual() rejects a positionally passed field", {
+  project <- .fakeProject(
+    individuals = list(indiv1 = list(species = "Human"))
+  )
+  expect_error(setIndividual(project, "indiv1", "Rat"), "must be named")
+  # The silent-drop version left the individual untouched and said nothing.
+  expect_identical(project$definitions$individuals$indiv1$species, "Human")
+})
+
+test_that("setPopulation() rejects a positionally passed field", {
+  project <- .fakeProject(
+    populations = list(pop1 = list(species = "Human"))
+  )
+  expect_error(setPopulation(project, "pop1", "Rat"), "must be named")
+})
+
 test_that(".coerceNumericField returns NULL for NULL and as.double otherwise", {
   # A NULL passes through as NULL so the set-path loops delete the key (clearing
   # the optional field); any other value coerces with as.double().

--- a/tests/testthat/test-scenarios.R
+++ b/tests/testthat/test-scenarios.R
@@ -749,6 +749,21 @@ test_that("setScenario names a field it cannot set rather than dropping it", {
   )
 })
 
+test_that("setScenario requires its fields to be named", {
+  # The fields arrive through `...` (as they do for `setIndividual()` and
+  # `setPopulation()`), so a positional one carries no name to apply it under.
+  project <- testProject()
+  before <- project$definitions$scenarios[["testscenario"]]$modelFile
+  expect_error(
+    setScenario(project, "testscenario", "Aciclovir.pkml"),
+    "must be named"
+  )
+  expect_equal(
+    project$definitions$scenarios[["testscenario"]]$modelFile,
+    before
+  )
+})
+
 # Passing a parsed Scenario record back ----
 
 test_that("a parsed scenario is accepted back by addScenario() unchanged", {

--- a/tests/testthat/test-scenarios.R
+++ b/tests/testthat/test-scenarios.R
@@ -841,6 +841,22 @@ test_that("a scenario record passed with field arguments alongside it aborts", {
   expect_snapshot(error = TRUE, setScenario(project, sc, individual = NULL))
 })
 
+test_that("a scenario record passed with an unnamed field alongside it aborts", {
+  # An all-positional `...` has no names attribute at all, so a guard reading
+  # only the names sees nothing to object to and the value goes nowhere: the
+  # record supplies every field the branch forwards.
+  project <- testProject()
+  sc <- project$definitions$scenarios[["testscenario"]]
+  expect_snapshot(error = TRUE, setScenario(project, sc, "Other.pkml"))
+
+  # Partially named, so the names attribute exists but carries a blank. The
+  # unnamed field is reported by its position, not as an empty field name.
+  expect_snapshot(
+    error = TRUE,
+    setScenario(project, sc, individual = NULL, "Other.pkml")
+  )
+})
+
 test_that("addScenario() reads a list of intervals as one grid for one scenario", {
   # A parsed multi-interval `simulationTime` is a list of length-3 numerics; with
   # one id that is one grid, not one value per id.


### PR DESCRIPTION
`setScenario()` spelled out all 16 settable fields as explicit arguments and reconstructed the supplied set through 14 `missing()` blocks. That whole interface existed for one reason: `overwrite` is a unique prefix of `overwriteFormulasInSS`, so R's partial matching turned the habit picked up from `addScenario()` into a silent change to a steady-state option. With `...` there is nothing after `project` and `id` to partial-match against, so the name lands in the field set and is rejected by name. `setIndividual()` and `setPopulation()` already had this shape.

## Authoring

- `setScenario(project, id, ...)`, forwarding to the method. Around 70 lines and 14 `@param` blocks go; the settable-field list now lives in two places instead of three (`.settableScenarioFields` stays as the impl's whitelist).
- `.assertScenarioRecordAlone()` takes the extra field names rather than a `match.call()`; `addScenario()` reads its own off `match.call()` through the new `.addScenarioExtraFields()`, since its formals still let `modelFile` through positionally.
- `@param ...` replaces the per-field blocks, modelled on `setIndividual()`'s.

## Unnamed fields

Making the fields travel through `...` exposed a silent drop that was already there for `setIndividual()` and `setPopulation()`: an unnamed field has no name to be looked up under, so the whole alignment skipped it and the definition came back unchanged with nothing said. `setIndividual(project, "indiv1", "Rat")` was a no-op.

- `.assertAuthoringFieldsNamed()` in `R/authoring-vectorize.R`, called on `dots` in all three `set*_impl` functions.
- `messages$unnamedAuthoringFields()` for the text.

## Breaking

A positional field on `setScenario()` (`setScenario(project, "sc", "model.pkml")`) is now an error instead of setting `modelFile`. This matches the two sibling functions. No NEWS entry: `setScenario()` itself is new in 6.0.0, so there is no released behaviour to describe a delta from.
