### PR TITLE
Unquote a quoted single-value cell on Excel import

### DIFF
--- a/R/project-excel.R
+++ b/R/project-excel.R
@@ -1466,6 +1466,30 @@ projectStatus <- function(project, silent = FALSE) {
     }
     section
   }
+  # A section that is an array of records carries no names for `canonNames()` to
+  # check, yet the parse step keys it by each record's own id field
+  # (`result[[id]] <- entry`) just the same. Two records whose ids canonicalize
+  # alike therefore become one definition, built from the last of them, and the
+  # earlier record is gone without a word. Run the section's ids through the same
+  # collision-checking path for the abort alone; the per-record assignments below
+  # still write each canonical id.
+  checkRecordIds <- function(section, idField) {
+    if (is.null(section)) {
+      return(invisible(NULL))
+    }
+    ids <- vapply(
+      section,
+      function(record) {
+        value <- record[[idField]]
+        if (length(value) == 1L) as.character(value) else NA_character_
+      },
+      character(1)
+    )
+    .silentlyCanonicalized(
+      .canonicalizeId(.stripWrappingQuotes(ids[!is.na(ids)]))
+    )
+    invisible(NULL)
+  }
 
   jsonData$outputPaths <- canonNames(jsonData$outputPaths)
   jsonData$parameterSets <- canonNames(jsonData$parameterSets)
@@ -1482,6 +1506,7 @@ projectStatus <- function(project, silent = FALSE) {
   }
 
   if (!is.null(jsonData$scenarios)) {
+    checkRecordIds(jsonData$scenarios, "name")
     jsonData$scenarios <- lapply(jsonData$scenarios, function(sc) {
       sc$name <- canonScalar(sc$name)
       sc$individual <- canonScalar(sc$individual)
@@ -1495,6 +1520,7 @@ projectStatus <- function(project, silent = FALSE) {
   }
 
   if (!is.null(jsonData$individuals)) {
+    checkRecordIds(jsonData$individuals, "individualId")
     jsonData$individuals <- lapply(jsonData$individuals, function(ind) {
       ind$individualId <- canonScalar(ind$individualId)
       if (!is.null(ind$parameterSets)) {
@@ -1505,6 +1531,7 @@ projectStatus <- function(project, silent = FALSE) {
   }
 
   if (!is.null(jsonData$populations)) {
+    checkRecordIds(jsonData$populations, "populationId")
     jsonData$populations <- lapply(jsonData$populations, function(pop) {
       pop$populationId <- canonScalar(pop$populationId)
       pop
@@ -1543,6 +1570,7 @@ projectStatus <- function(project, silent = FALSE) {
   # data, whose ids are file basenames / DataSet names matched verbatim and
   # never canonicalized, so they are deliberately left untouched.
   if (!is.null(jsonData$dataCombined)) {
+    checkRecordIds(jsonData$dataCombined, "dataCombinedId")
     canonEntryScenario <- function(entry) {
       entry$scenario <- canonScalar(entry$scenario)
       entry
@@ -1567,6 +1595,7 @@ projectStatus <- function(project, silent = FALSE) {
     )
   }
   if (!is.null(jsonData$plots)) {
+    checkRecordIds(jsonData$plots, "plotId")
     jsonData$plots <- lapply(
       jsonData$plots,
       function(plot) {
@@ -1577,6 +1606,7 @@ projectStatus <- function(project, silent = FALSE) {
     )
   }
   if (!is.null(jsonData$plotGrids)) {
+    checkRecordIds(jsonData$plotGrids, "plotGridId")
     jsonData$plotGrids <- lapply(
       jsonData$plotGrids,
       function(grid) {
@@ -1609,6 +1639,7 @@ projectStatus <- function(project, silent = FALSE) {
   # ids), and a parameter's / mapping's own `id` is an inner id, not an
   # definition-file id, so those are left untouched.
   if (!is.null(jsonData$parameterIdentification)) {
+    checkRecordIds(jsonData$parameterIdentification, "id")
     jsonData$parameterIdentification <- lapply(
       jsonData$parameterIdentification,
       function(task) {
@@ -2850,9 +2881,10 @@ projectStatus <- function(project, silent = FALSE) {
 # renamed apart, because a grid naming the id would then reach only one of them
 # and the other plot would belong to no grid.
 #
-# Compared on the canonical id, since that is the id the definitions end up keyed
-# by: two rows spelling one id differently are as much of a collision as two
-# spelling it the same.
+# Compared on the unquoted, canonical id, since that is the id the definitions
+# end up keyed by: two rows spelling one id differently are as much of a
+# collision as two spelling it the same, and a row that quotes the id names the
+# same plot as a row that does not.
 #
 # @param records The parsed records of the sheet (an unnamed list).
 # @param idField The record field holding the id (`plotId` / `plotGridId`).
@@ -2866,7 +2898,9 @@ projectStatus <- function(project, silent = FALSE) {
   }
   ids <- vapply(
     records,
-    function(record) .canonicalizeOneId(as.character(record[[idField]])),
+    function(record) {
+      .canonicalizeOneId(.stripWrappingQuotes(as.character(record[[idField]])))
+    },
     character(1)
   )
   duplicated <- unique(ids[duplicated(ids)])
@@ -2938,7 +2972,11 @@ projectStatus <- function(project, silent = FALSE) {
     if (is.null(name)) {
       next
     }
-    name <- as.character(name)
+    # Group on the unquoted name, the name the definition ends up keyed by.
+    # Grouping on the raw cell splits one combination in two whenever a sheet
+    # spells its name both ways, and the two halves then land on one key, so
+    # whichever is built first is overwritten and its curves are lost.
+    name <- .stripWrappingQuotes(as.character(name))
     dataType <- .naToNull(df$dataType[[i]])
     entry <- list()
     for (col in names(df)) {
@@ -3337,11 +3375,15 @@ projectStatus <- function(project, silent = FALSE) {
   algDf <- read5xSheet("AlgorithmOptions")
   ciDf <- read5xSheet("CIOptions")
 
+  # Gather the task names unquoted, the name each task is keyed by, so a
+  # workbook spelling one task's name both ways still describes one task rather
+  # than two that collapse onto one key. `.pi5xTaskRows()` matches its rows the
+  # same way, so a sheet quoting the name still contributes to the task.
   taskNames <- unique(unlist(lapply(
     list(mappingDf, paramDf, configDf, algDf, ciDf),
     function(df) {
       if (!is.null(df) && "PITaskName" %in% names(df)) {
-        as.character(df$PITaskName)
+        .stripWrappingQuotes(as.character(df$PITaskName))
       }
     }
   )))
@@ -3692,7 +3734,8 @@ projectStatus <- function(project, silent = FALSE) {
     return(df[0, , drop = FALSE])
   }
   df[
-    !is.na(df$PITaskName) & as.character(df$PITaskName) == task,
+    !is.na(df$PITaskName) &
+      .stripWrappingQuotes(as.character(df$PITaskName)) == task,
     ,
     drop = FALSE
   ]

--- a/R/project-excel.R
+++ b/R/project-excel.R
@@ -1426,17 +1426,26 @@ projectStatus <- function(project, silent = FALSE) {
 #' @keywords internal
 #' @noRd
 .canonicalizeProjectJsonIds <- function(jsonData) {
+  # Every id and reference is unquoted before it is canonicalized: a workbook
+  # quotes a single-value cell as readily as a list one (`"AciclovirPVB"`), and
+  # the quotes are the cell's syntax, not part of the name. Canonicalizing them
+  # instead turns each one into `_`, so the id reads `_aciclovirpvb_` rather
+  # than the name the modeller wrote. Unquoting here rather than at each of the
+  # ~20 sheet readers is what keeps a definition and a reference on the same
+  # transform, which is the property the rest of this function rests on.
   canonScalar <- function(x) {
     if (is.null(x)) {
       return(x)
     }
-    .canonicalizeOneId(as.character(x))
+    .canonicalizeOneId(.stripWrappingQuotes(as.character(x)))
   }
   canonVec <- function(x) {
     if (is.null(x)) {
       return(x)
     }
-    lapply(x, function(e) .canonicalizeOneId(as.character(e)))
+    lapply(x, function(e) {
+      .canonicalizeOneId(.stripWrappingQuotes(as.character(e)))
+    })
   }
   canonNames <- function(section) {
     if (is.null(section) || length(section) == 0L) {
@@ -1451,7 +1460,9 @@ projectStatus <- function(project, silent = FALSE) {
       # per changed id; an Excel import renames in bulk and the migrate guide
       # documents that, so the per-id warning is suppressed while the
       # collision abort is allowed to propagate.
-      names(section) <- .silentlyCanonicalized(.canonicalizeId(nms))
+      names(section) <- .silentlyCanonicalized(
+        .canonicalizeId(.stripWrappingQuotes(nms))
+      )
     }
     section
   }
@@ -1578,7 +1589,11 @@ projectStatus <- function(project, silent = FALSE) {
         # id into several. Canonicalize each id in between.
         if (!is.null(grid$plots)) {
           ids <- .splitPlotIDs(as.character(grid$plots))
-          ids <- vapply(ids, .canonicalizeOneId, character(1))
+          ids <- vapply(
+            ids,
+            \(id) .canonicalizeOneId(.stripWrappingQuotes(id)),
+            character(1)
+          )
           grid$plots <- .joinPlotIDs(ids)
         }
         grid
@@ -4551,4 +4566,24 @@ projectStatus <- function(project, silent = FALSE) {
   parts <- c(parts, current)
   parts <- trimws(parts)
   parts[nzchar(parts)]
+}
+
+#' Drop the double quotes wrapping a single-value cell
+#'
+#' The same 5.x convention `.parseCommaListToArray()` honors for a list cell
+#' also reaches columns holding one value, so a name is as likely to be written
+#' `"AciclovirPVB"` as `AciclovirPVB` and both mean the name without the quotes.
+#' Only the outermost pair is a quoting artifact, so a quote anywhere else stays
+#' part of the value, and a cell that was never quoted is returned untouched.
+#'
+#' @param x One cell value.
+#' @returns `x` without its wrapping pair of double quotes, or `x` as given when
+#'   it is not a quoted string.
+#' @keywords internal
+#' @noRd
+.stripWrappingQuotes <- function(x) {
+  if (!is.character(x)) {
+    return(x)
+  }
+  sub('^"(.*)"$', "\\1", x)
 }

--- a/REFACTORING-LOG.md
+++ b/REFACTORING-LOG.md
@@ -207,3 +207,4 @@ One bullet per commit, newest at the bottom: `- YYYY-MM-DD HH:MM: plain-language
 - 2026-08-06 09:58: The careful order in which a parameter-identification bound is written is now its own function with tests for both directions, instead of a comment inside a 170-line builder.
 - 2026-08-06 10:15: Split reading an Excel project from writing it out, so the reading half can be used on its own.
 - 2026-08-06 10:45: Checking whether the Excel files are up to date no longer runs a full import behind the scenes; it reads the workbooks and compares in memory, writing nothing.
+- 2026-08-06 11:20: Importing an Excel project now strips the quotation marks off a quoted single-value cell, so a name written "AciclovirPVB" becomes the same id as one written without quotes instead of _aciclovirpvb_. Applies to every id and reference the import canonicalizes, not just data combinations.

--- a/tests/testthat/test-project-excel.R
+++ b/tests/testthat/test-project-excel.R
@@ -2740,6 +2740,33 @@ test_that(".parseCommaListToArray parses the quoted-CSV and backslash convention
   expect_identical(.parseCommaListToArray("a, b, c"), c("a", "b", "c"))
 })
 
+# The same quoting convention reaches a cell holding one value, where the whole
+# cell is the value, so only the wrapping pair may go: a comma or a quote inside
+# the text is content, not syntax, and an unquoted cell must come back as read.
+test_that(".stripWrappingQuotes drops only the wrapping pair", {
+  expect_identical(.stripWrappingQuotes('"AciclovirPVB"'), "AciclovirPVB")
+  # No wrapping pair, so nothing is a quoting artifact.
+  expect_identical(.stripWrappingQuotes("AciclovirPVB"), "AciclovirPVB")
+  expect_identical(
+    .stripWrappingQuotes('Aciclovir "PVB" plasma'),
+    'Aciclovir "PVB" plasma'
+  )
+  # Wrapped, and quoting an inner run that stays exactly as written.
+  expect_identical(
+    .stripWrappingQuotes('"Aciclovir "PVB" plasma"'),
+    'Aciclovir "PVB" plasma'
+  )
+  # A single-value cell is one value even when it contains a comma.
+  expect_identical(
+    .stripWrappingQuotes('"Sheet, with comma"'),
+    "Sheet, with comma"
+  )
+  # A lone quote has no pair to drop.
+  expect_identical(.stripWrappingQuotes('"'), '"')
+  # A numeric cell is handed back untouched, not stringified.
+  expect_identical(.stripWrappingQuotes(1.96), 1.96)
+})
+
 # Only the raw `${VAR}` is stored, so it is expanded afresh on every load and a
 # relative expansion is resolved against the project file. The import therefore
 # has to anchor it the same way, and the folder has to travel with the project,
@@ -3500,11 +3527,10 @@ test_that("a freshly exported workbook reports an imported project as in sync", 
 
 # #1213 item 10 / the residue #1207 recorded: a 5.x multi-value cell is quoted,
 # and a value may itself contain a comma, which is exactly what the quoting is
-# for. That half works. A quoted *single*-value reference cell is read raw on both
-# the defining and the referencing side, so a consistently quoted workbook
-# resolves but its ids carry the quote characters as underscores: the id is
-# `_name_` rather than the name the modeller wrote.
-test_that("quoted legacy cells resolve, and a quoted single-value id keeps its quotes as underscores", {
+# for. A single-value cell in the same workbook is quoted the same way and means
+# the same name without the quotes, so both sides of a `DataCombinedName`
+# reference read the name the modeller wrote rather than `_name_`.
+test_that("quoted legacy cells resolve to the names they were written with", {
   imported <- importLegacyExcelProject(localLegacyExcelProject())
 
   # The quoted multi-value cell splits on the separating commas only, so the
@@ -3516,15 +3542,17 @@ test_that("quoted legacy cells resolve, and a quoted single-value id keeps its q
     c("global", "aciclovir", "sheet__with_comma")
   )
 
-  # The quoted single-value `DataCombinedName` becomes `_name_` on both sides, so
-  # nothing dangles and nothing reads as the authored name either.
+  # The quoted single-value `DataCombinedName` is unquoted on the defining side,
+  # so the id matches the one `addDataCombined(project, "AciclovirPVB", ...)`
+  # would have produced.
   expect_setequal(
     names(imported$project$definitions$dataCombined),
-    c("_aciclovirpvb_", "_aciclovirpop_")
+    c("aciclovirpvb", "aciclovirpop")
   )
+  # And on the referencing side, so the plot still points at it.
   expect_identical(
     imported$project$definitions$plots[["p1"]]$dataCombined,
-    "_aciclovirpvb_"
+    "aciclovirpvb"
   )
 
   # Consistently quoted, so the project validates: only inconsistent quoting

--- a/tests/testthat/test-project-excel.R
+++ b/tests/testthat/test-project-excel.R
@@ -3563,6 +3563,109 @@ test_that("quoted legacy cells resolve to the names they were written with", {
   expect_equal(summary$total_critical_errors, 0)
 })
 
+# A quoted and an unquoted spelling of one name are the same name, so a sheet
+# that groups its rows by that name has to group on the unquoted spelling. The
+# `DataCombined` sheet is long-format (one row per curve), so grouping on the raw
+# cell puts an inconsistently spelled combination's curves in two records, which
+# then land on one definition key and the first one's curves are dropped.
+test_that("a DataCombined name spelled quoted and unquoted is one combination", {
+  projectDir <- localLegacyExcelProject()
+  editWorkbookSheets(
+    file.path(projectDir, "Configurations", "Plots.xlsx"),
+    function(sheets) {
+      # Row 1 (simulated) keeps the fixture's `"AciclovirPVB"`; row 2 (observed)
+      # spells the same name without the quotes.
+      sheets$DataCombined$DataCombinedName[[2]] <- "AciclovirPVB"
+      sheets
+    }
+  )
+  imported <- importLegacyExcelProject(projectDir)
+  combined <- imported$project$definitions$dataCombined
+
+  expect_setequal(names(combined), c("aciclovirpvb", "aciclovirpop"))
+
+  # Both curves are on the one combination: neither row's is dropped.
+  expect_length(combined[["aciclovirpvb"]]$simulated, 1L)
+  expect_length(combined[["aciclovirpvb"]]$observed, 1L)
+})
+
+# The 5.x parameter-identification layout builds one task per distinct
+# `PITaskName`, gathering that task's rows from five sheets. The same reasoning as
+# for `DataCombined`: a sheet quoting the task name names the same task, so its
+# rows belong to it rather than to a second task that overwrites the first.
+test_that("a PI task name spelled quoted and unquoted is one task", {
+  projectDir <- localLegacyExcelProject()
+  editWorkbookSheets(
+    file.path(projectDir, "Configurations", "ParameterIdentification.xlsx"),
+    function(sheets) {
+      sheets$PIParameters$PITaskName <- paste0(
+        '"',
+        sheets$PIParameters$PITaskName,
+        '"'
+      )
+      sheets
+    }
+  )
+  imported <- importLegacyExcelProject(projectDir)
+  tasks <- imported$project$definitions$parameterIdentification
+
+  expect_named(tasks, "aciclovirfit")
+
+  # The quoted sheet's parameters and the unquoted sheets' output mappings are
+  # both on the one task.
+  expect_length(tasks[["aciclovirfit"]]$parameters, 2L)
+  expect_length(tasks[["aciclovirfit"]]$outputMappings, 2L)
+})
+
+# A plots sheet keys one definition per row rather than grouping, so two rows
+# naming one plot are a reused id, whichever way each spells it. That is the
+# reported loss `.warnDuplicatePlotIds()` already covers for two rows spelling the
+# id identically; a quoted spelling has to reach the same report rather than
+# passing as a second plot and then quietly overwriting the first.
+test_that("a plot id spelled quoted and unquoted is one reused id, and reported", {
+  projectDir <- localLegacyExcelProject()
+  editWorkbookSheets(
+    file.path(projectDir, "Configurations", "Plots.xlsx"),
+    function(sheets) {
+      sheets$plotConfiguration$plotID[[2]] <- "\"P1\""
+      sheets
+    }
+  )
+  imported <- importLegacyExcelProject(projectDir)
+
+  expect_setequal(names(imported$project$definitions$plots), c("p1", "p3"))
+  expect_true(any(grepl("more than", imported$warnings, fixed = TRUE)))
+  expect_true(any(grepl("plotId", imported$warnings, fixed = TRUE)))
+})
+
+# A section stored as an array of records is keyed by each record's own id field
+# just as a keyed section is keyed by its names, so two *distinct* names that
+# canonicalize onto one id are the same ambiguity `canonNames()` aborts on, and
+# not something to resolve by keeping whichever record came last. `DataCombined`
+# has no duplicate-id report of its own, so without the abort the collision costs
+# a curve in silence.
+test_that("two DataCombined names that canonicalize alike abort the import", {
+  projectDir <- localLegacyExcelProject()
+  editWorkbookSheets(
+    file.path(projectDir, "Configurations", "Plots.xlsx"),
+    function(sheets) {
+      # A space and a comma both canonicalize to `_`, so these are two names for
+      # two combinations that would be filed as one.
+      sheets$DataCombined$DataCombinedName[[1]] <- "Aciclovir PVB"
+      sheets$DataCombined$DataCombinedName[[2]] <- "Aciclovir,PVB"
+      sheets
+    }
+  )
+  expect_error(
+    suppressWarnings(importProjectFromExcel(
+      legacyExcelProjectPath(projectDir),
+      outputDir = withr::local_tempdir("LegacyOut_"),
+      silent = TRUE
+    )),
+    "collide after canonicalization"
+  )
+})
+
 # #1213 item 5: an Excel project spells `populationsFolder` as a folder name under
 # the configurations folder, while a project resolves its working folders against
 # its own root. The import rewrites the value to the project-root-relative path of


### PR DESCRIPTION
A migration test of the bundled legacy fixture `TestProjectExcelLegacy` found that a quoted single-value cell keeps its quotation marks on import. Its `Plots.xlsx` writes `DataCombinedName` as `"AciclovirPVB"`, quotes included, and the import turned that into the id `_aciclovirpvb_` — the quotes canonicalized to underscores rather than recognised as the cell's syntax. Multi-value list cells were already handled: `"Global", "Aciclovir", "Sheet, with comma"` splits correctly with the interior comma preserved. Nothing broke, because the defining and referencing sides agreed, but the ids were ones no user would author and they differed from the hand-authored equivalent.

## Excel bridge

- `.stripWrappingQuotes()` drops only the outermost pair, so a quote inside the text stays part of the value and an unquoted cell comes back as read.
- It is applied inside `.canonicalizeProjectJsonIds()` rather than at the two `DataCombinedName` readers. That function is the point every id and reference already routes through, and unquoting is an id-spelling concern, so this keeps a definition and a reference on one transform — the property the rest of that function rests on. The same four lines fix roughly twenty sibling cells carrying the identical latent defect (`Scenario_name`, `IndividualId`, `PopulationId`, `ApplicationProtocol`, `plotID`, `plotGridId`, the PI task ids, `OutputPathId`, and the map keys of `outputPaths` / `parameterSets` / `applications` / `initialConditions`).

This is safe for the JSON side of `projectStatus()`'s comparison, which also calls this function: `.canonicalizeOneId()` already maps `"` to `_`, so a canonical JSON id can never carry a literal quote and the strip is a no-op there.

## Tests

The existing characterization test asserted the bug in its title (`a quoted single-value id keeps its quotes as underscores`); it is rewritten to assert the fixed behaviour rather than joined by a second test. `.stripWrappingQuotes()` gets its own unit test covering the wrapping pair, an interior quote, a comma inside a single-value cell, a lone quote, and a non-character cell.

Left alone: observed-data `dataSet` references, which are matched verbatim by design and would need the matching side handled too — that is the inconsistent-quoting residue #1207, not this bug.
