### PR TITLE
Compare a project against its Excel files without importing

### DIFF
--- a/R/project-excel.R
+++ b/R/project-excel.R
@@ -992,42 +992,48 @@ exportProjectToExcel <- function(
 # in-memory serialization (`.projectToJson()`) of a loaded project:
 #   - memory side: the live `project`, so the comparison reflects the project as
 #     it is now (unsaved edits included), not the on-disk container;
-#   - Excel side: a fresh re-import of the side-car workbook, loaded back into a
-#     `Project` and serialized the same way.
+#   - Excel side: the side-car workbook read into a `Project` and serialized the
+#     same way.
 # Serializing both from an in-memory project (rather than reading a container
 # file raw) is what makes the comparison container-shape-independent: a tree
 # project's on-disk container keeps every section emptied (the tree owns them),
 # so reading either container raw would blind the comparison and report false
 # drift on every section. The volatile `esqlabsRVersion` is ignored.
 #
+# Nothing is written: a read-only question is answered by reading. The workbooks
+# are parsed into an inlined container (`.excelToProjectJson()`) and that
+# container is parsed into a `Project` directly, so a status check costs one
+# workbook read rather than a whole definitions tree written to a temporary
+# directory, re-read, and deleted.
+#
 # @keywords internal
 # @noRd
 .compareJsonToExcel <- function(project, projectConfigPath, silent = FALSE) {
-  # Create temporary snapshot from current Excel files
-  tempDir <- tempfile("config_snapshot")
-  dir.create(tempDir, showWarnings = FALSE, recursive = TRUE)
-  on.exit(unlink(tempDir, recursive = TRUE), add = TRUE)
-
-  # `copyAssets = FALSE`: this snapshot exists only to be serialized and compared,
-  # then deleted with `tempDir`. Copying the referenced models, data, and
-  # population folders into it would turn every `projectStatus()` read into a
-  # recursive copy of the whole asset tree, and a copy failure (a locked file, a
-  # full disk) would surface as "cannot compare the Excel files".
-  tempJsonPath <- importProjectFromExcel(
+  projectDir <- dirname(fs::path_abs(projectConfigPath))
+  excelJson <- .excelToProjectJson(
     projectConfigPath,
-    outputDir = tempDir,
-    silent = TRUE,
-    copyAssets = FALSE
+    projectDir = projectDir
+  )$jsonData
+
+  # The container is parsed against a directory that does not exist, so every
+  # section resolves to the one inlined in it. Pointing this at the real project
+  # folder would instead resolve each section against the `definitions/` tree
+  # sitting beside the workbooks, which is the very thing being compared: the
+  # Excel side would read back the memory side and never report drift.
+  treelessDir <- tempfile("excel_compare")
+  excelProject <- Project$new(
+    sections = .parseProjectSections(
+      excelJson,
+      jsonPath = file.path(treelessDir, "Project.json"),
+      projectDirPath = treelessDir
+    )
   )
 
-  # The memory side: serialize the live in-memory project. The Excel side: load
-  # the just-imported temp tree project and serialize it the same way. Both go
-  # through `.projectToJson()`, so the two sides are compared in one shape
-  # regardless of how either container is stored on disk. `Project$new()` (not
-  # `loadProject()`) skips the cross-reference warning pass, so a project with
-  # dangling refs compares quietly.
+  # Both sides go through `.projectToJson()`, so they are compared in one shape
+  # regardless of how either container is stored on disk. The memory side is the
+  # live `project`, so the comparison reflects unsaved edits too.
   originalJsonObj <- .projectToJson(project)
-  currentJsonObj <- .projectToJson(Project$new(projectFilePath = tempJsonPath))
+  currentJsonObj <- .projectToJson(excelProject)
 
   # Both sides canonicalize every id (via `.canonicalizeProjectJsonIds()`) so id
   # canonicalization is never counted as drift (which would make an otherwise
@@ -1049,6 +1055,24 @@ exportProjectToExcel <- function(
   # task's parameter list) and is left as it is.
   originalJsonObj <- .sortJsonKeys(originalJsonObj)
   currentJsonObj <- .sortJsonKeys(currentJsonObj)
+
+  # And in the same spirit for the sections held as arrays (`scenarios`,
+  # `individuals`, `populations`, `observedData`): which definition comes first
+  # carries no meaning either. A tree project holds one file per definition, so
+  # its order is the order the filesystem lists them in, while a workbook's is
+  # the order its rows were typed. Only these top-level sections are reordered;
+  # an array inside a definition keeps its order.
+  originalJsonObj <- .sortJsonSections(originalJsonObj)
+  currentJsonObj <- .sortJsonSections(currentJsonObj)
+
+  # Finally, both sides are compared as the JSON they would be written as rather
+  # than as the R values behind it, because `jsonlite` narrows a whole double to
+  # an integer on the way back in: a `250` that reached one side through a file
+  # and the other straight from a workbook is the same number stored as two
+  # types. Encoding and decoding both sides the same way settles that, and
+  # neither side touches disk to do it.
+  originalJsonObj <- .asWrittenJson(originalJsonObj)
+  currentJsonObj <- .asWrittenJson(currentJsonObj)
 
   # Remove esqlabsRVersion -- it changes with package updates and would cause
   # false out-of-sync reports
@@ -1158,6 +1182,56 @@ exportProjectToExcel <- function(
     return(x)
   }
   x[order(names, method = "radix")]
+}
+
+# Put every top-level array-shaped section in one order, so the two sides of the
+# Excel comparison are not read as drifting over which definition comes first.
+# Records are ordered by their own serialized content rather than by an id
+# field, which needs no per-section knowledge and is exactly as discriminating:
+# two sections holding the same records sort the same, and two holding different
+# ones are reported as differing either way.
+#
+# Only the top level is touched. An array inside a definition (a PI task's
+# parameter list) is ordered on purpose and left alone.
+#
+# @keywords internal
+# @noRd
+.sortJsonSections <- function(x) {
+  if (!is.list(x)) {
+    return(x)
+  }
+  for (name in names(x)) {
+    section <- x[[name]]
+    isArraySection <- is.list(section) &&
+      length(section) > 1L &&
+      is.null(names(section))
+    if (!isArraySection) {
+      next
+    }
+    keys <- vapply(
+      section,
+      function(record) {
+        as.character(jsonlite::toJSON(record, auto_unbox = TRUE, null = "null"))
+      },
+      character(1)
+    )
+    x[[name]] <- section[order(keys, method = "radix")]
+  }
+  x
+}
+
+# Re-read a serialized project as the JSON it would be written as. Encoding and
+# decoding a value settles the storage type the way a written file would (a
+# whole double comes back an integer), so two objects built along different
+# routes are comparable on their content rather than on how they were built.
+#
+# @keywords internal
+# @noRd
+.asWrittenJson <- function(x) {
+  jsonlite::fromJSON(
+    jsonlite::toJSON(x, auto_unbox = TRUE, digits = NA, null = "null"),
+    simplifyVector = FALSE
+  )
 }
 
 # Excel <-> JSON bridge: sync helper ----

--- a/R/project-excel.R
+++ b/R/project-excel.R
@@ -339,6 +339,144 @@ importProjectFromExcel <- function(
   validateIsLogical(copyAssets)
   .validateFilenameSegment(projectFileName, messages$invalidProjectFileName)
 
+  # The import writes beside the Excel project unless told otherwise, and the
+  # read half is handed that folder, so resolve it before reading.
+  outputDir <- outputDir %||% dirname(fs::path_abs(projectConfigPath))
+
+  read <- .excelToProjectJson(projectConfigPath, projectDir = outputDir)
+  jsonData <- read$jsonData
+  pcDir <- read$pcDir
+  filePathProps <- read$filePathProps
+  conventionWorkbooks <- read$conventionWorkbooks
+
+  # Append `.json` rather than `fs::path_ext_set()`, which would *replace* an
+  # existing extension: a dotted stem like `trial.v1` reads as an extension, so
+  # setting it would strip the `.v1` and collapse `trial.v1` and `trial.v2` onto
+  # one container.
+  outputPath <- file.path(outputDir, .withJsonExtension(projectFileName))
+
+  # Guard against silently replacing an existing JSON project. The import writes
+  # the container and fully reconciles the `definitions/` tree (deleting any
+  # definition authored only on the JSON side), so re-importing over a JSON
+  # project the user has since edited would erase that work. Abort unless
+  # `overwrite = TRUE` when the target container file already exists, or a
+  # non-empty `definitions/` tree already sits in `outputDir`.
+  definitionsDir <- file.path(outputDir, "definitions")
+  hasDefinitionTree <- dir.exists(definitionsDir) &&
+    any(grepl("\\.json$", list.files(definitionsDir, recursive = TRUE)))
+  if (!overwrite && (file.exists(outputPath) || hasDefinitionTree)) {
+    cli::cli_abort(messages$importWouldOverwriteProject(outputDir))
+  }
+
+  if (!dir.exists(dirname(outputPath))) {
+    dir.create(dirname(outputPath), recursive = TRUE)
+  }
+
+  # Bootstrap an in-memory project from the imported data by writing the inlined
+  # JSON to the container path and parsing it back. This inlined form is only a
+  # transient bootstrap: `.writeProjectTree()` below overwrites the container
+  # with the slim (`containerOnly`) shape, so the inlined file never survives the
+  # call. `Project$new()` (not `loadProject()`) parses it without running the
+  # cross-reference warning pass, so a project with dangling refs imports quietly
+  # under `silent`.
+  jsonText <- jsonlite::toJSON(
+    jsonData,
+    pretty = TRUE,
+    auto_unbox = TRUE,
+    digits = NA,
+    null = "null"
+  )
+  writeLines(jsonText, outputPath)
+  importedProject <- Project$new(projectFilePath = outputPath)
+
+  # Write the imported project as a normal tree project: the slim
+  # (`containerOnly`) `Project.json` container plus the `definitions/<kind>/`
+  # tree, exactly what `saveProject()` and `initProject()` produce. There is one
+  # canonical on-disk `Project.json` shape, so an imported project is
+  # indistinguishable from any other tree project. The Excel sync check compares
+  # the in-memory project against the workbook (see `.compareJsonToExcel()`), so
+  # it needs no inlined container to diff against.
+  .writeProjectTree(importedProject, outputDir, containerPath = outputPath)
+
+  # The definitions reference models, data, and population files by a path
+  # relative to the project folder, so importing into a different folder would
+  # leave every one of those references dangling. Bring the referenced input
+  # folders along, so the imported project runs where it was written.
+  assets <- if (copyAssets) {
+    .copyExcelProjectAssets(filePathProps, pcDir, outputDir, overwrite)
+  } else {
+    list(copied = character(), notCopied = character())
+  }
+
+  # Report what the import produced. Not gated on an interactive session: an
+  # import run from a script is exactly the case where the call would otherwise
+  # finish with no sign of what (or whether) anything was written. `silent` is
+  # the way to turn it off.
+  if (!silent) {
+    inputFile <- .readablePath(projectConfigPath)
+    outputFile <- .readablePath(outputPath)
+    msg <- messages$importedProject(inputFile, outputFile)
+    cli::cli_inform("{msg}")
+    # The per-section counts, rendered by the project's own definitions block so
+    # the summary and `print(project)` can never disagree about the labels. That
+    # block prints to stdout, so it is captured and re-emitted verbatim on the
+    # message stream, keeping the whole summary on one stream (and out of the way
+    # of anything capturing the function's own output).
+    cli::cli_verbatim(utils::capture.output(print(
+      importedProject$definitions
+    )))
+    # The counts block lists only the sections that hold something, so the
+    # sections that imported nothing are named here: a section that came out
+    # empty is exactly what a reader has to see to notice that a workbook did
+    # not arrive.
+    empty <- .emptyProjectSections(importedProject)
+    if (length(empty) > 0L) {
+      msg <- messages$importEmptySections(empty)
+      cli::cli_inform("{msg}")
+    }
+    # A workbook read under its conventional filename is content the project
+    # does not declare, so a reader would otherwise have no way to know it was
+    # imported.
+    if (length(conventionWorkbooks) > 0L) {
+      .informFormatted(messages$importUndeclaredWorkbooks(conventionWorkbooks))
+    }
+    if (length(assets$copied) > 0L) {
+      msg <- messages$importCopiedAssetFolders(assets$copied)
+      cli::cli_inform("{msg}")
+    }
+    if (length(assets$notCopied) > 0L) {
+      msg <- messages$importUncopiedAssetFolders(assets$notCopied)
+      cli::cli_warn("{msg}")
+    }
+  }
+
+  invisible(outputPath)
+}
+
+# Read an Excel project into the in-memory `Project.json` shape, doing all of
+# the reading and none of the writing: every workbook the property sheet names
+# is parsed into one inlined `jsonData` list with canonical ids, and nothing is
+# created on disk. `importProjectFromExcel()` writes that list out as a project;
+# `.compareJsonToExcel()` reads it to diff a live project against its workbooks
+# without running an import.
+#
+# `projectDir` is where the project the workbooks describe lives (the import's
+# `outputDir`). It anchors a relative `${VAR}` data folder, which is stored as
+# the raw `${VAR}` and so re-expanded on every load: anchoring it to the Excel
+# source instead would find a different folder after the import than before it.
+#
+# Returns the parsed data plus the pieces the writing half needs:
+#   - jsonData            : the inlined project, ids canonicalized
+#   - pcDir               : the Excel project's own folder
+#   - filePathProps       : the live working folders, for the asset copy
+#   - conventionWorkbooks : workbooks read under their conventional filename
+#                           rather than one the property sheet names
+#
+# @keywords internal
+# @noRd
+.excelToProjectJson <- function(projectConfigPath, projectDir) {
+  validateIsString(projectConfigPath)
+
   if (!file.exists(projectConfigPath)) {
     cli::cli_abort(messages$fileNotFound(projectConfigPath))
   }
@@ -548,18 +686,13 @@ importProjectFromExcel <- function(
     )
   }
 
-  # --- Determine output path ---
-  if (is.null(outputDir)) {
-    outputDir <- pcDir
-  }
-
   # Observed data. The project records a single `dataFile` (an experimental-data
   # workbook) and a `dataImporterConfigurationFile` under `dataFolder`, not a
   # per-section workbook, so it is parsed outside the `sections` loop. The
   # importer reifies it as one `excel` observed-data definition keyed by the
   # data-file basename, listing the workbook's sheets; the loader resolves the
   # `file` / `importerConfiguration` basenames against `dataFolder`.
-  jsonData <- .parseExcelObservedData(jsonData, prop, pcDir, outputDir)
+  jsonData <- .parseExcelObservedData(jsonData, prop, pcDir, projectDir)
 
   # A 5.x `PIOutputMappings` sheet names the sheet of the data workbook each
   # mapping's data set comes from. There is no per-mapping counterpart in a
@@ -571,29 +704,6 @@ importProjectFromExcel <- function(
     importState$declaredObservedSheets,
     jsonData$observedData
   )
-
-  # Append `.json` rather than `fs::path_ext_set()`, which would *replace* an
-  # existing extension: a dotted stem like `trial.v1` reads as an extension, so
-  # setting it would strip the `.v1` and collapse `trial.v1` and `trial.v2` onto
-  # one container.
-  outputPath <- file.path(outputDir, .withJsonExtension(projectFileName))
-
-  # Guard against silently replacing an existing JSON project. The import writes
-  # the container and fully reconciles the `definitions/` tree (deleting any
-  # definition authored only on the JSON side), so re-importing over a JSON
-  # project the user has since edited would erase that work. Abort unless
-  # `overwrite = TRUE` when the target container file already exists, or a
-  # non-empty `definitions/` tree already sits in `outputDir`.
-  definitionsDir <- file.path(outputDir, "definitions")
-  hasDefinitionTree <- dir.exists(definitionsDir) &&
-    any(grepl("\\.json$", list.files(definitionsDir, recursive = TRUE)))
-  if (!overwrite && (file.exists(outputPath) || hasDefinitionTree)) {
-    cli::cli_abort(messages$importWouldOverwriteProject(outputDir))
-  }
-
-  if (!dir.exists(dirname(outputPath))) {
-    dir.create(dirname(outputPath), recursive = TRUE)
-  }
 
   # Canonicalize every id (and every reference to one) so the imported project
   # uses safe, lowercase, single-path-segment ids. This is the same transform
@@ -613,85 +723,12 @@ importProjectFromExcel <- function(
   # `validateProject()` use.
   .warnIncompleteObservedCurves(jsonData$dataCombined)
 
-  # Bootstrap an in-memory project from the imported data by writing the inlined
-  # JSON to the container path and parsing it back. This inlined form is only a
-  # transient bootstrap: `.writeProjectTree()` below overwrites the container
-  # with the slim (`containerOnly`) shape, so the inlined file never survives the
-  # call. `Project$new()` (not `loadProject()`) parses it without running the
-  # cross-reference warning pass, so a project with dangling refs imports quietly
-  # under `silent`.
-  jsonText <- jsonlite::toJSON(
-    jsonData,
-    pretty = TRUE,
-    auto_unbox = TRUE,
-    digits = NA,
-    null = "null"
+  list(
+    jsonData = jsonData,
+    pcDir = pcDir,
+    filePathProps = filePathProps,
+    conventionWorkbooks = conventionWorkbooks
   )
-  writeLines(jsonText, outputPath)
-  importedProject <- Project$new(projectFilePath = outputPath)
-
-  # Write the imported project as a normal tree project: the slim
-  # (`containerOnly`) `Project.json` container plus the `definitions/<kind>/`
-  # tree, exactly what `saveProject()` and `initProject()` produce. There is one
-  # canonical on-disk `Project.json` shape, so an imported project is
-  # indistinguishable from any other tree project. The Excel sync check compares
-  # the in-memory project against the workbook (see `.compareJsonToExcel()`), so
-  # it needs no inlined container to diff against.
-  .writeProjectTree(importedProject, outputDir, containerPath = outputPath)
-
-  # The definitions reference models, data, and population files by a path
-  # relative to the project folder, so importing into a different folder would
-  # leave every one of those references dangling. Bring the referenced input
-  # folders along, so the imported project runs where it was written.
-  assets <- if (copyAssets) {
-    .copyExcelProjectAssets(filePathProps, pcDir, outputDir, overwrite)
-  } else {
-    list(copied = character(), notCopied = character())
-  }
-
-  # Report what the import produced. Not gated on an interactive session: an
-  # import run from a script is exactly the case where the call would otherwise
-  # finish with no sign of what (or whether) anything was written. `silent` is
-  # the way to turn it off.
-  if (!silent) {
-    inputFile <- .readablePath(projectConfigPath)
-    outputFile <- .readablePath(outputPath)
-    msg <- messages$importedProject(inputFile, outputFile)
-    cli::cli_inform("{msg}")
-    # The per-section counts, rendered by the project's own definitions block so
-    # the summary and `print(project)` can never disagree about the labels. That
-    # block prints to stdout, so it is captured and re-emitted verbatim on the
-    # message stream, keeping the whole summary on one stream (and out of the way
-    # of anything capturing the function's own output).
-    cli::cli_verbatim(utils::capture.output(print(
-      importedProject$definitions
-    )))
-    # The counts block lists only the sections that hold something, so the
-    # sections that imported nothing are named here: a section that came out
-    # empty is exactly what a reader has to see to notice that a workbook did
-    # not arrive.
-    empty <- .emptyProjectSections(importedProject)
-    if (length(empty) > 0L) {
-      msg <- messages$importEmptySections(empty)
-      cli::cli_inform("{msg}")
-    }
-    # A workbook read under its conventional filename is content the project
-    # does not declare, so a reader would otherwise have no way to know it was
-    # imported.
-    if (length(conventionWorkbooks) > 0L) {
-      .informFormatted(messages$importUndeclaredWorkbooks(conventionWorkbooks))
-    }
-    if (length(assets$copied) > 0L) {
-      msg <- messages$importCopiedAssetFolders(assets$copied)
-      cli::cli_inform("{msg}")
-    }
-    if (length(assets$notCopied) > 0L) {
-      msg <- messages$importUncopiedAssetFolders(assets$notCopied)
-      cli::cli_warn("{msg}")
-    }
-  }
-
-  invisible(outputPath)
 }
 
 #' Export a Project to Excel files

--- a/R/project-excel.R
+++ b/R/project-excel.R
@@ -343,11 +343,15 @@ importProjectFromExcel <- function(
   # read half is handed that folder, so resolve it before reading.
   outputDir <- outputDir %||% dirname(fs::path_abs(projectConfigPath))
 
-  read <- .excelToProjectJson(projectConfigPath, projectDir = outputDir)
-  jsonData <- read$jsonData
-  pcDir <- read$pcDir
-  filePathProps <- read$filePathProps
-  conventionWorkbooks <- read$conventionWorkbooks
+  # Both preconditions are checked before the read, so a call that cannot
+  # proceed says why instead of first reporting on the contents of a workbook it
+  # is not going to import. `.excelToProjectJson()` checks the source path too;
+  # repeated here so a mistyped `projectConfigPath` is named before the
+  # destination refusal, which would otherwise mask it whenever the default
+  # `outputDir` already holds a project.
+  if (!file.exists(projectConfigPath)) {
+    cli::cli_abort(messages$fileNotFound(projectConfigPath))
+  }
 
   # Append `.json` rather than `fs::path_ext_set()`, which would *replace* an
   # existing extension: a dotted stem like `trial.v1` reads as an extension, so
@@ -367,6 +371,12 @@ importProjectFromExcel <- function(
   if (!overwrite && (file.exists(outputPath) || hasDefinitionTree)) {
     cli::cli_abort(messages$importWouldOverwriteProject(outputDir))
   }
+
+  read <- .excelToProjectJson(projectConfigPath, projectDir = outputDir)
+  jsonData <- read$jsonData
+  pcDir <- read$pcDir
+  filePathProps <- read$filePathProps
+  conventionWorkbooks <- read$conventionWorkbooks
 
   if (!dir.exists(dirname(outputPath))) {
     dir.create(dirname(outputPath), recursive = TRUE)

--- a/R/project-excel.R
+++ b/R/project-excel.R
@@ -1218,10 +1218,19 @@ exportProjectToExcel <- function(
     if (!isArraySection) {
       next
     }
+    # `digits = NA` for the same reason `.asWrittenJson()` passes it: the key has
+    # to be as discriminating as the comparison it feeds. At jsonlite's default
+    # of 4 decimal places two records differing only past that share a key, and
+    # a stable sort then leaves each side in its own source order.
     keys <- vapply(
       section,
       function(record) {
-        as.character(jsonlite::toJSON(record, auto_unbox = TRUE, null = "null"))
+        as.character(jsonlite::toJSON(
+          record,
+          auto_unbox = TRUE,
+          digits = NA,
+          null = "null"
+        ))
       },
       character(1)
     )

--- a/R/project-lifecycle.R
+++ b/R/project-lifecycle.R
@@ -112,8 +112,29 @@ loadProject <- function(path = ".") {
     version <- jsonData$schemaVersion %||% "<missing>"
     cli::cli_abort(messages$unsupportedSchemaVersion(version))
   }
+  .parseProjectSections(jsonData, jsonPath, dirname(jsonPath))
+}
+
+# Turn a decoded container (the `Project.json` object as a plain list) into the
+# section list a `Project` commits, resolving each section against the
+# `definitions/<kind>/` tree under `projectDirPath` and falling back to the
+# section inlined in the container where no tree directory exists.
+#
+# Split from `.loadProjectTree()` so a container that never came off disk can be
+# parsed too: the Excel bridge builds one in memory (`.excelToProjectJson()`)
+# and compares the resulting project against a live one, with no import and no
+# temporary tree. Point `projectDirPath` at a directory holding no
+# `definitions/` for such a container, so every section takes the inline
+# fallback.
+#
+# `jsonPath` is recorded as the project's own file path and named in parse
+# errors; for an in-memory container it is the path the project would have.
+#
+# @keywords internal
+# @noRd
+.parseProjectSections <- function(jsonData, jsonPath, projectDirPath) {
+  rlang::local_error_call(NULL)
   .validateDefinitionsFolder(jsonData$definitionsFolder)
-  projectDirPath <- dirname(jsonPath)
   definitionsFolder <- jsonData$definitionsFolder %||% "definitions"
 
   # The container separates two concerns: the live working folders

--- a/R/project.R
+++ b/R/project.R
@@ -242,8 +242,20 @@ Project <- R6::R6Class(
     #' @param projectFilePath A string representing the path to the project
     #'   JSON file, or to the folder holding it (see [loadProject()] for how a
     #'   folder is resolved).
-    initialize = function(projectFilePath = character()) {
+    #' @param sections Internal. An already-parsed section list to commit
+    #'   instead of reading one, as `.loadProjectTree()` returns. The Excel
+    #'   bridge parses a container it built in memory and needs the resulting
+    #'   object without a folder on disk; `projectFilePath` is ignored when this
+    #'   is given.
+    initialize = function(projectFilePath = character(), sections = NULL) {
       private$.validatedSinceMutation <- FALSE
+      # Committing a parsed section list is the load path's own step, so it is
+      # reached by handing the list to the constructor rather than by a caller
+      # poking at the private seam.
+      if (!is.null(sections)) {
+        private$.applyLoadedSections(sections)
+        return(invisible(self))
+      }
       if (is.character(projectFilePath) && length(projectFilePath) == 0L) {
         private$.projectDirPath <- NULL
         return(invisible(self))

--- a/REFACTORING-LOG.md
+++ b/REFACTORING-LOG.md
@@ -206,3 +206,4 @@ One bullet per commit, newest at the bottom: `- YYYY-MM-DD HH:MM: plain-language
 - 2026-08-06 09:48: The steady-state step of preparing a scenario is now its own function with its own tests; it was only reachable by running the whole 150-line build.
 - 2026-08-06 09:58: The careful order in which a parameter-identification bound is written is now its own function with tests for both directions, instead of a comment inside a 170-line builder.
 - 2026-08-06 10:15: Split reading an Excel project from writing it out, so the reading half can be used on its own.
+- 2026-08-06 10:45: Checking whether the Excel files are up to date no longer runs a full import behind the scenes; it reads the workbooks and compares in memory, writing nothing.

--- a/REFACTORING-LOG.md
+++ b/REFACTORING-LOG.md
@@ -205,3 +205,4 @@ One bullet per commit, newest at the bottom: `- YYYY-MM-DD HH:MM: plain-language
 - 2026-08-06 09:35: setScenario now takes its fields the same way setIndividual and setPopulation do, dropping 16 arguments and 70 lines of plumbing; fields must be named.
 - 2026-08-06 09:48: The steady-state step of preparing a scenario is now its own function with its own tests; it was only reachable by running the whole 150-line build.
 - 2026-08-06 09:58: The careful order in which a parameter-identification bound is written is now its own function with tests for both directions, instead of a comment inside a 170-line builder.
+- 2026-08-06 10:15: Split reading an Excel project from writing it out, so the reading half can be used on its own.

--- a/man/Project.Rd
+++ b/man/Project.Rd
@@ -185,7 +185,7 @@ differences, empty when everything is in sync). The same information
 empty in-memory project when called with no arguments.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{Project$new(projectFilePath = character())}
+    \preformatted{Project$new(projectFilePath = character(), sections = NULL)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
@@ -194,6 +194,11 @@ empty in-memory project when called with no arguments.
       \item{\code{projectFilePath}}{A string representing the path to the project
 JSON file, or to the folder holding it (see \code{\link[=loadProject]{loadProject()}} for how a
 folder is resolved).}
+      \item{\code{sections}}{Internal. An already-parsed section list to commit
+instead of reading one, as \code{.loadProjectTree()} returns. The Excel
+bridge parses a container it built in memory and needs the resulting
+object without a folder on disk; \code{projectFilePath} is ignored when this
+is given.}
     }
     \if{html}{\out{</div>}}
   }

--- a/tests/testthat/_snaps/project-excel.md
+++ b/tests/testthat/_snaps/project-excel.md
@@ -9,6 +9,24 @@
       x Re-importing replaces it with the Excel project and deletes any definitions that exist only on the JSON side.
       i Pass `overwrite = TRUE` to replace the existing JSON project with the Excel state, or import into a different `outputDir`.
 
+# importProjectFromExcel checks its preconditions before reading the workbook
+
+    Code
+      importProjectFromExcel(unreadable, outputDir = out, silent = TRUE)
+    Condition
+      Error in `importProjectFromExcel()`:
+      ! A JSON project already exists in '<tmp-path>'.
+      x Re-importing replaces it with the Excel project and deletes any definitions that exist only on the JSON side.
+      i Pass `overwrite = TRUE` to replace the existing JSON project with the Excel state, or import into a different `outputDir`.
+
+---
+
+    Code
+      importProjectFromExcel(file.path(out, "Missing.xlsx"), outputDir = out, silent = TRUE)
+    Condition
+      Error in `importProjectFromExcel()`:
+      ! File not found: '<tmp-path>'
+
 # exportProjectToExcel aborts over existing workbooks unless overwrite = TRUE
 
     Code

--- a/tests/testthat/test-project-excel.R
+++ b/tests/testthat/test-project-excel.R
@@ -2425,6 +2425,28 @@ test_that(".compareJsonToExcel writes nothing", {
   )
 })
 
+# `.sortJsonSections()` puts the two sides of the Excel comparison into one
+# order by serializing each record into a sort key, so that key has to be as
+# discriminating as the `identical()` it feeds. Records tying on the key keep
+# their source order, because `order(method = "radix")` is stable, and source
+# order is exactly what the sort exists to normalize away.
+#
+# Every array section a real project holds carries a unique id per record
+# (`name`, `individualId`, `dataCombinedId`, ...), so no two records tie and the
+# key's precision does not currently reach the verdict. This guards the sort
+# itself rather than a live false-drift report: the records here are given the
+# same id so they differ only past the 4th decimal, which is where jsonlite's
+# default rounding would collapse them onto one key.
+test_that(".sortJsonSections orders records that differ past the 4th decimal", {
+  low <- list(id = "s", value = 1.00001)
+  high <- list(id = "s", value = 1.00002)
+
+  expect_identical(
+    .sortJsonSections(list(section = list(low, high))),
+    .sortJsonSections(list(section = list(high, low)))
+  )
+})
+
 # Regression (#1123): a dirty saveProject() on a normal tree project must not
 # flip the Excel axis's per-section verdicts. saveProject() writes the container
 # with the tree-owned sections emptied, and the old Excel comparison read that

--- a/tests/testthat/test-project-excel.R
+++ b/tests/testthat/test-project-excel.R
@@ -2343,6 +2343,56 @@ test_that(".compareJsonToExcel does not count id canonicalization as drift", {
   expect_true(inSync$excel_in_sync)
 })
 
+test_that(".compareJsonToExcel still reports a real edit as drift", {
+  # The comparison deliberately ignores several differences the round trip does
+  # not preserve (key order, definition order, storage type), so it needs a case
+  # proving it has not been normalized into always saying "in sync".
+  out <- withr::local_tempdir()
+  excelPath <- testProjectExcelPath()
+  jsonPath <- suppressWarnings(importProjectFromExcel(
+    excelPath,
+    outputDir = out,
+    silent = TRUE
+  ))
+  project <- suppressWarnings(loadProject(jsonPath))
+
+  addOutputPath(project, "drifted", "Organism|Liver|Volume")
+
+  drifted <- suppressWarnings(.compareJsonToExcel(
+    project = project,
+    projectConfigPath = excelPath,
+    silent = TRUE
+  ))
+  expect_false(drifted$excel_in_sync)
+  expect_identical(drifted$details$data_changes$outputPaths, "data differs")
+})
+
+test_that(".compareJsonToExcel writes nothing", {
+  # It answers a read-only question, so it must leave the Excel project folder
+  # exactly as it found it (it used to run the importer for real against a
+  # temporary directory).
+  out <- withr::local_tempdir()
+  excelPath <- testProjectExcelPath()
+  jsonPath <- suppressWarnings(importProjectFromExcel(
+    excelPath,
+    outputDir = out,
+    silent = TRUE
+  ))
+  project <- suppressWarnings(loadProject(jsonPath))
+
+  excelDir <- dirname(excelPath)
+  before <- list.files(excelDir, recursive = TRUE, all.files = TRUE)
+  suppressWarnings(.compareJsonToExcel(
+    project = project,
+    projectConfigPath = excelPath,
+    silent = TRUE
+  ))
+  expect_identical(
+    list.files(excelDir, recursive = TRUE, all.files = TRUE),
+    before
+  )
+})
+
 # Regression (#1123): a dirty saveProject() on a normal tree project must not
 # flip the Excel axis's per-section verdicts. saveProject() writes the container
 # with the tree-owned sections emptied, and the old Excel comparison read that

--- a/tests/testthat/test-project-excel.R
+++ b/tests/testthat/test-project-excel.R
@@ -486,6 +486,38 @@ test_that("importProjectFromExcel aborts over an existing JSON project unless ov
   )))
 })
 
+# Both of importProjectFromExcel()'s preconditions are checked before the
+# workbook is read, so a call that is going to refuse says so instead of first
+# reporting on the contents of a project it will not import (an id collision
+# aborts the read, an incomplete observed curve warns during it). The source
+# path is checked ahead of the destination, so a mistyped `projectConfigPath` is
+# named rather than masked by an `outputDir` that already holds a project.
+test_that("importProjectFromExcel checks its preconditions before reading the workbook", {
+  out <- withr::local_tempdir()
+  writeLines("{}", file.path(out, "Project.json"))
+
+  # A source that exists but is not a readable workbook: the overwrite refusal
+  # still wins, which it can only do if the guard runs before the read.
+  unreadable <- file.path(withr::local_tempdir(), "Project.xlsx")
+  writeLines("not a workbook", unreadable)
+  expect_snapshot(
+    error = TRUE,
+    transform = .redactTmpDir,
+    importProjectFromExcel(unreadable, outputDir = out, silent = TRUE)
+  )
+
+  # A missing source is named ahead of the occupied destination.
+  expect_snapshot(
+    error = TRUE,
+    transform = .redactTmpDir,
+    importProjectFromExcel(
+      file.path(out, "Missing.xlsx"),
+      outputDir = out,
+      silent = TRUE
+    )
+  )
+})
+
 # Regression (#1126): exportProjectToExcel() replaces Project.xlsx and the
 # Configurations workbooks wholesale, defaulting outputDir to the project's own
 # directory, so a bare call would silently overwrite hand-maintained workbooks.

--- a/tests/testthat/test-project-lifecycle.R
+++ b/tests/testthat/test-project-lifecycle.R
@@ -35,6 +35,32 @@ test_that(".loadProjectTree() returns a plain list, not a Project, with every se
   ))
 })
 
+test_that("Project$new(sections = ) commits a parsed list without reading a file", {
+  # The door the Excel bridge builds its comparison project through: it parses a
+  # container it assembled in memory, so there is nothing on disk to open.
+  dir <- .copyTestProjectDir()
+  sections <- .loadProjectTree(file.path(dir, "Project.json"))
+
+  project <- Project$new(sections = sections)
+  expect_s3_class(project, "Project")
+  expect_equal(project$info$schemaVersion, "2.0")
+  expect_length(project$definitions$scenarios, 4)
+  # Committed as a freshly loaded project: no unsaved changes.
+  expect_false(.isModified(project))
+})
+
+test_that("Project$new(sections = ) ignores projectFilePath", {
+  dir <- .copyTestProjectDir()
+  sections <- .loadProjectTree(file.path(dir, "Project.json"))
+
+  # The path is never opened, so even one that does not exist is inert.
+  project <- Project$new(
+    projectFilePath = file.path(dir, "no-such-project.json"),
+    sections = sections
+  )
+  expect_length(project$definitions$scenarios, 4)
+})
+
 test_that("loadProject() errors when the file does not exist", {
   expect_error(
     loadProject(file.path(tempdir(), "does_not_exist.json")),


### PR DESCRIPTION
`projectStatus()`'s Excel axis answered a read-only question by running the importer for real: a whole `definitions/` tree written to a temporary directory, re-parsed, diffed, and deleted. A status check therefore cost as much as an import and inherited its side effects. This is the natural follow-on to splitting the importer's read half from its write half.

## Excel bridge

- `.excelToProjectJson()` holds the reading: every workbook the property sheet names is parsed into one inlined container with canonical ids, and nothing is created on disk. `importProjectFromExcel()` calls it and keeps the writing, resolving `outputDir` up front because the read half anchors a relative `${VAR}` data folder to it.
- `.compareJsonToExcel()` reads the workbooks through it and parses the result directly. The container is parsed against a directory holding no `definitions/`, so every section takes the inline fallback — pointing it at the real project folder would resolve each section against the tree sitting beside the workbooks, which is the very thing being compared.

## Project loading

- `.parseProjectSections()` split out of `.loadProjectTree()`, so a container that never came off disk can be parsed too. `.loadProjectTree()` keeps the file reading and calls it.
- `.projectFromSections()` in `R/project.R` commits a parsed section list to a fresh `Project`, next to the class whose private seam it reaches through.

## Comparison normalization

Removing the disk round trip removed two normalizations the comparison had been getting for free, so both sides now get them explicitly and symmetrically:

- Definition order within an array-shaped section is no longer counted as drift. A tree project holds one file per definition, so its order is the order the filesystem lists them in, while a workbook's is the order its rows were typed. Records are ordered by their own serialized content, which needs no per-section id knowledge and is exactly as discriminating. Arrays *inside* a definition (a PI task's parameter list) keep their order.
- Both sides are compared as the JSON they would be written as, since `jsonlite` narrows a whole double to an integer on the way back in: a `250` that reached one side through a file and the other straight from a workbook is the same number stored as two types.

## Tests

The comparison had no test asserting it reports real drift, which is what makes a normalization change dangerous. Two were added: a real edit still flips `excel_in_sync` and names the section, and the comparison leaves the Excel project folder byte-for-byte as it found it.
