### PR TITLE
Read the sensitivity parameter factor from the dataset label, not the factor level

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 - `sensitivityCalculation()` no longer errors when all runs for a parameter fail; it now warns and omits that parameter from the results (#1056).
 - `sensitivityTornadoPlot()` now matches the `parameterFactor` and its reciprocal against the analysis results with a numerical tolerance, so user supplied reciprocal factors are no longer rejected due to floating point representation (#1056).
 - `createPITasks()` no longer rejects parameter bounds that exclude the model's current value, applying the sheet `StartValue` before validating them (#1140).
+- `sensitivityTimeProfiles()` again labels the parameter-factor colour legend with the variation values (for example 0.1, 1, 20) and draws the lines in factor order. With ospsuite 13, which returns dataset names from `DataCombined` as a factor, the factors had been read as their positions 1, 2, 3 (#1259).
 
 # esqlabsR 5.7.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,7 @@
 - `sensitivityCalculation()` no longer errors when all runs for a parameter fail; it now warns and omits that parameter from the results (#1056).
 - `sensitivityTornadoPlot()` now matches the `parameterFactor` and its reciprocal against the analysis results with a numerical tolerance, so user supplied reciprocal factors are no longer rejected due to floating point representation (#1056).
 - `createPITasks()` no longer rejects parameter bounds that exclude the model's current value, applying the sheet `StartValue` before validating them (#1140).
-- `sensitivityTimeProfiles()` again labels the parameter-factor colour legend with the variation values (for example 0.1, 1, 20) and draws the lines in factor order. With ospsuite 13, which returns dataset names from `DataCombined` as a factor, the factors had been read as their positions 1, 2, 3 (#1259).
+- `sensitivityTimeProfiles()` again labels the parameter-factor colour legend with the variation values (for example 0.1, 1, 20) and draws the lines in factor order. With ospsuite 13, which returns dataset names from `DataCombined` as a factor, the factors had been read as their positions in the list (1, 2, 3, 4) (#1259).
 
 # esqlabsR 5.7.0
 

--- a/R/sensivitity-time-profiles.R
+++ b/R/sensivitity-time-profiles.R
@@ -545,11 +545,13 @@ sensitivityTimeProfiles <- function(
     ParameterPathUserName = parameterPathUserName %||% NA_character_
   )
 
-  # Convert parameterFactor to numeric for simulated data
+  # Convert parameterFactor to numeric for simulated data. `name` comes back
+  # from `DataCombined$toDataFrame()` as a factor, so go through the label:
+  # `as.numeric()` on the factor itself would give the level position.
   combinedDf <- dplyr::rowwise(combinedDf) |>
     dplyr::mutate(
       ParameterFactor = if (dataType == "simulated") {
-        as.numeric(name)
+        as.numeric(as.character(name))
       } else {
         NA_real_
       }

--- a/tests/testthat/test-sensitivity-time-profiles.R
+++ b/tests/testthat/test-sensitivity-time-profiles.R
@@ -53,7 +53,7 @@ test_that("simulated ParameterFactor carries the variation values", {
     xUnits = NULL,
     yUnits = NULL
   )
-  expect_setequal(unique(data$ParameterFactor), c(0.1, 1, 2, 20))
+  expect_equal(sort(unique(data$ParameterFactor)), c(0.1, 1, 2, 20))
 })
 
 # Validate plotting arguments ---------------------------------------------

--- a/tests/testthat/test-sensitivity-time-profiles.R
+++ b/tests/testthat/test-sensitivity-time-profiles.R
@@ -39,6 +39,23 @@ obsData <<- loadDataSetsFromExcel(
   importerConfigurationOrPath = dataConfiguration
 )
 
+# Plot data ---------------------------------------------------------------
+
+test_that("simulated ParameterFactor carries the variation values", {
+  # `DataCombined$toDataFrame()` hands the dataset names back as a factor, so
+  # the numeric factor must come from the label, not the level position;
+  # otherwise 0.1 / 2 / 20 turn into 1 / 2 / 4 and the colour legend follows.
+  data <- .aggregateSimulationAndObservedData(
+    simulationResults = results$simulationResults,
+    dataSets = NULL,
+    parameterPaths = results$parameterPaths,
+    outputPaths = results$outputPaths,
+    xUnits = NULL,
+    yUnits = NULL
+  )
+  expect_setequal(unique(data$ParameterFactor), c(0.1, 1, 2, 20))
+})
+
 # Validate plotting arguments ---------------------------------------------
 
 test_that("sensitivityTimeProfiles fails with invalid input", {


### PR DESCRIPTION
Fixes the `sensitivityTimeProfiles()` regression behind the 12 failing SVG snapshots on `main`. The snapshots themselves are unchanged: with the fix, the plots render exactly as the committed SVGs.

## Symptom

With ospsuite 13, the "Parameter factor" colour bar lost its `0.1 / 1.0 / 20.0` labels (showing a single `4`), and the factor lines were drawn in a different order. 10 `expect_doppelganger()` cases in `test-sensitivity-time-profiles.R` and 1 in `test-utilities-sensitivity-calculation.R` failed.

## Root cause

ospsuite 13 changed `DataCombined$toDataFrame()` to return the `name` column as a factor (levels in insertion order — see its NEWS). `.aggregateSimulationAndObservedData()` in `R/sensivitity-time-profiles.R` builds the numeric `ParameterFactor` with `as.numeric(name)`; on a factor that yields the level position, so variation factors `0.1, 1, 2, 20` became `1, 2, 3, 4`. Everything downstream — colour scale limits, legend breaks (`min`, `1`, `max` collapsed to `1, 4`), line order — followed. The simulation results were never wrong, which is why the curves' coordinates in the SVGs did not move.

Verified by inspecting the built plot: colour scale limits `log(2)…log(4)`, stored breaks `1 4`, guide label `4`.

## Change

- `as.numeric(as.character(name))` in `.aggregateSimulationAndObservedData()`, with a comment on why.
- New test `simulated ParameterFactor carries the variation values` asserting `unique(data$ParameterFactor)` is `{0.1, 1, 2, 20}`; it fails on the unpatched code and passes with the fix.
- NEWS bullet under "Minor improvements and bug fixes".

No snapshot files touched. `test-sensitivity-time-profiles.R` + `test-utilities-sensitivity-calculation.R`: 69 pass, 0 fail against ospsuite 13.0.0.9005 / ggplot2 4.0.3.

Other `toDataFrame()` consumers were checked: `R/utilities-data-combined.R` compares `name == label` (factor-safe); `pkData` builds `ParameterFactor` from list names, not from `DataCombined`, and was already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected sensitivity time profile labels so parameter variation values display accurately.
  * Improved ordering of sensitivity profile lines by parameter factor.
  * Added compatibility for factor names from ospsuite 13.
  * Preserved numeric variation values, including cases where a variation is omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->