### PR TITLE
Store a PI member id verbatim, and match an observed-data id either way

### DIFF
--- a/R/observed-data.R
+++ b/R/observed-data.R
@@ -636,11 +636,12 @@ addObservedData <- function(project, entry, overwrite = FALSE) {
 #' @param id Character vector of ids. An observed-data id is the declaration's
 #'   `id` field, or, when it declares none, comes from the data source itself
 #'   (the `DataSet` name of an unsaved programmatic source, or a file basename
-#'   for a file-based source). Either way it is matched exactly as the
-#'   declaration stores it: a declared `id` is stored canonicalized (the form
-#'   [addObservedData()] reported back to you), a derived one exactly as its
-#'   source spells it. A saved programmatic source that declares no `id` is
-#'   matched by its `<name>.pkml` basename (see the note above).
+#'   for a file-based source). Each is matched as the declaration stores it and,
+#'   failing that, as [addObservedData()] would have canonicalized it, so a
+#'   derived id is found by the source's own spelling and a declared one by
+#'   either the form you authored or the canonical form you were given back. A
+#'   saved programmatic source that declares no `id` is matched by its
+#'   `<name>.pkml` basename (see the note above).
 #' @returns The `project` object, invisibly.
 #' @export
 #' @family observedData
@@ -666,6 +667,13 @@ removeObservedData <- function(project, id) {
   dropIdx <- integer()
   programmaticNames <- character()
   missingIds <- character()
+  entriesWithId <- function(key) {
+    which(vapply(
+      observedData,
+      function(e) identical(.observedDataEntryIdOrNA(e), key),
+      logical(1)
+    ))
+  }
   for (one in id) {
     if (one %in% names(private$.programmaticDataSets)) {
       programmaticNames <- c(programmaticNames, one)
@@ -679,11 +687,17 @@ removeObservedData <- function(project, id) {
       dropIdx <- c(dropIdx, matchIdx)
       next
     }
-    matchIdx <- which(vapply(
-      observedData,
-      function(e) identical(.observedDataEntryIdOrNA(e), one),
-      logical(1)
-    ))
+    matchIdx <- entriesWithId(one)
+    if (length(matchIdx) == 0L) {
+      # An id this section stores is one of two kinds, so the match takes two
+      # passes rather than one transform. A derived id is the source's own
+      # string (a `file` basename, a `DataSet` name), which only the verbatim
+      # pass above finds; a declared id is stored the way `addObservedData()`
+      # canonicalized it, so the id as the user authored it needs the same
+      # transform to reach it. Verbatim first, so a derived id that another
+      # entry's declared id happens to canonicalize to still wins its own match.
+      matchIdx <- entriesWithId(.silentlyCanonicalized(.canonicalizeId(one)))
+    }
     if (length(matchIdx) == 0L) {
       missingIds <- c(missingIds, one)
       next

--- a/R/observed-data.R
+++ b/R/observed-data.R
@@ -405,12 +405,15 @@ getObservedDataNames <- function(project) {
 #'
 #' `id` names the declaration itself: it becomes the declaration's file under
 #' the project's definitions folder (`definitions/observed-data/<id>.json` in
-#' the default layout) and is the id [removeObservedData()] matches on. Left
-#' out, the `file` basename serves as both. It is not the name the data is
-#' known by: each imported [`ospsuite::DataSet`] carries the name its source
-#' gives it (the data-set name in an Excel sheet, the name inside a PKML file),
-#' and that name, not the declaration's id, is what a `dataCombined` entry
-#' references.
+#' the default layout) and is the id [removeObservedData()] matches on. It is
+#' canonicalized like every other definition id (lowercased and made a safe
+#' filename segment), and you are told when that changes it. Left out, the
+#' `file` basename serves as both, kept exactly as the source spells it.
+#'
+#' An id is not the name the data is known by: each imported
+#' [`ospsuite::DataSet`] carries the name its source gives it (the data-set name
+#' in an Excel sheet, the name inside a PKML file), and that name, not the
+#' declaration's id, is what a `dataCombined` entry references.
 #'
 #' A `DataSet` you pass lives in the R session until you save. On
 #' [saveProject()] it is written to a PKML file named `<DataSet name>.pkml`
@@ -551,6 +554,16 @@ addObservedData <- function(project, entry, overwrite = FALSE) {
         "An observedData entry's {.field id} must be a single non-empty string."
       )
     }
+    # A declared id names a definition file, so it runs through the same
+    # canonicalizer every other section's `add*` runs its id through: two ids
+    # differing only in case would otherwise be two declarations mapping to one
+    # file on a case-insensitive filesystem. Only a declared id is rewritten; an
+    # id derived from the `file` basename or a programmatic `DataSet` name is the
+    # source's own string, which `.validateObservedDataId()` rejects rather than
+    # reshapes.
+    if (!is.null(entry[["id"]])) {
+      entry[["id"]] <- .canonicalizeId(entry[["id"]])
+    }
     # Config entries are keyed by the id `removeObservedData()` matches on: the
     # entry's own `id` when it declares one, else its `file` basename. That id
     # also names the definition file, so reject an unsafe one here rather than
@@ -623,9 +636,11 @@ addObservedData <- function(project, entry, overwrite = FALSE) {
 #' @param id Character vector of ids. An observed-data id is the declaration's
 #'   `id` field, or, when it declares none, comes from the data source itself
 #'   (the `DataSet` name of an unsaved programmatic source, or a file basename
-#'   for a file-based source). Either way it is matched verbatim, not
-#'   canonicalized. A saved programmatic source that declares no `id` is matched
-#'   by its `<name>.pkml` basename (see the note above).
+#'   for a file-based source). Either way it is matched exactly as the
+#'   declaration stores it: a declared `id` is stored canonicalized (the form
+#'   [addObservedData()] reported back to you), a derived one exactly as its
+#'   source spells it. A saved programmatic source that declares no `id` is
+#'   matched by its `<name>.pkml` basename (see the note above).
 #' @returns The `project` object, invisibly.
 #' @export
 #' @family observedData

--- a/R/parameter-identification.R
+++ b/R/parameter-identification.R
@@ -1624,8 +1624,9 @@ removePITask <- function(project, id) {
   invisible(self)
 }
 
-# Canonicalize the scenario references on a PIParameter record (its `id` is a
-# free label the PI run uses, not a definition-file id, so it is left as-is).
+# Canonicalize the scenario references on a PIParameter record. Only the
+# references: a record handed to `addPITask()` keeps its own `id` verbatim,
+# where `addPIParameter()` canonicalizes the `id` it is given.
 #
 # @keywords internal
 # @noRd
@@ -1711,7 +1712,8 @@ removePITask <- function(project, id) {
 #'   exist in `scenarios` definitions.
 #' @param minValue,maxValue,startValue Numeric scalars.
 #' @param units Optional character scalar.
-#' @param id Optional character scalar; auto-generated as
+#' @param id Optional character scalar, canonicalized the same way
+#'   [addPITask()] canonicalizes a task id; auto-generated as
 #'   `<task>_param_<N>` when absent.
 #' @param overwrite Logical scalar. When `FALSE` (default), an explicit `id`
 #'   that already exists in the task aborts. When `TRUE`, the existing
@@ -1790,8 +1792,13 @@ addPIParameter <- function(
   }
   piTask <- self$definitions$parameterIdentification[[task]]
   existingIds <- vapply(piTask$parameters, `[[`, character(1), "id")
+  # A generated id is built from the already-canonical task id; a supplied one
+  # is canonicalized like every other authored id, so hand-authoring and the
+  # Excel import file the same parameter under the same id.
   if (is.null(id)) {
     id <- .nextFreeId(paste0(task, "_param_"), existingIds)
+  } else {
+    id <- .canonicalizeId(id)
   }
   existingIdx <- which(existingIds == id)
   if (length(existingIdx) > 0L && !overwrite) {
@@ -1829,7 +1836,8 @@ addPIParameter <- function(
 #'
 #' @param project A `Project` object.
 #' @param task Character scalar. Existing PI task id.
-#' @param id Character scalar. Parameter id to remove.
+#' @param id Character scalar. Parameter id to remove, canonicalized the same
+#'   way [addPIParameter()] canonicalizes it.
 #' @returns The `project` object, invisibly.
 #' @export
 #' @family parameterIdentification
@@ -1863,6 +1871,9 @@ removePIParameter <- function(project, task, id) {
 # @keywords internal
 # @noRd
 .removePIMember <- function(self, private, task, id, field, label) {
+  # The add side canonicalizes a supplied id, so the removal has to run the same
+  # transform or an id typed the way it was first added would not find it.
+  id <- .canonicalizeId(id)
   piTask <- self$definitions$parameterIdentification[[task]]
   ids <- vapply(piTask[[field]], `[[`, character(1), "id")
   if (!(id %in% ids)) {
@@ -1892,7 +1903,8 @@ removePIParameter <- function(project, task, id) {
 #' @param scenarios Character vector of scenario names.
 #' @param scaling,xOffset,yOffset,xFactor,yFactor,weight Optional
 #'   per-mapping fitting metadata. Defaults match `PIOutputMapping()`.
-#' @param id Optional character scalar; auto-generated as
+#' @param id Optional character scalar, canonicalized the same way
+#'   [addPITask()] canonicalizes a task id; auto-generated as
 #'   `<task>_mapping_<N>` when absent.
 #' @param overwrite Logical scalar. When `FALSE` (default), an explicit `id`
 #'   that already exists in the task aborts. When `TRUE`, the existing mapping
@@ -1966,8 +1978,12 @@ addPIOutputMapping <- function(
   }
   piTask <- self$definitions$parameterIdentification[[task]]
   existingIds <- vapply(piTask$outputMappings, `[[`, character(1), "id")
+  # Same id rule as `.addPIParameter_impl()`: generated from the canonical task
+  # id, or canonicalized when supplied.
   if (is.null(id)) {
     id <- .nextFreeId(paste0(task, "_mapping_"), existingIds)
+  } else {
+    id <- .canonicalizeId(id)
   }
   existingIdx <- which(existingIds == id)
   if (length(existingIdx) > 0L && !overwrite) {
@@ -2008,7 +2024,8 @@ addPIOutputMapping <- function(
 #'
 #' @param project A `Project` object.
 #' @param task Character scalar. Existing PI task id.
-#' @param id Character scalar. Output mapping id to remove.
+#' @param id Character scalar. Output mapping id to remove, canonicalized the
+#'   same way [addPIOutputMapping()] canonicalizes it.
 #' @returns The `project` object, invisibly.
 #' @export
 #' @family parameterIdentification

--- a/R/parameter-identification.R
+++ b/R/parameter-identification.R
@@ -1625,8 +1625,10 @@ removePITask <- function(project, id) {
 }
 
 # Canonicalize the scenario references on a PIParameter record. Only the
-# references: a record handed to `addPITask()` keeps its own `id` verbatim,
-# where `addPIParameter()` canonicalizes the `id` it is given.
+# references: a member's own `id` is a free label inside the task's definition
+# file, not a definition-file id of its own, so no door that makes one
+# (`addPITask()`, `addPIParameter()`, `.parsePIParameters()`, the Excel import)
+# reshapes it, and `.removePIMember()` matches it exactly as stored.
 #
 # @keywords internal
 # @noRd
@@ -1712,9 +1714,9 @@ removePITask <- function(project, id) {
 #'   exist in `scenarios` definitions.
 #' @param minValue,maxValue,startValue Numeric scalars.
 #' @param units Optional character scalar.
-#' @param id Optional character scalar, canonicalized the same way
-#'   [addPITask()] canonicalizes a task id; auto-generated as
-#'   `<task>_param_<N>` when absent.
+#' @param id Optional character scalar, stored exactly as given (unlike a task
+#'   id, a parameter id names no file, so it is not canonicalized);
+#'   auto-generated as `<task>_param_<N>` when absent.
 #' @param overwrite Logical scalar. When `FALSE` (default), an explicit `id`
 #'   that already exists in the task aborts. When `TRUE`, the existing
 #'   parameter is replaced (last-write-wins). Ignored for an auto-generated
@@ -1792,13 +1794,8 @@ addPIParameter <- function(
   }
   piTask <- self$definitions$parameterIdentification[[task]]
   existingIds <- vapply(piTask$parameters, `[[`, character(1), "id")
-  # A generated id is built from the already-canonical task id; a supplied one
-  # is canonicalized like every other authored id, so hand-authoring and the
-  # Excel import file the same parameter under the same id.
   if (is.null(id)) {
     id <- .nextFreeId(paste0(task, "_param_"), existingIds)
-  } else {
-    id <- .canonicalizeId(id)
   }
   existingIdx <- which(existingIds == id)
   if (length(existingIdx) > 0L && !overwrite) {
@@ -1836,8 +1833,8 @@ addPIParameter <- function(
 #'
 #' @param project A `Project` object.
 #' @param task Character scalar. Existing PI task id.
-#' @param id Character scalar. Parameter id to remove, canonicalized the same
-#'   way [addPIParameter()] canonicalizes it.
+#' @param id Character scalar. Parameter id to remove, matched exactly as the
+#'   task stores it.
 #' @returns The `project` object, invisibly.
 #' @export
 #' @family parameterIdentification
@@ -1871,9 +1868,6 @@ removePIParameter <- function(project, task, id) {
 # @keywords internal
 # @noRd
 .removePIMember <- function(self, private, task, id, field, label) {
-  # The add side canonicalizes a supplied id, so the removal has to run the same
-  # transform or an id typed the way it was first added would not find it.
-  id <- .canonicalizeId(id)
   piTask <- self$definitions$parameterIdentification[[task]]
   ids <- vapply(piTask[[field]], `[[`, character(1), "id")
   if (!(id %in% ids)) {
@@ -1903,9 +1897,9 @@ removePIParameter <- function(project, task, id) {
 #' @param scenarios Character vector of scenario names.
 #' @param scaling,xOffset,yOffset,xFactor,yFactor,weight Optional
 #'   per-mapping fitting metadata. Defaults match `PIOutputMapping()`.
-#' @param id Optional character scalar, canonicalized the same way
-#'   [addPITask()] canonicalizes a task id; auto-generated as
-#'   `<task>_mapping_<N>` when absent.
+#' @param id Optional character scalar, stored exactly as given (unlike a task
+#'   id, a mapping id names no file, so it is not canonicalized);
+#'   auto-generated as `<task>_mapping_<N>` when absent.
 #' @param overwrite Logical scalar. When `FALSE` (default), an explicit `id`
 #'   that already exists in the task aborts. When `TRUE`, the existing mapping
 #'   is replaced (last-write-wins). Ignored for an auto-generated `id`, which
@@ -1978,12 +1972,8 @@ addPIOutputMapping <- function(
   }
   piTask <- self$definitions$parameterIdentification[[task]]
   existingIds <- vapply(piTask$outputMappings, `[[`, character(1), "id")
-  # Same id rule as `.addPIParameter_impl()`: generated from the canonical task
-  # id, or canonicalized when supplied.
   if (is.null(id)) {
     id <- .nextFreeId(paste0(task, "_mapping_"), existingIds)
-  } else {
-    id <- .canonicalizeId(id)
   }
   existingIdx <- which(existingIds == id)
   if (length(existingIdx) > 0L && !overwrite) {
@@ -2024,8 +2014,8 @@ addPIOutputMapping <- function(
 #'
 #' @param project A `Project` object.
 #' @param task Character scalar. Existing PI task id.
-#' @param id Character scalar. Output mapping id to remove, canonicalized the
-#'   same way [addPIOutputMapping()] canonicalizes it.
+#' @param id Character scalar. Output mapping id to remove, matched exactly as
+#'   the task stores it.
 #' @returns The `project` object, invisibly.
 #' @export
 #' @family parameterIdentification

--- a/REFACTORING-LOG.md
+++ b/REFACTORING-LOG.md
@@ -208,3 +208,4 @@ One bullet per commit, newest at the bottom: `- YYYY-MM-DD HH:MM: plain-language
 - 2026-08-06 10:15: Split reading an Excel project from writing it out, so the reading half can be used on its own.
 - 2026-08-06 10:45: Checking whether the Excel files are up to date no longer runs a full import behind the scenes; it reads the workbooks and compares in memory, writing nothing.
 - 2026-08-06 11:20: Importing an Excel project now strips the quotation marks off a quoted single-value cell, so a name written "AciclovirPVB" becomes the same id as one written without quotes instead of _aciclovirpvb_. Applies to every id and reference the import canonicalizes, not just data combinations.
+- 2026-08-06 11:23: Made the observed-data and parameter-identification add functions clean up the ids you give them, the same way every other add function already does, so hand-authoring a project and importing the same one from Excel now file things under the same names.

--- a/man/addObservedData.Rd
+++ b/man/addObservedData.Rd
@@ -48,12 +48,15 @@ A \code{script} source runs the R file it names (see the Security section of
 
 \code{id} names the declaration itself: it becomes the declaration's file under
 the project's definitions folder (\verb{definitions/observed-data/<id>.json} in
-the default layout) and is the id \code{\link[=removeObservedData]{removeObservedData()}} matches on. Left
-out, the \code{file} basename serves as both. It is not the name the data is
-known by: each imported \code{\link[ospsuite:DataSet]{ospsuite::DataSet}} carries the name its source
-gives it (the data-set name in an Excel sheet, the name inside a PKML file),
-and that name, not the declaration's id, is what a \code{dataCombined} entry
-references.
+the default layout) and is the id \code{\link[=removeObservedData]{removeObservedData()}} matches on. It is
+canonicalized like every other definition id (lowercased and made a safe
+filename segment), and you are told when that changes it. Left out, the
+\code{file} basename serves as both, kept exactly as the source spells it.
+
+An id is not the name the data is known by: each imported
+\code{\link[ospsuite:DataSet]{ospsuite::DataSet}} carries the name its source gives it (the data-set name
+in an Excel sheet, the name inside a PKML file), and that name, not the
+declaration's id, is what a \code{dataCombined} entry references.
 
 A \code{DataSet} you pass lives in the R session until you save. On
 \code{\link[=saveProject]{saveProject()}} it is written to a PKML file named \verb{<DataSet name>.pkml}

--- a/man/addPIOutputMapping.Rd
+++ b/man/addPIOutputMapping.Rd
@@ -36,9 +36,9 @@ literal model path it maps to. Both resolve to the same output path.}
 \item{scaling, xOffset, yOffset, xFactor, yFactor, weight}{Optional
 per-mapping fitting metadata. Defaults match \code{PIOutputMapping()}.}
 
-\item{id}{Optional character scalar, canonicalized the same way
-\code{\link[=addPITask]{addPITask()}} canonicalizes a task id; auto-generated as
-\verb{<task>_mapping_<N>} when absent.}
+\item{id}{Optional character scalar, stored exactly as given (unlike a task
+id, a mapping id names no file, so it is not canonicalized);
+auto-generated as \verb{<task>_mapping_<N>} when absent.}
 
 \item{overwrite}{Logical scalar. When \code{FALSE} (default), an explicit \code{id}
 that already exists in the task aborts. When \code{TRUE}, the existing mapping

--- a/man/addPIOutputMapping.Rd
+++ b/man/addPIOutputMapping.Rd
@@ -36,7 +36,8 @@ literal model path it maps to. Both resolve to the same output path.}
 \item{scaling, xOffset, yOffset, xFactor, yFactor, weight}{Optional
 per-mapping fitting metadata. Defaults match \code{PIOutputMapping()}.}
 
-\item{id}{Optional character scalar; auto-generated as
+\item{id}{Optional character scalar, canonicalized the same way
+\code{\link[=addPITask]{addPITask()}} canonicalizes a task id; auto-generated as
 \verb{<task>_mapping_<N>} when absent.}
 
 \item{overwrite}{Logical scalar. When \code{FALSE} (default), an explicit \code{id}

--- a/man/addPIParameter.Rd
+++ b/man/addPIParameter.Rd
@@ -31,9 +31,9 @@ exist in \code{scenarios} definitions.}
 
 \item{units}{Optional character scalar.}
 
-\item{id}{Optional character scalar, canonicalized the same way
-\code{\link[=addPITask]{addPITask()}} canonicalizes a task id; auto-generated as
-\verb{<task>_param_<N>} when absent.}
+\item{id}{Optional character scalar, stored exactly as given (unlike a task
+id, a parameter id names no file, so it is not canonicalized);
+auto-generated as \verb{<task>_param_<N>} when absent.}
 
 \item{overwrite}{Logical scalar. When \code{FALSE} (default), an explicit \code{id}
 that already exists in the task aborts. When \code{TRUE}, the existing

--- a/man/addPIParameter.Rd
+++ b/man/addPIParameter.Rd
@@ -31,7 +31,8 @@ exist in \code{scenarios} definitions.}
 
 \item{units}{Optional character scalar.}
 
-\item{id}{Optional character scalar; auto-generated as
+\item{id}{Optional character scalar, canonicalized the same way
+\code{\link[=addPITask]{addPITask()}} canonicalizes a task id; auto-generated as
 \verb{<task>_param_<N>} when absent.}
 
 \item{overwrite}{Logical scalar. When \code{FALSE} (default), an explicit \code{id}

--- a/man/removeObservedData.Rd
+++ b/man/removeObservedData.Rd
@@ -12,11 +12,12 @@ removeObservedData(project, id)
 \item{id}{Character vector of ids. An observed-data id is the declaration's
 \code{id} field, or, when it declares none, comes from the data source itself
 (the \code{DataSet} name of an unsaved programmatic source, or a file basename
-for a file-based source). Either way it is matched exactly as the
-declaration stores it: a declared \code{id} is stored canonicalized (the form
-\code{\link[=addObservedData]{addObservedData()}} reported back to you), a derived one exactly as its
-source spells it. A saved programmatic source that declares no \code{id} is
-matched by its \verb{<name>.pkml} basename (see the note above).}
+for a file-based source). Each is matched as the declaration stores it and,
+failing that, as \code{\link[=addObservedData]{addObservedData()}} would have canonicalized it, so a
+derived id is found by the source's own spelling and a declared one by
+either the form you authored or the canonical form you were given back. A
+saved programmatic source that declares no \code{id} is matched by its
+\verb{<name>.pkml} basename (see the note above).}
 }
 \value{
 The \code{project} object, invisibly.

--- a/man/removeObservedData.Rd
+++ b/man/removeObservedData.Rd
@@ -12,9 +12,11 @@ removeObservedData(project, id)
 \item{id}{Character vector of ids. An observed-data id is the declaration's
 \code{id} field, or, when it declares none, comes from the data source itself
 (the \code{DataSet} name of an unsaved programmatic source, or a file basename
-for a file-based source). Either way it is matched verbatim, not
-canonicalized. A saved programmatic source that declares no \code{id} is matched
-by its \verb{<name>.pkml} basename (see the note above).}
+for a file-based source). Either way it is matched exactly as the
+declaration stores it: a declared \code{id} is stored canonicalized (the form
+\code{\link[=addObservedData]{addObservedData()}} reported back to you), a derived one exactly as its
+source spells it. A saved programmatic source that declares no \code{id} is
+matched by its \verb{<name>.pkml} basename (see the note above).}
 }
 \value{
 The \code{project} object, invisibly.

--- a/man/removePIOutputMapping.Rd
+++ b/man/removePIOutputMapping.Rd
@@ -11,8 +11,8 @@ removePIOutputMapping(project, task, id)
 
 \item{task}{Character scalar. Existing PI task id.}
 
-\item{id}{Character scalar. Output mapping id to remove, canonicalized the
-same way \code{\link[=addPIOutputMapping]{addPIOutputMapping()}} canonicalizes it.}
+\item{id}{Character scalar. Output mapping id to remove, matched exactly as
+the task stores it.}
 }
 \value{
 The \code{project} object, invisibly.

--- a/man/removePIOutputMapping.Rd
+++ b/man/removePIOutputMapping.Rd
@@ -11,7 +11,8 @@ removePIOutputMapping(project, task, id)
 
 \item{task}{Character scalar. Existing PI task id.}
 
-\item{id}{Character scalar. Output mapping id to remove.}
+\item{id}{Character scalar. Output mapping id to remove, canonicalized the
+same way \code{\link[=addPIOutputMapping]{addPIOutputMapping()}} canonicalizes it.}
 }
 \value{
 The \code{project} object, invisibly.

--- a/man/removePIParameter.Rd
+++ b/man/removePIParameter.Rd
@@ -11,7 +11,8 @@ removePIParameter(project, task, id)
 
 \item{task}{Character scalar. Existing PI task id.}
 
-\item{id}{Character scalar. Parameter id to remove.}
+\item{id}{Character scalar. Parameter id to remove, canonicalized the same
+way \code{\link[=addPIParameter]{addPIParameter()}} canonicalizes it.}
 }
 \value{
 The \code{project} object, invisibly.

--- a/man/removePIParameter.Rd
+++ b/man/removePIParameter.Rd
@@ -11,8 +11,8 @@ removePIParameter(project, task, id)
 
 \item{task}{Character scalar. Existing PI task id.}
 
-\item{id}{Character scalar. Parameter id to remove, canonicalized the same
-way \code{\link[=addPIParameter]{addPIParameter()}} canonicalizes it.}
+\item{id}{Character scalar. Parameter id to remove, matched exactly as the
+task stores it.}
 }
 \value{
 The \code{project} object, invisibly.

--- a/tests/testthat/test-observed-data.R
+++ b/tests/testthat/test-observed-data.R
@@ -756,6 +756,60 @@ test_that("addObservedData rejects a duplicate declared id", {
   expect_identical(entry[[1]][["file"]], "b.pkml")
 })
 
+test_that("addObservedData canonicalizes a declared id", {
+  # A declared id names the declaration's definition file, and the Excel
+  # importer already files the same declaration under the canonicalized id, so
+  # hand-authoring has to reach the same one. Two ids differing only in case
+  # would otherwise be two declarations mapping to one file on a
+  # case-insensitive filesystem.
+  project <- testProject()
+  dir <- file.path(project$info$projectDirPath, "definitions", "observed-data")
+
+  expect_warning(
+    addObservedData(
+      project,
+      list(
+        id = "TestProject_TimeValuesData",
+        type = "pkml",
+        file = "TimeValues.pkml"
+      )
+    ),
+    "Canonicalized"
+  )
+  expect_true(
+    "testproject_timevaluesdata" %in%
+      .observedDataSectionIds(project$definitions$observedData)
+  )
+
+  saveProject(project)
+  expect_true("testproject_timevaluesdata.json" %in% list.files(dir))
+  expect_false("TestProject_TimeValuesData.json" %in% list.files(dir))
+
+  # The canonical id is the handle the removal matches on.
+  removeObservedData(project, "testproject_timevaluesdata")
+  saveProject(project)
+  expect_false("testproject_timevaluesdata.json" %in% list.files(dir))
+})
+
+test_that("addObservedData leaves a derived id and a DataSet name as they are", {
+  # Only a declared id is canonicalized. A derived id is the source's own
+  # string: the `file` basename is one segment of a real path, and a
+  # programmatic entry's id is the `DataSet` name that `dataCombined` entries
+  # and PI output mappings reference.
+  project <- testProject()
+  ds <- ospsuite::DataSet$new(name = "MyProgSet")
+  ds$setValues(xValues = c(1, 2), yValues = c(3, 4))
+  # The DataSet goes in first: it resolves every declared source to check its
+  # name, which a config entry naming a file that is not there would abort.
+  suppressMessages(addObservedData(project, ds))
+  addObservedData(project, list(type = "pkml", file = "sub/MyObs.pkml"))
+
+  expect_setequal(
+    .observedDataSectionIds(project$definitions$observedData),
+    c("Aciclovir_TimeValuesData.xlsx", "MyObs.pkml", "MyProgSet")
+  )
+})
+
 test_that("addObservedData rejects an id that is not a single non-empty string", {
   project <- testProject()
   # An id names the declaration's file and is its remove handle, so a blank, NA,

--- a/tests/testthat/test-observed-data.R
+++ b/tests/testthat/test-observed-data.R
@@ -810,6 +810,45 @@ test_that("addObservedData leaves a derived id and a DataSet name as they are", 
   )
 })
 
+test_that("removeObservedData finds every id kind by the spelling it was added with", {
+  # Three kinds of id share this one section. A declared id is stored the way
+  # `addObservedData()` canonicalized it; a derived one (a `file` basename, a
+  # `DataSet` name) is the source's own string and carries casing no
+  # canonicalization produces. Each has to be removable by the id its caller
+  # typed, which is why the match takes a verbatim pass and a canonical one.
+  project <- testProject()
+  ds <- ospsuite::DataSet$new(name = "MyProgSet")
+  ds$setValues(xValues = c(1, 2), yValues = c(3, 4))
+  # The DataSet goes in first: it resolves every declared source to check its
+  # name, which a config entry naming a file that is not there would abort.
+  suppressMessages(addObservedData(project, ds))
+  addObservedData(project, list(type = "pkml", file = "sub/MyObs.pkml"))
+  suppressWarnings(addObservedData(
+    project,
+    list(id = "MyDeclared", type = "pkml", file = "TimeValues.pkml")
+  ))
+
+  # A genuine miss still warns, naming the id as typed rather than the
+  # canonical form the second pass tried.
+  expect_warning(removeObservedData(project, "NotThere"), "NotThere")
+
+  # A declared id answers to the spelling that was authored, not only to the
+  # canonical one that spelling was rewritten to.
+  removeObservedData(project, "MyDeclared")
+  expect_false(
+    "mydeclared" %in% .observedDataSectionIds(project$definitions$observedData)
+  )
+
+  # A derived id and a programmatic `DataSet` name are matched verbatim, so
+  # canonicalizing the search key unconditionally would strand both.
+  removeObservedData(project, c("MyObs.pkml", "MyProgSet"))
+  expect_setequal(
+    .observedDataSectionIds(project$definitions$observedData),
+    "Aciclovir_TimeValuesData.xlsx"
+  )
+  expect_false("MyProgSet" %in% getObservedDataNames(project))
+})
+
 test_that("addObservedData rejects an id that is not a single non-empty string", {
   project <- testProject()
   # An id names the declaration's file and is its remove handle, so a blank, NA,

--- a/tests/testthat/test-parameter-identification.R
+++ b/tests/testthat/test-parameter-identification.R
@@ -2255,7 +2255,7 @@ test_that("PIOutputMapping weight survives a Project save / load round trip", {
   addPIOutputMapping(
     project,
     task = "wt",
-    id = "scalar_weight",
+    id = "scalarWeight",
     outputPath = "aciclovir_pvb",
     observedData = "D2",
     scenarios = "testscenario",
@@ -2460,15 +2460,27 @@ test_that("addPIParameter() overwrite = TRUE replaces the existing parameter", {
   expect_identical(params[[1]]$path, "a|b")
 })
 
-test_that("addPIParameter() canonicalizes an explicit id", {
-  # The Excel importer coins this parameter's id as "lipophilicity"
-  # (`.uniqueImportedId()`), so hand-authoring has to land on the same id or the
-  # two routes build different tasks from one input.
+test_that("a PI parameter is removable by the id both doors stored it under", {
+  # A member id is a label inside the task's own definition file, so both doors
+  # that make one store it as typed. Were only `addPIParameter()` to lowercase
+  # it, the two doors would disagree and one of the two members below would be
+  # unreachable: nothing canonicalizes to a string carrying an uppercase letter,
+  # so no spelling would remove it.
   project <- testProject()
   addPITask(
     project,
     id = "t",
     scenarios = "testscenario",
+    parameters = list(
+      PIParameter(
+        id = "Lipophilicity",
+        scenarios = "testscenario",
+        path = "Aciclovir|Lipophilicity",
+        minValue = 0,
+        maxValue = 1,
+        startValue = 0.5
+      )
+    ),
     outputMappings = list(
       PIOutputMapping(
         id = "m",
@@ -2478,31 +2490,45 @@ test_that("addPIParameter() canonicalizes an explicit id", {
       )
     )
   )
-  expect_warning(
-    addPIParameter(
-      project,
-      task = "t",
-      id = "Lipophilicity",
-      path = "Aciclovir|Lipophilicity",
-      scenarios = "testscenario",
-      minValue = 0,
-      maxValue = 1,
-      startValue = 0.5
+  addPIParameter(
+    project,
+    task = "t",
+    id = "Solubility",
+    path = "Aciclovir|Solubility",
+    scenarios = "testscenario",
+    minValue = 0,
+    maxValue = 1,
+    startValue = 0.5
+  )
+  expect_identical(
+    vapply(
+      project$definitions$parameterIdentification$t$parameters,
+      `[[`,
+      character(1),
+      "id"
     ),
-    "Canonicalized"
+    c("Lipophilicity", "Solubility")
   )
-  params <- project$definitions$parameterIdentification$t$parameters
-  expect_identical(vapply(params, `[[`, character(1), "id"), "lipophilicity")
 
-  # The removal runs the same transform, so the id as typed still finds it.
+  # Exactly as stored, so the canonical spelling of a stored id is a different
+  # id and misses; the spelling each was added with removes it.
   expect_warning(
-    removePIParameter(project, task = "t", id = "Lipophilicity"),
-    "Canonicalized"
+    removePIParameter(project, task = "t", id = "lipophilicity"),
+    "not found"
   )
+  expect_warning(
+    removePIParameter(project, task = "t", id = "solubility"),
+    "not found"
+  )
+  removePIParameter(project, task = "t", id = "Lipophilicity")
+  removePIParameter(project, task = "t", id = "Solubility")
   expect_length(project$definitions$parameterIdentification$t$parameters, 0L)
 })
 
-test_that("addPIOutputMapping() canonicalizes an explicit id", {
+test_that("addPIParameter(overwrite = TRUE) replaces an inline-added member", {
+  # The overwrite lookup is the same exact match the removal makes, so a member
+  # `addPITask()` filed under a mixed-case id is replaced rather than joined by
+  # a second record under a rewritten id.
   project <- testProject()
   addPITask(
     project,
@@ -2510,44 +2536,84 @@ test_that("addPIOutputMapping() canonicalizes an explicit id", {
     scenarios = "testscenario",
     parameters = list(
       PIParameter(
-        id = "k",
+        id = "Lipophilicity",
         scenarios = "testscenario",
-        path = "x|y",
+        path = "old|path",
         minValue = 0,
         maxValue = 1,
         startValue = 0.5
       )
     )
   )
-  expect_warning(
-    addPIOutputMapping(
-      project,
-      task = "t",
-      id = "Plasma (Peripheral Venous Blood)",
-      outputPath = "aciclovir_pvb",
-      observedData = "D",
-      scenarios = "testscenario"
-    ),
-    "Canonicalized"
+  addPIParameter(
+    project,
+    task = "t",
+    id = "Lipophilicity",
+    path = "new|path",
+    scenarios = "testscenario",
+    minValue = 0,
+    maxValue = 1,
+    startValue = 0.5,
+    overwrite = TRUE
   )
-  mappings <- project$definitions$parameterIdentification$t$outputMappings
+  params <- project$definitions$parameterIdentification$t$parameters
+  expect_length(params, 1L)
+  expect_identical(params[[1]]$id, "Lipophilicity")
+  expect_identical(params[[1]]$path, "new|path")
+})
+
+test_that("a PI output mapping is removable by the id both doors stored it under", {
+  project <- testProject()
+  addPITask(
+    project,
+    id = "t",
+    scenarios = "testscenario",
+    outputMappings = list(
+      PIOutputMapping(
+        id = "Plasma (Peripheral Venous Blood)",
+        scenarios = "testscenario",
+        outputPath = "aciclovir_pvb",
+        observedData = "D"
+      )
+    )
+  )
+  addPIOutputMapping(
+    project,
+    task = "t",
+    id = "scalarWeight",
+    outputPath = "aciclovir_pvb",
+    observedData = "D2",
+    scenarios = "testscenario"
+  )
   expect_identical(
-    vapply(mappings, `[[`, character(1), "id"),
-    "plasma_(peripheral_venous_blood)"
+    vapply(
+      project$definitions$parameterIdentification$t$outputMappings,
+      `[[`,
+      character(1),
+      "id"
+    ),
+    c("Plasma (Peripheral Venous Blood)", "scalarWeight")
   )
 
   expect_warning(
     removePIOutputMapping(
       project,
       task = "t",
-      id = "Plasma (Peripheral Venous Blood)"
+      id = "plasma_(peripheral_venous_blood)"
     ),
-    "Canonicalized"
+    "not found"
   )
-  expect_length(
-    project$definitions$parameterIdentification$t$outputMappings,
-    0L
+  removePIOutputMapping(
+    project,
+    task = "t",
+    id = "Plasma (Peripheral Venous Blood)"
   )
+  # Removing the last mapping leaves the task with no work at all, so it goes.
+  expect_warning(
+    removePIOutputMapping(project, task = "t", id = "scalarWeight"),
+    "now empty"
+  )
+  expect_null(project$definitions$parameterIdentification$t)
 })
 
 test_that(".validatePI surfaces duplicate output mapping ids within a task", {

--- a/tests/testthat/test-parameter-identification.R
+++ b/tests/testthat/test-parameter-identification.R
@@ -2255,7 +2255,7 @@ test_that("PIOutputMapping weight survives a Project save / load round trip", {
   addPIOutputMapping(
     project,
     task = "wt",
-    id = "scalarWeight",
+    id = "scalar_weight",
     outputPath = "aciclovir_pvb",
     observedData = "D2",
     scenarios = "testscenario",
@@ -2458,6 +2458,96 @@ test_that("addPIParameter() overwrite = TRUE replaces the existing parameter", {
   expect_length(params, 1L)
   expect_identical(params[[1]]$id, "dup")
   expect_identical(params[[1]]$path, "a|b")
+})
+
+test_that("addPIParameter() canonicalizes an explicit id", {
+  # The Excel importer coins this parameter's id as "lipophilicity"
+  # (`.uniqueImportedId()`), so hand-authoring has to land on the same id or the
+  # two routes build different tasks from one input.
+  project <- testProject()
+  addPITask(
+    project,
+    id = "t",
+    scenarios = "testscenario",
+    outputMappings = list(
+      PIOutputMapping(
+        id = "m",
+        scenarios = "testscenario",
+        outputPath = "aciclovir_pvb",
+        observedData = "D"
+      )
+    )
+  )
+  expect_warning(
+    addPIParameter(
+      project,
+      task = "t",
+      id = "Lipophilicity",
+      path = "Aciclovir|Lipophilicity",
+      scenarios = "testscenario",
+      minValue = 0,
+      maxValue = 1,
+      startValue = 0.5
+    ),
+    "Canonicalized"
+  )
+  params <- project$definitions$parameterIdentification$t$parameters
+  expect_identical(vapply(params, `[[`, character(1), "id"), "lipophilicity")
+
+  # The removal runs the same transform, so the id as typed still finds it.
+  expect_warning(
+    removePIParameter(project, task = "t", id = "Lipophilicity"),
+    "Canonicalized"
+  )
+  expect_length(project$definitions$parameterIdentification$t$parameters, 0L)
+})
+
+test_that("addPIOutputMapping() canonicalizes an explicit id", {
+  project <- testProject()
+  addPITask(
+    project,
+    id = "t",
+    scenarios = "testscenario",
+    parameters = list(
+      PIParameter(
+        id = "k",
+        scenarios = "testscenario",
+        path = "x|y",
+        minValue = 0,
+        maxValue = 1,
+        startValue = 0.5
+      )
+    )
+  )
+  expect_warning(
+    addPIOutputMapping(
+      project,
+      task = "t",
+      id = "Plasma (Peripheral Venous Blood)",
+      outputPath = "aciclovir_pvb",
+      observedData = "D",
+      scenarios = "testscenario"
+    ),
+    "Canonicalized"
+  )
+  mappings <- project$definitions$parameterIdentification$t$outputMappings
+  expect_identical(
+    vapply(mappings, `[[`, character(1), "id"),
+    "plasma_(peripheral_venous_blood)"
+  )
+
+  expect_warning(
+    removePIOutputMapping(
+      project,
+      task = "t",
+      id = "Plasma (Peripheral Venous Blood)"
+    ),
+    "Canonicalized"
+  )
+  expect_length(
+    project$definitions$parameterIdentification$t$outputMappings,
+    0L
+  )
 })
 
 test_that(".validatePI surfaces duplicate output mapping ids within a task", {


### PR DESCRIPTION
Two authoring entrypoints skipped the id canonicalization every other `add*()` applies, so hand-authoring a project and importing the same project from Excel filed the same definition under different ids. Found by a migration test that built one project both ways and diffed the trees.

Review then showed that the two halves needed opposite answers, so this PR now does two different things rather than one uniform one.

## Observed data: canonicalize on add, match either spelling on remove

`addObservedData()` takes an `entry` list rather than an `id` argument, and the id inside it was written verbatim, so a declared `id = "TestProject_TimeValuesData"` produced a definition file carrying capitals — the case-collision the canonicalization rule exists to prevent on a case-insensitive filesystem.

An observed-data id genuinely does name a definition file, so the add side canonicalizes through the warning-emitting `.canonicalizeId()`, and the rewrite is reported.

Review caught the other half: `.removeObservedData_impl()` still matched verbatim, so you could not remove by the id you had just typed. It now keeps the verbatim pass and retries against the canonical spelling only when that misses. Verbatim stays first so a *derived* id — a file basename spelled exactly as its source spells it, or a programmatic `DataSet` name — still wins its own match. A real miss still warns under the caller's spelling.

## PI members: no door canonicalizes them

The original commit canonicalized the `id =` arguments of `addPIParameter()` and `addPIOutputMapping()`, and `.removePIMember()` with them. Review showed that made things worse, not better: `addPITask()` stores an inline `PIParameter(id = ...)` verbatim, and because canonicalization lowercases, **no input string canonicalizes to anything containing an uppercase letter** — so a member stored as `Lipophilicity` became unremovable by any id at all, and `addPIParameter(..., overwrite = TRUE)` appended a duplicate instead of replacing it.

The transform is therefore removed from all three sites. A PI member id is now stored exactly as every door is given it. The reasoning:

- **A member id is not a definition-file id.** It labels a record inside its task's JSON; nothing derives a filename from it, so the hazard that justifies `.canonicalizeId()` elsewhere does not exist here. The codebase already draws this line: a parameter-set *entry* is matched verbatim on `containerPath` + `parameterName`, while only the *set* id, which does name a file, is canonicalized.
- **Canonicalizing the inline ids would not have restored the invariant.** `.parsePIParameters()` and the new-layout Excel reader also store member ids verbatim, so a task loaded from a hand-edited definition file would stay unremovable. Closing that needs canonicalization on load, which is the round-trip change this stack deliberately defers.
- **A lookup fallback would fix removal only**, leaving a mixed canonical/verbatim section and needing the two-pass match at all three lookups to also fix the `overwrite` duplicate.

The PR's original motive did not survive checking: the legacy 5.x importer canonicalizes via `.uniqueImportedId()` because it *coins* an id from a free-text parameter name, not because members are keyed canonically.

## Consequence worth knowing

Because PI member ids are no longer canonicalized on the authoring side, an Excel-imported project and a hand-authored one can spell the same PI member differently — the importer coins `lipophilicity`, `addPIParameter(id = "Lipophilicity")` stores `Lipophilicity`. That is a spelling difference in a label, not a broken reference, and both projects run identically. Making the two agree needs canonicalization on load, which is the deferred change above.

## Tests

Removal by the typed spelling and by the canonical spelling, for both `addPIParameter()`-supplied and `addPITask()`-inline members; for observed data, the declared, derived and programmatic kinds, so the verbatim-first rule is pinned rather than assumed.

`@param id` docs updated on both families to describe the matching rule that now holds.
