### PR TITLE
Give the PI bounds-ordering hazard its own function

### DIFF
--- a/R/parameter-identification.R
+++ b/R/parameter-identification.R
@@ -983,12 +983,13 @@ print.PITask <- function(x, ...) {
 #
 # The two bounds cannot be set at once, and each setter validates the new bound
 # against the *other* one, which still holds the model's default until it is
-# overwritten in turn. So one of the two orders passes through an invalid pair
-# and aborts: raising `minValue` above the stale `maxValue`, or lowering
-# `maxValue` below the stale `minValue`. Which one depends on where the new
-# bounds sit relative to the model defaults, so the order is chosen per
-# parameter. A `PIParameter()` record is already validated as
-# `minValue <= startValue <= maxValue`, so the other order always succeeds.
+# overwritten in turn. The order only matters when the new window sits entirely
+# outside the current one: above it, `minValue` first is blocked by the stale
+# `maxValue`; below it, `maxValue` first is blocked by the stale `minValue`. A
+# window that overlaps the current one goes through in either order. A
+# `PIParameter()` record is already validated as
+# `minValue <= startValue <= maxValue`, so a window cannot sit both above and
+# below: at most one order is ever blocked, and this picks the other.
 #
 # Mutates `runtime` in place (an R6 object) and returns it invisibly.
 #

--- a/R/parameter-identification.R
+++ b/R/parameter-identification.R
@@ -880,13 +880,8 @@ print.PITask <- function(x, ...) {
       parameters = if (length(paramObjs) == 1L) paramObjs[[1]] else paramObjs
     )
     # Apply the declared display unit first so bounds and start value are
-    # interpreted in it, then the start value. The bound setters validate each
-    # new bound against the *other* bound, which still holds its model-default
-    # value until we overwrite it. Assign the bounds in whichever order keeps
-    # every intermediate state valid: if the new minValue would exceed the
-    # stale maxValue, raise maxValue first; otherwise lower minValue first. The
-    # PIParameter() record is already validated as minValue <= startValue <=
-    # maxValue, so one of the two orders always succeeds.
+    # interpreted in it, then the start value, then the bounds
+    # (`.assignPIBounds()` owns their ordering hazard).
     #
     # A unit that is not one of the parameter's own dimension is reported and
     # left unapplied, rather than aborting the task. The legacy 5.x
@@ -909,13 +904,7 @@ print.PITask <- function(x, ...) {
       }
     }
     runtime$startValue <- p$startValue
-    if (p$minValue >= runtime$maxValue) {
-      runtime$maxValue <- p$maxValue
-      runtime$minValue <- p$minValue
-    } else {
-      runtime$minValue <- p$minValue
-      runtime$maxValue <- p$maxValue
-    }
+    .assignPIBounds(runtime, p$minValue, p$maxValue)
     runtime
   })
 
@@ -987,6 +976,33 @@ print.PITask <- function(x, ...) {
     outputMappings = outputMappings,
     configuration = piConfig
   )
+}
+
+# Write a PI parameter's search bounds onto its runtime object, in an order that
+# keeps every intermediate state valid.
+#
+# The two bounds cannot be set at once, and each setter validates the new bound
+# against the *other* one, which still holds the model's default until it is
+# overwritten in turn. So one of the two orders passes through an invalid pair
+# and aborts: raising `minValue` above the stale `maxValue`, or lowering
+# `maxValue` below the stale `minValue`. Which one depends on where the new
+# bounds sit relative to the model defaults, so the order is chosen per
+# parameter. A `PIParameter()` record is already validated as
+# `minValue <= startValue <= maxValue`, so the other order always succeeds.
+#
+# Mutates `runtime` in place (an R6 object) and returns it invisibly.
+#
+# @keywords internal
+# @noRd
+.assignPIBounds <- function(runtime, minValue, maxValue) {
+  if (minValue >= runtime$maxValue) {
+    runtime$maxValue <- maxValue
+    runtime$minValue <- minValue
+  } else {
+    runtime$minValue <- minValue
+    runtime$maxValue <- maxValue
+  }
+  invisible(runtime)
 }
 
 # @keywords internal

--- a/REFACTORING-LOG.md
+++ b/REFACTORING-LOG.md
@@ -204,3 +204,4 @@ One bullet per commit, newest at the bottom: `- YYYY-MM-DD HH:MM: plain-language
 - 2026-08-06 09:20: A field passed without a name to setScenario, setIndividual or setPopulation is now an error; it used to be dropped in silence, leaving the definition unchanged.
 - 2026-08-06 09:35: setScenario now takes its fields the same way setIndividual and setPopulation do, dropping 16 arguments and 70 lines of plumbing; fields must be named.
 - 2026-08-06 09:48: The steady-state step of preparing a scenario is now its own function with its own tests; it was only reachable by running the whole 150-line build.
+- 2026-08-06 09:58: The careful order in which a parameter-identification bound is written is now its own function with tests for both directions, instead of a comment inside a 170-line builder.

--- a/tests/testthat/test-parameter-identification.R
+++ b/tests/testthat/test-parameter-identification.R
@@ -3160,3 +3160,71 @@ test_that(".validatePI reports every incomplete PI record at once", {
   # No spurious bounds complaint: the comparison is skipped, not run on NULL.
   expect_false(any(grepl("invalid bounds", msgs, ignore.case = TRUE)))
 })
+
+# Runtime bounds assignment ----
+
+# A stand-in for `ospsuite.parameteridentification::PIParameters`' bound
+# setters: each rejects a value that would cross the *other* bound as it stands
+# right then, which is the constraint `.assignPIBounds()` has to route around.
+.boundedRuntime <- function(minValue, maxValue) {
+  R6::R6Class(
+    "FakePIParameters",
+    public = list(
+      initialize = function(minValue, maxValue) {
+        private$.min <- minValue
+        private$.max <- maxValue
+      }
+    ),
+    private = list(.min = NULL, .max = NULL),
+    active = list(
+      minValue = function(value) {
+        if (missing(value)) {
+          return(private$.min)
+        }
+        if (value > private$.max) {
+          stop("minValue above the current maxValue")
+        }
+        private$.min <- value
+      },
+      maxValue = function(value) {
+        if (missing(value)) {
+          return(private$.max)
+        }
+        if (value < private$.min) {
+          stop("maxValue below the current minValue")
+        }
+        private$.max <- value
+      }
+    )
+  )$new(minValue, maxValue)
+}
+
+test_that(".assignPIBounds sets bounds that sit above the model defaults", {
+  # New window entirely above the stale one: setting minValue first would cross
+  # the default maxValue, so maxValue has to be raised first.
+  runtime <- .boundedRuntime(minValue = 0, maxValue = 1)
+  .assignPIBounds(runtime, minValue = 10, maxValue = 20)
+  expect_identical(runtime$minValue, 10)
+  expect_identical(runtime$maxValue, 20)
+})
+
+test_that(".assignPIBounds sets bounds that sit below the model defaults", {
+  # New window entirely below the stale one: maxValue first would cross the
+  # default minValue, so minValue has to be lowered first.
+  runtime <- .boundedRuntime(minValue = 100, maxValue = 200)
+  .assignPIBounds(runtime, minValue = 1, maxValue = 5)
+  expect_identical(runtime$minValue, 1)
+  expect_identical(runtime$maxValue, 5)
+})
+
+test_that(".assignPIBounds sets bounds that overlap the model defaults", {
+  runtime <- .boundedRuntime(minValue = 0, maxValue = 10)
+  .assignPIBounds(runtime, minValue = 2, maxValue = 8)
+  expect_identical(runtime$minValue, 2)
+  expect_identical(runtime$maxValue, 8)
+})
+
+test_that(".assignPIBounds returns the runtime invisibly", {
+  runtime <- .boundedRuntime(minValue = 0, maxValue = 10)
+  expect_invisible(.assignPIBounds(runtime, minValue = 1, maxValue = 9))
+})


### PR DESCRIPTION
Writing a PI parameter's two search bounds is order-dependent: each setter validates the new bound against the *other* one, which still holds the model's default until it is overwritten in turn, so one of the two orders passes through an invalid pair and aborts. Which one depends on where the new window sits relative to the defaults. That was a correct-by-construction `if` buried in a 170-line task builder with a comment and no test surface.

## Parameter identification

- `.assignPIBounds(runtime, minValue, maxValue)` extracted, carrying the explanation with it. `.createSinglePITask()` calls it.
- Tests drive it against a stand-in with the same crossing-rejection semantics, covering a new window above the model defaults, below them, and overlapping them. The stand-in was checked to reproduce the hazard: the naive single order aborts in both directions.
