### PR TITLE
ci: add the OSP R-universe to dependency resolution

### DIFF
--- a/.github/workflows/check-dev-deps.yaml
+++ b/.github/workflows/check-dev-deps.yaml
@@ -18,3 +18,4 @@ jobs:
     with:
       setup-quarto: true
       extra-packages: local::.
+      extra-repositories: https://open-systems-pharmacology.r-universe.dev

--- a/.github/workflows/check-released-deps.yaml
+++ b/.github/workflows/check-released-deps.yaml
@@ -14,3 +14,5 @@ permissions: read-all
 jobs:
   check-released-deps:
     uses: Open-Systems-Pharmacology/Workflows/.github/workflows/R-CMD-check-released-deps.yaml@main
+    with:
+      extra-repositories: https://open-systems-pharmacology.r-universe.dev

--- a/.github/workflows/merge-to-main.yaml
+++ b/.github/workflows/merge-to-main.yaml
@@ -29,10 +29,13 @@ jobs:
     with:
       setup-quarto: true
       extra-packages: local::.
+      extra-repositories: https://open-systems-pharmacology.r-universe.dev
 
   test-coverage:
     if: ${{ !cancelled() }}
     uses: Open-Systems-Pharmacology/Workflows/.github/workflows/test-coverage.yaml@main
+    with:
+      extra-repositories: https://open-systems-pharmacology.r-universe.dev
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -46,3 +49,5 @@ jobs:
       contents: write # deploys the built pkgdown site
       pull-requests: read # the workflow's check-changes job reads PR file changes
     uses: Open-Systems-Pharmacology/Workflows/.github/workflows/pkgdown.yaml@main
+    with:
+      extra-repositories: https://open-systems-pharmacology.r-universe.dev

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,6 +32,7 @@ jobs:
     with:
       setup-quarto: true
       extra-packages: local::.
+      extra-repositories: https://open-systems-pharmacology.r-universe.dev
 
   publish-release:
     needs: [guard-branch, R-CMD-Check]

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -3,6 +3,11 @@ name: Pull Request Workflow
 # Runs on every pull request. sync-remotes pins/unpins `Remotes:` in DESCRIPTION
 # to match the package Version and commits the fix to the PR branch; the checks
 # then run on that synced tree so what gets validated is what will be merged.
+#
+# Every check passes the OSP R-universe as an extra repository: ospsuite pulls
+# in packages that are not on CRAN (ospsuite.plots, tlf), and pak does not read
+# a dependency's own Additional_repositories, so without it dependency
+# resolution fails before any check runs.
 
 on:
   pull_request:
@@ -23,11 +28,14 @@ jobs:
     with:
       setup-quarto: true
       extra-packages: local::.
+      extra-repositories: https://open-systems-pharmacology.r-universe.dev
 
   test-coverage:
     needs: [sync-remotes]
     if: ${{ !cancelled() && needs.sync-remotes.result != 'failure' }}
     uses: Open-Systems-Pharmacology/Workflows/.github/workflows/test-coverage.yaml@main
+    with:
+      extra-repositories: https://open-systems-pharmacology.r-universe.dev
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -43,3 +51,5 @@ jobs:
       contents: write # required by the pkgdown reusable workflow (no deploy on PRs)
       pull-requests: read # the workflow's check-changes job reads PR file changes
     uses: Open-Systems-Pharmacology/Workflows/.github/workflows/pkgdown.yaml@main
+    with:
+      extra-repositories: https://open-systems-pharmacology.r-universe.dev


### PR DESCRIPTION
## Problem

Every check on `main` and on open PRs (#1256, #1257) fails before any test runs, at pak's dependency resolution:

```
* ospsuite=Open-Systems-Pharmacology/OSPSuite-R: Can't install dependency ospsuite.plots (>= 1.3.0)
* ospsuite.plots: Can't find package called tlf, ospsuite.plots.
```

`Remotes:` resolves `ospsuite` to OSPSuite-R `main` (13.0.0.9006), which imports `ospsuite.plots (>= 1.3.0)` and `tlf (>= 1.6.0)`. Neither is on CRAN; both live on `https://open-systems-pharmacology.r-universe.dev`. OSPSuite-R declares that repository in its own `Additional_repositories`, but pak does not read a dependency's `Additional_repositories`, and esqlabsR's workflows add no extra repository. The `Merge to Main Workflow` run of 2026-08-28 13:52 failed the same way, so this predates the open PRs.

## Change

Pass `extra-repositories: https://open-systems-pharmacology.r-universe.dev` to every reusable OSP workflow that installs the package's dependencies — the same input OSPSuite-R's own `pull-request.yaml` passes:

- `pull-request.yaml`: R-CMD-Check, test-coverage, pkgdown
- `merge-to-main.yaml`: R-CMD-Check, test-coverage, pkgdown
- `check-dev-deps.yaml`, `check-released-deps.yaml`, `publish.yaml`: R-CMD-Check

All five reusable workflows declare the `extra-repositories` input (verified in `Open-Systems-Pharmacology/Workflows@main`: `R-CMD-check-build.yaml`, `test-coverage.yaml`, `pkgdown.yaml`, `R-CMD-check-released-deps.yaml`). A short comment in `pull-request.yaml` records why the input is there.

Workflow files only; no R code, no NEWS bullet.

## Verification

All seven workflow files parse as YAML. The real check is this PR's own run: with the fix, dependency resolution must get past `Creating lockfile '.github/pkg.lock'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build, validation, testing, documentation, and publishing workflows to use the Open Systems Pharmacology R-universe as an additional package repository.
  * Added workflow documentation clarifying the repository requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->