### PR TITLE
docs: one NEWS bullet per user-visible change, not per PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,9 @@ The target reader of all user-facing documentation (roxygen `@description`, `@pa
 ## Pull requests
 
 - Open new PRs as **draft (WIP)**.
-- Add one `NEWS.md` bullet per PR with user-facing changes, summarizing them for the end user. Skip the bullet when a PR has none.
+- Every PR with user-facing changes needs at least one `NEWS.md` bullet, written for the end user. Add **one bullet per user-visible change**, not one per PR — a PR that changes three things visible to users gets three bullets. Do not combine unrelated changes into a single bullet.
+- Skip `NEWS.md` only when the PR has no user-facing change at all (internal refactoring, tests, CI, agent guidance).
+- Each bullet names the affected function as `functionName()`, says what the user now sees or can do, and ends with the issue number in parentheses, e.g. `(#1056)`. File it under `## Breaking changes`, `## New features`, or `## Minor improvements and bug fixes` in the development section.
 
 ## Documentation / Rd files
 


### PR DESCRIPTION
## Problem

`AGENTS.md` said:

> Add one `NEWS.md` bullet per PR with user-facing changes, summarizing them for the end user. Skip the bullet when a PR has none.

"One X per Y" reads as a cap rather than a floor, so agents treat it as a budget and compress several unrelated changes into a single sentence. The rule that was actually intended has two parts — *at least* one bullet, and *one bullet per visible change* — and only half of it was written down.

The repo's own history shows the intended pattern: PR #1056 correctly produced six separate bullets in the development section of `NEWS.md`.

## Change

Splits the line into three bullets under `## Pull requests`:

- **Granularity:** one bullet per user-visible change, not one per PR, with an explicit example, plus a ban on combining unrelated changes.
- **Skip condition:** narrowed from the vague "when a PR has none" to the actual cases (internal refactoring, tests, CI, agent guidance).
- **Entry format:** backticked `functionName()`, user-visible phrasing, trailing issue number, and the correct `NEWS.md` heading — the conventions existing entries already follow but that were never stated.

## Notes

- Agent guidance only; no runtime, test, or Rd changes, so no `NEWS.md` bullet of its own — which the new second bullet now says explicitly.
- Applies org-wide, since this file is the guide for every esqLABS repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pull-request guidance to require separate release-note entries for each user-visible change, including affected areas, observable behavior, and issue references.
  * Clarified that release notes may be omitted when a pull request has no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->