### PR TITLE
Give the steady-state step of a scenario build its own function

### DIFF
--- a/R/scenario-execution.R
+++ b/R/scenario-execution.R
@@ -477,22 +477,48 @@
   }
 
   # 7. Steady state
-  if (scenario$simulateSteadyState) {
-    ignoreIfFormula <- !scenario$overwriteFormulasInSS
-    initialValues <- ospsuite::getSteadyState(
-      simulations = list(simulation),
-      steadyStateTime = list(scenario$steadyStateTime),
-      ignoreIfFormula = ignoreIfFormula,
-      simulationRunOptions = simulationRunOptions
-    )
-    ospsuite::setQuantityValuesByPath(
-      quantityPaths = initialValues[[simulation$id]]$paths,
-      values = initialValues[[simulation$id]]$values,
-      simulation = simulation
-    )
-  }
+  .applyScenarioSteadyState(simulation, scenario, simulationRunOptions)
 
   list(simulation = simulation, population = population)
+}
+
+# .applyScenarioSteadyState ----
+
+# Bring a scenario's simulation to steady state, when it asks for one: solve for
+# the steady-state quantity values at the scenario's `steadyStateTime` and write
+# them back as the simulation's start values. A scenario with
+# `simulateSteadyState` off is a no-op.
+#
+# `overwriteFormulasInSS` is the scenario's own spelling of the inverse of
+# `ospsuite`'s `ignoreIfFormula`: a quantity whose start value is a formula
+# keeps that formula unless the scenario opts into overwriting it.
+#
+# Mutates `simulation` in place (an `ospsuite::Simulation` is a reference
+# object), like the other steps of `.prepareScenario()`, and returns it
+# invisibly.
+#
+# @keywords internal
+# @noRd
+.applyScenarioSteadyState <- function(
+  simulation,
+  scenario,
+  simulationRunOptions
+) {
+  if (!scenario$simulateSteadyState) {
+    return(invisible(simulation))
+  }
+  initialValues <- ospsuite::getSteadyState(
+    simulations = list(simulation),
+    steadyStateTime = list(scenario$steadyStateTime),
+    ignoreIfFormula = !scenario$overwriteFormulasInSS,
+    simulationRunOptions = simulationRunOptions
+  )
+  ospsuite::setQuantityValuesByPath(
+    quantityPaths = initialValues[[simulation$id]]$paths,
+    values = initialValues[[simulation$id]]$values,
+    simulation = simulation
+  )
+  invisible(simulation)
 }
 
 # .scenarioBuildPreflight ----

--- a/REFACTORING-LOG.md
+++ b/REFACTORING-LOG.md
@@ -203,3 +203,4 @@ One bullet per commit, newest at the bottom: `- YYYY-MM-DD HH:MM: plain-language
 - 2026-08-06 09:05: Exporting to Excel no longer throws away a steady-state time a scenario declares but is not currently using; it used to come back as 1000 minutes.
 - 2026-08-06 09:20: A field passed without a name to setScenario, setIndividual or setPopulation is now an error; it used to be dropped in silence, leaving the definition unchanged.
 - 2026-08-06 09:35: setScenario now takes its fields the same way setIndividual and setPopulation do, dropping 16 arguments and 70 lines of plumbing; fields must be named.
+- 2026-08-06 09:48: The steady-state step of preparing a scenario is now its own function with its own tests; it was only reachable by running the whole 150-line build.

--- a/tests/testthat/test-scenario-execution.R
+++ b/tests/testthat/test-scenario-execution.R
@@ -952,7 +952,13 @@ test_that(".applyScenarioSteadyState solves at the scenario's time and writes th
         ignoreIfFormula = ignoreIfFormula,
         simulationRunOptions = simulationRunOptions
       )
-      list(sim1 = list(paths = c("Organism|A"), values = 3.5))
+      # `getSteadyState()` answers one entry per simulation it was handed. The
+      # entry for the simulation under test comes second, so reading the result
+      # positionally instead of by id picks up the other simulation's values.
+      list(
+        other = list(paths = "Organism|B", values = 99),
+        sim1 = list(paths = c("Organism|A"), values = 3.5)
+      )
     },
     setQuantityValuesByPath = function(quantityPaths, values, simulation) {
       written <<- list(

--- a/tests/testthat/test-scenario-execution.R
+++ b/tests/testthat/test-scenario-execution.R
@@ -909,6 +909,106 @@ test_that(".buildScenarioSimulations shares one build cache across scenarios in 
   expect_identical(built, 1L)
 })
 
+# Steady state ----
+
+# A stand-in for the one thing `.applyScenarioSteadyState()` reads off the
+# simulation, so the tests below need no PK-Sim model loaded.
+.fakeSimulation <- function(id = "sim1") {
+  list(id = id)
+}
+
+test_that(".applyScenarioSteadyState is a no-op when the scenario does not ask for one", {
+  called <- FALSE
+  local_mocked_bindings(
+    getSteadyState = function(...) {
+      called <<- TRUE
+      list()
+    },
+    .package = "ospsuite"
+  )
+  scenario <- Scenario(modelFile = "m.pkml", simulateSteadyState = FALSE)
+  simulation <- .fakeSimulation()
+
+  expect_identical(
+    .applyScenarioSteadyState(simulation, scenario, NULL),
+    simulation
+  )
+  expect_false(called)
+})
+
+test_that(".applyScenarioSteadyState solves at the scenario's time and writes the values back", {
+  solved <- NULL
+  written <- NULL
+  local_mocked_bindings(
+    getSteadyState = function(
+      simulations,
+      steadyStateTime,
+      ignoreIfFormula,
+      simulationRunOptions
+    ) {
+      solved <<- list(
+        simulations = simulations,
+        steadyStateTime = steadyStateTime,
+        ignoreIfFormula = ignoreIfFormula,
+        simulationRunOptions = simulationRunOptions
+      )
+      list(sim1 = list(paths = c("Organism|A"), values = 3.5))
+    },
+    setQuantityValuesByPath = function(quantityPaths, values, simulation) {
+      written <<- list(
+        quantityPaths = quantityPaths,
+        values = values,
+        simulation = simulation
+      )
+      invisible(NULL)
+    },
+    .package = "ospsuite"
+  )
+  scenario <- Scenario(
+    modelFile = "m.pkml",
+    simulateSteadyState = TRUE,
+    steadyStateTime = 600,
+    overwriteFormulasInSS = FALSE
+  )
+  simulation <- .fakeSimulation()
+  runOptions <- ospsuite::SimulationRunOptions$new(numberOfCores = 1)
+
+  .applyScenarioSteadyState(simulation, scenario, runOptions)
+
+  expect_identical(solved$simulations, list(simulation))
+  expect_identical(solved$steadyStateTime, list(600))
+  expect_identical(solved$simulationRunOptions, runOptions)
+  # The scenario's `overwriteFormulasInSS` is the inverse of `ignoreIfFormula`:
+  # off means a formula-valued start value is left alone.
+  expect_true(solved$ignoreIfFormula)
+
+  # The solved values land on the simulation, keyed by its own id.
+  expect_identical(written$quantityPaths, c("Organism|A"))
+  expect_identical(written$values, 3.5)
+  expect_identical(written$simulation, simulation)
+})
+
+test_that(".applyScenarioSteadyState overwrites formulas when the scenario says so", {
+  ignoreIfFormula <- NULL
+  local_mocked_bindings(
+    getSteadyState = function(simulations, steadyStateTime, ...) {
+      ignoreIfFormula <<- list(...)$ignoreIfFormula
+      list(sim1 = list(paths = character(), values = numeric()))
+    },
+    setQuantityValuesByPath = function(...) invisible(NULL),
+    .package = "ospsuite"
+  )
+  scenario <- Scenario(
+    modelFile = "m.pkml",
+    simulateSteadyState = TRUE,
+    steadyStateTime = 600,
+    overwriteFormulasInSS = TRUE
+  )
+
+  .applyScenarioSteadyState(.fakeSimulation(), scenario, NULL)
+  expect_false(ignoreIfFormula)
+})
+
 # Population source resolution ----
 
 test_that(".resolveScenarioPopulation resolves a programmatic entry from the runtime store", {


### PR DESCRIPTION
The steady-state step of `.prepareScenario()` is the scientifically load-bearing one and was the only step with no direct test: every pure merge step around it is unit-tested, but the branch calling `ospsuite::getSteadyState()` was reachable only by driving the whole 150-line orchestration.

## Scenario execution

- `.applyScenarioSteadyState(simulation, scenario, simulationRunOptions)` extracted alongside the other merge helpers; step 7 of `.prepareScenario()` becomes one call. Behaviour is unchanged, including the truthiness test on `simulateSteadyState` (a corrupt `NA` still errors rather than silently skipping steady state).
- Tests cover the no-op, the solve-and-write-back keyed by simulation id, and the `overwriteFormulasInSS` to `ignoreIfFormula` inversion, with the `ospsuite` bindings mocked. No PK-Sim model is loaded.
